### PR TITLE
Kw/develop

### DIFF
--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -80,7 +80,7 @@ public:
         = 0;
 
     /// create a [multisampled] 2D render- or depth-stencil target
-    [[nodiscard]] virtual handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples = 1, rt_clear_value const* optimized_clear_val = nullptr)
+    [[nodiscard]] virtual handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples = 1, unsigned array_size = 1, rt_clear_value const* optimized_clear_val = nullptr)
         = 0;
 
     /// create a buffer, with an element stride if its an index or vertex buffer

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -29,7 +29,8 @@ namespace detail
     PHI_X(debug_marker)            \
     PHI_X(update_bottom_level)     \
     PHI_X(update_top_level)        \
-    PHI_X(dispatch_rays)
+    PHI_X(dispatch_rays)           \
+    PHI_X(clear_textures)
 
 enum class cmd_type : uint8_t
 {
@@ -402,6 +403,18 @@ PHI_DEFINE_CMD(dispatch_rays)
     unsigned width = 0;
     unsigned height = 0;
     unsigned depth = 0;
+};
+
+/// clear up to 4 textures to specified values - standalone (outside of begin/end_render_pass)
+PHI_DEFINE_CMD(clear_textures)
+{
+    struct clear_info
+    {
+        resource_view rv;
+        rt_clear_value value;
+    };
+
+    cmd_vector<clear_info, 4> clear_ops;
 };
 
 #undef PHI_DEFINE_CMD

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -452,6 +452,8 @@ public:
         _cursor += sizeof(CMDT);
     }
 
+    void advance_cursor(size_t amount) { _cursor += amount; }
+
 #ifndef PHI_ENABLE_DEBUG_MARKERS
     void add_command(cmd::debug_marker const&)
     {
@@ -460,9 +462,13 @@ public:
 #endif
 
 public:
+    /// returns the size of the written section in bytes
     size_t size() const { return _cursor; }
+    /// returns the start of the buffer
     std::byte* buffer() const { return _out_buffer; }
-
+    /// returns the current head of the buffer
+    std::byte* buffer_head() const { return _out_buffer + _cursor; }
+    /// returns the maximum size of the buffer
     size_t max_size() const { return _max_size; }
 
     bool empty() const { return _cursor == 0; }

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -61,9 +61,9 @@ public:
         return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav);
     }
 
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, rt_clear_value const* optimized_clear_val) override
+    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val) override
     {
-        return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, optimized_clear_val);
+        return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, optimized_clear_val);
     }
 
     [[nodiscard]] handle::resource createBuffer(unsigned size_bytes, unsigned stride_bytes, bool allow_uav) override

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -87,6 +87,8 @@ struct command_list_translator
 
     void execute(cmd::dispatch_rays const& dispatch_rays);
 
+    void execute(cmd::clear_textures const& clear_tex);
+
 private:
     // non-owning constant (global)
     translator_global_memory _globals;

--- a/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
@@ -92,6 +92,11 @@ namespace phi::d3d12::util
     case af::bc6h_16uf:
         return DXGI_FORMAT_BC6H_UF16;
 
+    case af::r24un_g8t:
+        return DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+    case af::r24t_g8u:
+        return DXGI_FORMAT_X24_TYPELESS_G8_UINT;
+
     case af::depth32f:
         return DXGI_FORMAT_D32_FLOAT;
     case af::depth16un:

--- a/src/phantasm-hardware-interface/d3d12/common/util.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/util.hh
@@ -11,6 +11,7 @@ namespace phi::d3d12::util
 {
 inline void set_viewport(ID3D12GraphicsCommandList* command_list, tg::isize2 size)
 {
+    // depthrange is hardcoded to [0, 1]
     auto const viewport = D3D12_VIEWPORT{0.f, 0.f, float(size.width), float(size.height), 0.f, 1.f};
     auto const scissor_rect = D3D12_RECT{0, 0, LONG(size.width), LONG(size.height)};
 

--- a/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
+++ b/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
@@ -46,6 +46,7 @@ ID3D12PipelineState* phi::d3d12::create_pipeline_state(ID3D12Device& device,
     pso_desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     pso_desc.RasterizerState.CullMode = util::to_native(config.cull);
     pso_desc.RasterizerState.FrontCounterClockwise = true;
+    pso_desc.RasterizerState.ConservativeRaster = config.conservative_raster ? D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON : D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 
     pso_desc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
     pso_desc.DepthStencilState.DepthEnable = config.depth != phi::depth_function::none && !framebuffer_format.depth_target.empty();

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -90,7 +90,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createTexture(format format, uns
     return acquireImage(alloc, format, initial_state, real_mip_levels, desc.DepthOrArraySize);
 }
 
-phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, rt_clear_value const* optimized_clear_val)
+phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val)
 {
     auto const format_dxgi = util::to_dxgi_format(format);
     if (is_depth_format(format))
@@ -111,8 +111,8 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(phi::format f
             clear_value.DepthStencil.Stencil = 0;
         }
 
-        auto const desc = CD3DX12_RESOURCE_DESC::Tex2D(format_dxgi, w, h, 1, 1, samples, samples != 1 ? DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN : 0,
-                                                       D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+        auto const desc = CD3DX12_RESOURCE_DESC::Tex2D(format_dxgi, w, h, UINT16(array_size), 1, samples,
+                                                       samples != 1 ? DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN : 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
         auto* const alloc = mAllocator.allocate(desc, util::to_native(initial_state), &clear_value);
         util::set_object_name(alloc->GetResource(), "respool depth stencil target");
@@ -137,7 +137,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(phi::format f
             clear_value.Color[3] = 1.0f;
         }
 
-        auto const desc = CD3DX12_RESOURCE_DESC::Tex2D(format_dxgi, UINT(w), UINT(h), 1, 1, UINT(samples),
+        auto const desc = CD3DX12_RESOURCE_DESC::Tex2D(format_dxgi, w, h, UINT16(array_size), 1, samples,
                                                        samples != 1 ? DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN : 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
 
         auto* const alloc = mAllocator.allocate(desc, util::to_native(initial_state), &clear_value);

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -22,7 +22,8 @@ public:
         format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim = texture_dimension::t2d, unsigned depth_or_array_size = 1, bool allow_uav = false);
 
     /// create a render- or depth-stencil target
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, rt_clear_value const* optimized_clear_val = nullptr);
+    [[nodiscard]] handle::resource createRenderTarget(
+        phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val = nullptr);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
     [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, bool allow_uav);

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -165,7 +165,7 @@ enum class format : uint8_t
     bc6h_16f,
     bc6h_16uf,
 
-    // view-only formats
+    // view-only formats - depth
     r24un_g8t, // view the depth part of depth24un_stencil8u
     r24t_g8u,  // view the stencil part of depth24un_stencil8u
 
@@ -178,11 +178,14 @@ enum class format : uint8_t
     depth24un_stencil8u,
 };
 
+/// returns true if the format is a view-only format
+[[nodiscard]] constexpr bool is_view_format(format fmt) { return fmt >= format::r24un_g8t && fmt < format::depth32f; }
+
 /// returns true if the format is a depth OR depth stencil format
-[[nodiscard]] inline constexpr bool is_depth_format(format fmt) { return fmt >= format::depth32f; }
+[[nodiscard]] constexpr bool is_depth_format(format fmt) { return fmt >= format::depth32f; }
 
 /// returns true if the format is a depth stencil format
-[[nodiscard]] inline constexpr bool is_depth_stencil_format(format fmt) { return fmt >= format::depth32f_stencil8u; }
+[[nodiscard]] constexpr bool is_depth_stencil_format(format fmt) { return fmt >= format::depth32f_stencil8u; }
 
 /// information about a single vertex attribute
 struct vertex_attribute_info
@@ -395,14 +398,14 @@ struct sampler_config
     float lod_bias;          ///< offset from the calculated MIP level (sampled = calculated + lod_bias)
     unsigned max_anisotropy; ///< maximum amount of anisotropy in [1, 16], req. sampler_filter::anisotropic
     sampler_compare_func compare_func;
-    sampler_border_color border_color; ///< the border color to use, req. sampler_filter::clamp_border
+    sampler_border_color border_color; ///< the border color to use, req. sampler_address_mode::clamp_border
 
-    void init_default(sampler_filter filter, unsigned anisotropy = 16u)
+    void init_default(sampler_filter filter, unsigned anisotropy = 16u, sampler_address_mode address_mode = sampler_address_mode::wrap)
     {
         this->filter = filter;
-        address_u = sampler_address_mode::wrap;
-        address_v = sampler_address_mode::wrap;
-        address_w = sampler_address_mode::wrap;
+        address_u = address_mode;
+        address_v = address_mode;
+        address_w = address_mode;
         min_lod = 0.f;
         max_lod = 100000.f;
         lod_bias = 0.f;

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -457,6 +457,7 @@ struct pipeline_config
     bool depth_readonly = false;
     cull_mode cull = cull_mode::none;
     int samples = 1;
+    bool conservative_raster = false;
 };
 
 /// operation to perform on render targets upon render pass begin

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -122,7 +122,7 @@ enum class resource_state : uint8_t
 };
 
 /// pixel format of a texture, or texture view (DXGI_FORMAT / VkFormat)
-/// [f]loat, [i]nt, [u]int, [un]orm, [uf]loat
+/// [f]loat, [i]nt, [u]int, [un]orm, [uf]loat, [t]ypeless
 enum class format : uint8_t
 {
     // regular formats
@@ -164,6 +164,10 @@ enum class format : uint8_t
     // compressed formats
     bc6h_16f,
     bc6h_16uf,
+
+    // view-only formats
+    r24un_g8t, // view the depth part of depth24un_stencil8u
+    r24t_g8u,  // view the stencil part of depth24un_stencil8u
 
     // depth formats
     depth32f,

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -475,6 +475,22 @@ union rt_clear_value {
         float depth;
         uint8_t stencil;
     } depth_stencil;
+
+    rt_clear_value() = default;
+
+    rt_clear_value(float r, float g, float b, float a)
+    {
+        color[0] = r;
+        color[1] = g;
+        color[2] = b;
+        color[3] = a;
+    }
+
+    rt_clear_value(float depth, uint8_t stencil)
+    {
+        depth_stencil.depth = depth;
+        depth_stencil.stencil = stencil;
+    }
 };
 
 /// blending logic operation a (graphics) handle::pipeline_state performs on its render targets

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -55,9 +55,9 @@ public:
         return mPoolResources.createTexture(format, static_cast<unsigned>(size.width), static_cast<unsigned>(size.height), mips, dim, depth_or_array_size, allow_uav);
     }
 
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, rt_clear_value const*) override
+    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const*) override
     {
-        return mPoolResources.createRenderTarget(format, static_cast<unsigned>(size.width), static_cast<unsigned>(size.height), samples);
+        return mPoolResources.createRenderTarget(format, static_cast<unsigned>(size.width), static_cast<unsigned>(size.height), samples, array_size);
     }
 
     [[nodiscard]] handle::resource createBuffer(unsigned size_bytes, unsigned stride_bytes = 0, bool allow_uav = false) override

--- a/src/phantasm-hardware-interface/vulkan/Device.cc
+++ b/src/phantasm-hardware-interface/vulkan/Device.cc
@@ -14,7 +14,8 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
     CC_ASSERT(mDevice == nullptr && "vk::Device initialized twice");
 
     mHasRaytracing = false;
-    auto const active_lay_ext = get_used_device_lay_ext(device.available_layers_extensions, config, mHasRaytracing);
+    mHasConservativeRaster = false;
+    auto const active_lay_ext = get_used_device_lay_ext(device.available_layers_extensions, config, mHasRaytracing, mHasConservativeRaster);
 
     // chose family queue indices
     {
@@ -87,9 +88,10 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
     }
 
     if (hasRaytracing())
-    {
         initializeRaytracing();
-    }
+
+    if (hasConservativeRaster())
+        initializeConservativeRaster();
 }
 
 void phi::vk::Device::destroy()
@@ -102,10 +104,21 @@ void phi::vk::Device::initializeRaytracing()
 {
     mInformation.raytrace_properties = {};
     mInformation.raytrace_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV;
+    queryDeviceProps2(&mInformation.raytrace_properties);
+}
 
+void phi::vk::Device::initializeConservativeRaster()
+{
+    mInformation.conservative_raster_properties = {};
+    mInformation.conservative_raster_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT;
+    queryDeviceProps2(&mInformation.conservative_raster_properties);
+}
+
+void phi::vk::Device::queryDeviceProps2(void* property_obj)
+{
     VkPhysicalDeviceProperties2 props = {};
     props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-    props.pNext = &mInformation.raytrace_properties;
+    props.pNext = &property_obj;
     props.properties = {};
 
     vkGetPhysicalDeviceProperties2(mPhysicalDevice, &props);

--- a/src/phantasm-hardware-interface/vulkan/Device.cc
+++ b/src/phantasm-hardware-interface/vulkan/Device.cc
@@ -90,8 +90,9 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
     if (hasRaytracing())
         initializeRaytracing();
 
-    if (hasConservativeRaster())
-        initializeConservativeRaster();
+    // TODO: these properties are unused (never read) right now, and this call crashes on non-charging optimus laptops
+    // if (hasConservativeRaster())
+    //  initializeConservativeRaster();
 }
 
 void phi::vk::Device::destroy()

--- a/src/phantasm-hardware-interface/vulkan/Device.cc
+++ b/src/phantasm-hardware-interface/vulkan/Device.cc
@@ -90,9 +90,8 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
     if (hasRaytracing())
         initializeRaytracing();
 
-    // TODO: these properties are unused (never read) right now, and this call crashes on non-charging optimus laptops
-    // if (hasConservativeRaster())
-    //  initializeConservativeRaster();
+    if (hasConservativeRaster())
+        initializeConservativeRaster();
 }
 
 void phi::vk::Device::destroy()
@@ -119,7 +118,7 @@ void phi::vk::Device::queryDeviceProps2(void* property_obj)
 {
     VkPhysicalDeviceProperties2 props = {};
     props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-    props.pNext = &property_obj;
+    props.pNext = property_obj;
     props.properties = {};
 
     vkGetPhysicalDeviceProperties2(mPhysicalDevice, &props);

--- a/src/phantasm-hardware-interface/vulkan/Device.hh
+++ b/src/phantasm-hardware-interface/vulkan/Device.hh
@@ -34,6 +34,7 @@ public:
     VkPhysicalDeviceMemoryProperties const& getMemoryProperties() const { return mInformation.memory_properties; }
     VkPhysicalDeviceProperties const& getDeviceProperties() const { return mInformation.device_properties; }
     bool hasRaytracing() const { return mHasRaytracing; }
+    bool hasConservativeRaster() const { return mHasConservativeRaster; }
 
 public:
     VkPhysicalDevice getPhysicalDevice() const { return mPhysicalDevice; }
@@ -41,6 +42,9 @@ public:
 
 private:
     void initializeRaytracing();
+    void initializeConservativeRaster();
+
+    void queryDeviceProps2(void* property_obj);
 
 private:
     VkPhysicalDevice mPhysicalDevice;
@@ -63,8 +67,11 @@ private:
         VkPhysicalDeviceMemoryProperties memory_properties;
         VkPhysicalDeviceProperties device_properties;
         VkPhysicalDeviceRayTracingPropertiesNV raytrace_properties;
+        VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_raster_properties;
     } mInformation;
 
     bool mHasRaytracing = false;
+    bool mHasConservativeRaster = false;
+    void queryDeviceProps2();
 };
 }

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -236,6 +236,8 @@ void phi::vk::command_list_translator::execute(const phi::cmd::end_render_pass&)
         vkCmdEndRenderPass(_cmd_list);
         _bound.raw_render_pass = nullptr;
     }
+
+    _bound.reset();
 }
 
 void phi::vk::command_list_translator::execute(const phi::cmd::transition_resources& transition_res)
@@ -472,13 +474,13 @@ void phi::vk::command_list_translator::execute(const phi::cmd::clear_textures& c
             VkClearDepthStencilValue clearval = {};
             clearval.depth = op.value.depth_stencil.depth;
             clearval.stencil = op.value.depth_stencil.stencil;
-            vkCmdClearDepthStencilImage(_cmd_list, resource, VK_IMAGE_LAYOUT_GENERAL, &clearval, 1, &range);
+            vkCmdClearDepthStencilImage(_cmd_list, resource, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearval, 1, &range);
         }
         else
         {
             VkClearColorValue clearval = {};
             std::memcpy(clearval.float32, op.value.color, sizeof(float[4]));
-            vkCmdClearColorImage(_cmd_list, resource, VK_IMAGE_LAYOUT_GENERAL, &clearval, 1, &range);
+            vkCmdClearColorImage(_cmd_list, resource, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearval, 1, &range);
         }
     }
 }

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -75,6 +75,8 @@ struct command_list_translator
 
     void execute(cmd::dispatch_rays const& dispatch_rays);
 
+    void execute(cmd::clear_textures const& clear_tex);
+
 private:
     void bind_shader_arguments(handle::pipeline_state pso, std::byte const* root_consts, cc::span<shader_argument const> shader_args, VkPipelineBindPoint bind_point);
 

--- a/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
@@ -8,7 +8,7 @@
 
 namespace phi::vk::util
 {
-[[nodiscard]] inline constexpr VkAccessFlags to_access_flags(resource_state state)
+[[nodiscard]] constexpr VkAccessFlags to_access_flags(resource_state state)
 {
     using rs = resource_state;
     switch (state)
@@ -61,7 +61,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] inline constexpr VkImageLayout to_image_layout(resource_state state)
+[[nodiscard]] constexpr VkImageLayout to_image_layout(resource_state state)
 {
     using rs = resource_state;
     switch (state)
@@ -108,7 +108,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] inline constexpr VkPipelineStageFlags to_pipeline_stage_flags(phi::shader_stage stage)
+[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_flags(phi::shader_stage stage)
 {
     switch (stage)
     {
@@ -137,7 +137,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(stage);
 }
 
-[[nodiscard]] inline constexpr VkPipelineStageFlags to_pipeline_stage_flags_bitwise(phi::shader_stage_flags_t stage_flags)
+[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_flags_bitwise(phi::shader_stage_flags_t stage_flags)
 {
     VkPipelineStageFlags res = 0;
 
@@ -167,7 +167,7 @@ namespace phi::vk::util
     return res;
 }
 
-[[nodiscard]] inline constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, VkPipelineStageFlags shader_flags)
+[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, VkPipelineStageFlags shader_flags)
 {
     using rs = resource_state;
     switch (state)
@@ -216,12 +216,12 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] inline constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, shader_stage stage = shader_stage::pixel)
+[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, shader_stage stage = shader_stage::pixel)
 {
     return to_pipeline_stage_dependency(state, to_pipeline_stage_flags(stage));
 }
 
-[[nodiscard]] inline constexpr VkPrimitiveTopology to_native(phi::primitive_topology topology)
+[[nodiscard]] constexpr VkPrimitiveTopology to_native(phi::primitive_topology topology)
 {
     switch (topology)
     {
@@ -238,7 +238,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(topology);
 }
 
-[[nodiscard]] inline constexpr VkCompareOp to_native(phi::depth_function depth_func)
+[[nodiscard]] constexpr VkCompareOp to_native(phi::depth_function depth_func)
 {
     switch (depth_func)
     {
@@ -265,7 +265,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(depth_func);
 }
 
-[[nodiscard]] inline constexpr VkCullModeFlags to_native(phi::cull_mode cull_mode)
+[[nodiscard]] constexpr VkCullModeFlags to_native(phi::cull_mode cull_mode)
 {
     switch (cull_mode)
     {
@@ -281,7 +281,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] inline constexpr VkShaderStageFlagBits to_shader_stage_flags(phi::shader_stage stage)
+[[nodiscard]] constexpr VkShaderStageFlagBits to_shader_stage_flags(phi::shader_stage stage)
 {
     switch (stage)
     {
@@ -315,7 +315,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] inline constexpr VkDescriptorType to_native_srv_desc_type(resource_view_dimension sv_dim)
+[[nodiscard]] constexpr VkDescriptorType to_native_srv_desc_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -337,7 +337,7 @@ namespace phi::vk::util
 
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
-[[nodiscard]] inline constexpr VkDescriptorType to_native_uav_desc_type(resource_view_dimension sv_dim)
+[[nodiscard]] constexpr VkDescriptorType to_native_uav_desc_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -361,12 +361,12 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
 
-[[nodiscard]] inline constexpr bool is_valid_as_uav_desc_type(resource_view_dimension sv_dim)
+[[nodiscard]] constexpr bool is_valid_as_uav_desc_type(resource_view_dimension sv_dim)
 {
     return to_native_uav_desc_type(sv_dim) != VK_DESCRIPTOR_TYPE_MAX_ENUM;
 }
 
-[[nodiscard]] inline constexpr VkImageViewType to_native_image_view_type(resource_view_dimension sv_dim)
+[[nodiscard]] constexpr VkImageViewType to_native_image_view_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -396,13 +396,25 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
 
-[[nodiscard]] inline constexpr VkImageAspectFlags to_native_image_aspect(format format)
+[[nodiscard]] constexpr VkImageAspectFlags to_native_image_aspect(format fmt)
 {
-    if (is_depth_stencil_format(format))
+    if (is_view_format(fmt))
+    {
+        if (fmt == format::r24un_g8t)
+        {
+            return VK_IMAGE_ASPECT_DEPTH_BIT;
+        }
+        else
+        {
+            CC_ASSERT(fmt == format::r24t_g8u && "unhandled view-type format");
+            return VK_IMAGE_ASPECT_STENCIL_BIT;
+        }
+    }
+    else if (is_depth_stencil_format(fmt))
     {
         return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     }
-    else if (is_depth_format(format))
+    else if (is_depth_format(fmt))
     {
         return VK_IMAGE_ASPECT_DEPTH_BIT;
     }
@@ -413,7 +425,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] inline constexpr VkFilter to_min_filter(sampler_filter filter)
+[[nodiscard]] constexpr VkFilter to_min_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -433,7 +445,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] inline constexpr VkFilter to_mag_filter(sampler_filter filter)
+[[nodiscard]] constexpr VkFilter to_mag_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -453,7 +465,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] inline constexpr VkSamplerMipmapMode to_mipmap_filter(sampler_filter filter)
+[[nodiscard]] constexpr VkSamplerMipmapMode to_mipmap_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -473,7 +485,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] inline constexpr VkSamplerAddressMode to_native(sampler_address_mode mode)
+[[nodiscard]] constexpr VkSamplerAddressMode to_native(sampler_address_mode mode)
 {
     switch (mode)
     {
@@ -490,7 +502,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(mode);
 }
 
-[[nodiscard]] inline constexpr VkCompareOp to_native(sampler_compare_func mode)
+[[nodiscard]] constexpr VkCompareOp to_native(sampler_compare_func mode)
 {
     switch (mode)
     {
@@ -516,7 +528,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(mode);
 }
 
-[[nodiscard]] inline constexpr VkBorderColor to_native(sampler_border_color color)
+[[nodiscard]] constexpr VkBorderColor to_native(sampler_border_color color)
 {
     switch (color)
     {
@@ -537,7 +549,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(color);
 }
 
-[[nodiscard]] inline constexpr VkSampleCountFlagBits to_native_sample_flags(unsigned num_samples)
+[[nodiscard]] constexpr VkSampleCountFlagBits to_native_sample_flags(unsigned num_samples)
 {
     switch (num_samples)
     {
@@ -560,7 +572,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(num_samples);
 }
 
-[[nodiscard]] inline constexpr VkAttachmentLoadOp to_native(rt_clear_type clear_type)
+[[nodiscard]] constexpr VkAttachmentLoadOp to_native(rt_clear_type clear_type)
 {
     switch (clear_type)
     {
@@ -575,7 +587,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(clear_type);
 }
 
-[[nodiscard]] inline constexpr VkImageType to_native(texture_dimension dim)
+[[nodiscard]] constexpr VkImageType to_native(texture_dimension dim)
 {
     switch (dim)
     {
@@ -590,7 +602,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(dim);
 }
 
-[[nodiscard]] inline constexpr VkLogicOp to_native(blend_logic_op op)
+[[nodiscard]] constexpr VkLogicOp to_native(blend_logic_op op)
 {
     switch (op)
     {
@@ -631,7 +643,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(op);
 }
 
-[[nodiscard]] inline constexpr VkBlendOp to_native(blend_op op)
+[[nodiscard]] constexpr VkBlendOp to_native(blend_op op)
 {
     switch (op)
     {
@@ -650,7 +662,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(op);
 }
 
-[[nodiscard]] inline constexpr VkBlendFactor to_native(blend_factor bf)
+[[nodiscard]] constexpr VkBlendFactor to_native(blend_factor bf)
 {
     switch (bf)
     {
@@ -679,7 +691,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(bf);
 }
 
-[[nodiscard]] inline constexpr VkBuildAccelerationStructureFlagsNV to_native_flags(accel_struct_build_flags_t flags)
+[[nodiscard]] constexpr VkBuildAccelerationStructureFlagsNV to_native_flags(accel_struct_build_flags_t flags)
 {
     VkBuildAccelerationStructureFlagsNV res = 0;
 

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -92,6 +92,11 @@ namespace phi::vk::util
     case bf::bc6h_16uf:
         return VK_FORMAT_BC6H_UFLOAT_BLOCK;
 
+    case bf::r24un_g8t:
+        return VK_FORMAT_X8_D24_UNORM_PACK32;
+    case bf::r24t_g8u:
+        return VK_FORMAT_R8_UINT; // this is almost certainly wrong
+
     case bf::depth32f:
         return VK_FORMAT_D32_SFLOAT;
     case bf::depth16un:

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -92,10 +92,11 @@ namespace phi::vk::util
     case bf::bc6h_16uf:
         return VK_FORMAT_BC6H_UFLOAT_BLOCK;
 
+        // view-only formats are handled in image aspect bits
     case bf::r24un_g8t:
-        return VK_FORMAT_X8_D24_UNORM_PACK32;
+        return VK_FORMAT_D24_UNORM_S8_UINT;
     case bf::r24t_g8u:
-        return VK_FORMAT_R8_UINT; // this is almost certainly wrong
+        return VK_FORMAT_D24_UNORM_S8_UINT;
 
     case bf::depth32f:
         return VK_FORMAT_D32_SFLOAT;

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -177,8 +177,8 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
     {
         if (!add_layer("VK_LAYER_KHRONOS_validation"))
         {
-            log::err() << "Validation enabled, but no layers available on Vulkan instance";
-            log::err() << "Download the LunarG SDK for your operating system,";
+            log::err() << "validation enabled, but no layers available on Vulkan instance";
+            log::err() << "download the LunarG SDK for your operating system,";
             log::err() << "then set these environment variables: (all paths absolute)";
             log::err() << "VK_LAYER_PATH - <sdk>/x86_64/etc/vulkan/explicit_layer.d/";
             log::err() << "VULKAN_SDK - <sdk>/x86_64/bin";
@@ -187,7 +187,7 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
 
         if (!add_ext(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
         {
-            log::err() << "Missing debug utils extension";
+            log::err() << "missing debug utils extension";
         }
     }
 
@@ -195,7 +195,7 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
     {
         if (!add_ext("VK_EXT_validation_features"))
         {
-            log::err() << "Missing GPU-assisted validation extension";
+            log::err() << "missing GPU-assisted validation extension";
         }
     }
 
@@ -203,7 +203,7 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
     {
         if (!add_layer("VK_LAYER_LUNARG_api_dump"))
         {
-            log::err() << "Missing API dump layer";
+            log::err() << "missing API dump layer";
         }
     }
 
@@ -211,14 +211,14 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
     for (char const* const required_device_ext : get_platform_instance_extensions())
     {
         if (!add_ext(required_device_ext))
-            log::err() << "Missing required extension" << required_device_ext;
+            log::err() << "missing required extension" << required_device_ext;
     }
 
 
     return used_res;
 }
 
-phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_set& available, const phi::backend_config& config, bool& has_raytracing)
+phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_set& available, const phi::backend_config& config, bool& has_raytracing, bool& has_conservative_raster)
 {
     lay_ext_array used_res;
 
@@ -242,11 +242,17 @@ phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_s
 
     if (!add_ext(VK_KHR_SWAPCHAIN_EXTENSION_NAME))
     {
-        log::err() << "Missing swapchain extension";
+        log::err() << "missing swapchain extension";
+    }
+
+    // additional extensions
+    has_conservative_raster = false;
+    if (add_ext(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME))
+    {
+        has_conservative_raster = true;
     }
 
     has_raytracing = false;
-
     if (config.enable_raytracing)
     {
         if (add_ext(VK_NV_RAY_TRACING_EXTENSION_NAME))
@@ -257,7 +263,7 @@ phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_s
             }
             else
             {
-                log::err()("Missing raytracing extension dependency {}", VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+                log::err()("missing raytracing extension dependency {}", VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
             }
         }
     }

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
@@ -42,6 +42,6 @@ struct lay_ext_array
 [[nodiscard]] lay_ext_set get_available_device_lay_ext(VkPhysicalDevice physical);
 
 [[nodiscard]] lay_ext_array get_used_instance_lay_ext(lay_ext_set const& available, backend_config const& config);
-[[nodiscard]] lay_ext_array get_used_device_lay_ext(lay_ext_set const& available, backend_config const& config, bool& has_raytracing);
+[[nodiscard]] lay_ext_array get_used_device_lay_ext(lay_ext_set const& available, backend_config const& config, bool& has_raytracing, bool& has_conservative_raster);
 
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -99,7 +99,10 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
     image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    // sampled bit for SRVs, transfer src for copy from, transfer dst for explicit clear (cmd::clear_textures)
+    image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    // Attachment bits so we can render to it
     if (phi::is_depth_format(format))
         image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     else

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -82,7 +82,7 @@ phi::handle::resource phi::vk::ResourcePool::createTexture(format format, unsign
     return acquireImage(res_alloc, res_image, format, image_info.mipLevels, image_info.arrayLayers);
 }
 
-phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples)
+phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size)
 {
     VkImageCreateInfo image_info = {};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -93,7 +93,7 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
     image_info.extent.height = static_cast<uint32_t>(h);
     image_info.extent.depth = 1;
     image_info.mipLevels = 1;
-    image_info.arrayLayers = 1;
+    image_info.arrayLayers = array_size;
 
     image_info.samples = util::to_native_sample_flags(samples);
     image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -354,7 +354,9 @@ phi::handle::resource phi::vk::ResourcePool::acquireBuffer(
         VkDescriptorBufferInfo cbv_info = {};
         cbv_info.buffer = buffer;
         cbv_info.offset = 0;
-        cbv_info.range = cc::min<uint64_t>(256, buffer_width);
+        cbv_info.range = buffer_width;
+        // NOTE: no idea what the line below tried to accomplish
+        //cc::min<uint64_t>(256, buffer_width);
 
         cc::capped_vector<VkWriteDescriptorSet, 2> writes;
         {

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -24,7 +24,7 @@ public:
     [[nodiscard]] handle::resource createTexture(format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav);
 
     /// create a render- or depth-stencil target
-    [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples);
+    [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples, unsigned array_size);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
     [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, bool allow_uav);

--- a/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
+++ b/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
@@ -246,6 +246,15 @@ VkPipeline phi::vk::create_pipeline(VkDevice device,
     rasterizer.depthBiasClamp = 0.0f;          // Optional
     rasterizer.depthBiasSlopeFactor = 0.0f;    // Optional
 
+    VkPipelineRasterizationConservativeStateCreateInfoEXT conservative_raster = {};
+
+    if (config.conservative_raster)
+    {
+        conservative_raster.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT;
+        conservative_raster.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT;
+        rasterizer.pNext = &conservative_raster;
+    }
+
     VkPipelineMultisampleStateCreateInfo multisampling = {};
     multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     multisampling.sampleShadingEnable = VK_FALSE;


### PR DESCRIPTION
- Add conservative rasterization
- Add typeless view-only formats
- Add `cmd::clear_textures` for explicit / standalone texture clearing
- Add support for array render targets
- Expand API of command writer utilities

**Vulkan**
- Fix fence ringbuffer overcommit crash on startup
- Fix CBV descriptor byte range