### PR TITLE
Groundwork for full queue support

### DIFF
--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -93,10 +93,13 @@ void phi::d3d12::BackendD3D12::initialize(const phi::backend_config& config, con
             thread_allocator_ptrs.push_back(&thread_comp.cmd_list_allocator);
         }
 
-        mPoolCmdLists.initialize(*this, config.num_cmdlist_allocators_per_thread, config.num_cmdlists_per_allocator, thread_allocator_ptrs);
+        mPoolCmdLists.initialize(*this, int(config.num_cmdlist_allocators_per_thread), int(config.num_cmdlists_per_allocator), thread_allocator_ptrs);
     }
 
     mDiagnostics.init();
+
+    mFlushEvent = CreateEventEx(nullptr, FALSE, FALSE, EVENT_ALL_ACCESS);
+    CC_ASSERT(mFlushEvent != INVALID_HANDLE_VALUE && "failed to create win32 event");
 }
 
 void phi::d3d12::BackendD3D12::destroy()
@@ -123,6 +126,8 @@ void phi::d3d12::BackendD3D12::destroy()
         }
 
         mAdapter.invalidate();
+
+        ::CloseHandle(mFlushEvent);
     }
 }
 
@@ -130,14 +135,23 @@ phi::d3d12::BackendD3D12::~BackendD3D12() { destroy(); }
 
 void phi::d3d12::BackendD3D12::flushGPU()
 {
-    shared_com_ptr<ID3D12Fence> fence;
-    PHI_D3D12_VERIFY(mDevice.getDevice().CreateFence(0, D3D12_FENCE_FLAG_NONE, PHI_COM_WRITE(fence)));
-    PHI_D3D12_VERIFY(mDirectQueue.getQueue().Signal(fence, 1));
+    auto lg = std::lock_guard(mFlushMutex);
 
-    auto const handle = CreateEvent(nullptr, FALSE, FALSE, nullptr);
-    fence->SetEventOnCompletion(1, handle);
-    ::WaitForSingleObject(handle, INFINITE);
-    ::CloseHandle(handle);
+    ++mFlushSignalVal;
+
+    PHI_D3D12_VERIFY(mDirectQueue.getQueue().Signal(&mDirectQueue.getFence(), mFlushSignalVal));
+    PHI_D3D12_VERIFY(mComputeQueue.getQueue().Signal(&mComputeQueue.getFence(), mFlushSignalVal));
+    PHI_D3D12_VERIFY(mCopyQueue.getQueue().Signal(&mCopyQueue.getFence(), mFlushSignalVal));
+
+    cc::array<ID3D12Fence*, 3> fences;
+    fences[0] = &mDirectQueue.getFence();
+    fences[1] = &mComputeQueue.getFence();
+    fences[2] = &mCopyQueue.getFence();
+
+    cc::array<uint64_t, 3> fence_vals = {mFlushSignalVal, mFlushSignalVal, mFlushSignalVal};
+
+    PHI_D3D12_VERIFY(mDevice.getDevice1().SetEventOnMultipleFenceCompletion(fences.data(), fence_vals.data(), 3, D3D12_MULTIPLE_FENCE_WAIT_FLAG_ALL, mFlushEvent));
+    ::WaitForSingleObject(mFlushEvent, INFINITE);
 }
 
 phi::handle::resource phi::d3d12::BackendD3D12::acquireBackbuffer()

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include <clean-core/fwd_array.hh>
 
 #include <phantasm-hardware-interface/Backend.hh>
@@ -148,14 +150,16 @@ public:
 
     void signalFenceGPU(handle::fence fence, uint64_t new_value, queue_type queue) override
     {
-        CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.signalGPU(fence, new_value, mDirectQueue.getQueue());
+        ID3D12CommandQueue& target
+            = (queue == queue_type::direct ? mDirectQueue.getQueue() : (queue == queue_type::compute ? mComputeQueue.getQueue() : mCopyQueue.getQueue()));
+        mPoolFences.signalGPU(fence, new_value, target);
     }
 
     void waitFenceGPU(handle::fence fence, uint64_t wait_value, queue_type queue) override
     {
-        CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.waitGPU(fence, wait_value, mDirectQueue.getQueue());
+        ID3D12CommandQueue& target
+            = (queue == queue_type::direct ? mDirectQueue.getQueue() : (queue == queue_type::compute ? mComputeQueue.getQueue() : mCopyQueue.getQueue()));
+        mPoolFences.waitGPU(fence, wait_value, target);
     }
 
     void free(cc::span<handle::fence const> fences) override { mPoolFences.free(fences); }
@@ -218,9 +222,15 @@ private:
     // Core components
     Adapter mAdapter;
     Device mDevice;
+
     Queue mDirectQueue;
     Queue mCopyQueue;
     Queue mComputeQueue;
+
+    ::HANDLE mFlushEvent;
+    UINT64 mFlushSignalVal = 0;
+    std::mutex mFlushMutex;
+
     Swapchain mSwapchain;
 
     // Pools

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -149,13 +149,13 @@ public:
     void signalFenceGPU(handle::fence fence, uint64_t new_value, queue_type queue) override
     {
         CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.signalGPU(fence, new_value, mGraphicsQueue.getQueue());
+        mPoolFences.signalGPU(fence, new_value, mDirectQueue.getQueue());
     }
 
     void waitFenceGPU(handle::fence fence, uint64_t wait_value, queue_type queue) override
     {
         CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.waitGPU(fence, wait_value, mGraphicsQueue.getQueue());
+        mPoolFences.waitGPU(fence, wait_value, mDirectQueue.getQueue());
     }
 
     void free(cc::span<handle::fence const> fences) override { mPoolFences.free(fences); }
@@ -211,14 +211,16 @@ public:
     // backend-internal
 
     [[nodiscard]] ID3D12Device& getDevice() { return mDevice.getDevice(); }
-    [[nodiscard]] ID3D12CommandQueue& getDirectQueue() { return mGraphicsQueue.getQueue(); }
+    [[nodiscard]] ID3D12CommandQueue& getDirectQueue() { return mDirectQueue.getQueue(); }
 
 
 private:
     // Core components
     Adapter mAdapter;
     Device mDevice;
-    Queue mGraphicsQueue;
+    Queue mDirectQueue;
+    Queue mCopyQueue;
+    Queue mComputeQueue;
     Swapchain mSwapchain;
 
     // Pools

--- a/src/phantasm-hardware-interface/d3d12/Device.cc
+++ b/src/phantasm-hardware-interface/d3d12/Device.cc
@@ -39,6 +39,11 @@ void phi::d3d12::Device::initialize(IDXGIAdapter& adapter, const backend_config&
     mFeatures = check_capabilities(mDevice);
 
     // QIs
+
+    // always get ID3D12Device1
+    PHI_D3D12_VERIFY(mDevice->QueryInterface(PHI_COM_WRITE(mDevice1)));
+
+    // try to receive ID3D12Device5
     auto const got_device5 = SUCCEEDED(mDevice->QueryInterface(PHI_COM_WRITE(mDevice5)));
     if (!got_device5)
     {

--- a/src/phantasm-hardware-interface/d3d12/Device.hh
+++ b/src/phantasm-hardware-interface/d3d12/Device.hh
@@ -27,11 +27,13 @@ public:
     ID3D12Device& getDevice() const { return *mDevice.get(); }
     shared_com_ptr<ID3D12Device> const& getDeviceShared() const { return mDevice; }
 
+    ID3D12Device1& getDevice1() const { return *mDevice1.get(); }
     ID3D12Device5* getDevice5() const { return mDevice5.get(); }
 
 private:
     shared_com_ptr<ID3D12DeviceRemovedExtendedDataSettings> mDREDSettings;
     shared_com_ptr<ID3D12Device> mDevice;
+    shared_com_ptr<ID3D12Device1> mDevice1;
     shared_com_ptr<ID3D12Device5> mDevice5;
     gpu_feature_flags mFeatures;
 };

--- a/src/phantasm-hardware-interface/d3d12/Fence.cc
+++ b/src/phantasm-hardware-interface/d3d12/Fence.cc
@@ -9,7 +9,7 @@ void phi::d3d12::SimpleFence::initialize(ID3D12Device& device)
 {
     CC_ASSERT(!mFence.is_valid());
     mEvent = CreateEventEx(nullptr, FALSE, FALSE, EVENT_ALL_ACCESS);
-    CC_ASSERT(mEvent != INVALID_HANDLE_VALUE);
+    CC_ASSERT(mEvent != INVALID_HANDLE_VALUE && "failed to create win32 event");
     PHI_D3D12_VERIFY(device.CreateFence(0, D3D12_FENCE_FLAG_NONE, PHI_COM_WRITE(mFence)));
 }
 

--- a/src/phantasm-hardware-interface/d3d12/Fence.hh
+++ b/src/phantasm-hardware-interface/d3d12/Fence.hh
@@ -40,7 +40,7 @@ public:
 
 private:
     shared_com_ptr<ID3D12Fence> mFence;
-    HANDLE mEvent;
+    ::HANDLE mEvent;
 };
 
 class Fence

--- a/src/phantasm-hardware-interface/d3d12/Queue.cc
+++ b/src/phantasm-hardware-interface/d3d12/Queue.cc
@@ -31,4 +31,7 @@ void phi::d3d12::Queue::initialize(ID3D12Device& device, queue_type type)
 
     PHI_D3D12_VERIFY(device.CreateCommandQueue(&queueDesc, PHI_COM_WRITE(mQueue)));
     util::set_object_name(mQueue, "%s queue", to_queue_type_literal(type));
+
+    PHI_D3D12_VERIFY(device.CreateFence(0, D3D12_FENCE_FLAG_NONE, PHI_COM_WRITE(mInternalFence)));
+    util::set_object_name(mInternalFence, "internal fence for %s queue", to_queue_type_literal(type));
 }

--- a/src/phantasm-hardware-interface/d3d12/Queue.cc
+++ b/src/phantasm-hardware-interface/d3d12/Queue.cc
@@ -5,6 +5,24 @@
 #include "common/util.hh"
 #include "common/verify.hh"
 
+namespace
+{
+char const* to_queue_type_literal(phi::queue_type t)
+{
+    switch (t)
+    {
+    case phi::queue_type::direct:
+        return "direct";
+    case phi::queue_type::copy:
+        return "copy";
+    case phi::queue_type::compute:
+        return "compute";
+    }
+
+    return "unknown_type";
+}
+}
+
 void phi::d3d12::Queue::initialize(ID3D12Device& device, queue_type type)
 {
     D3D12_COMMAND_QUEUE_DESC queueDesc = {};
@@ -12,5 +30,5 @@ void phi::d3d12::Queue::initialize(ID3D12Device& device, queue_type type)
     queueDesc.Type = util::to_native(type);
 
     PHI_D3D12_VERIFY(device.CreateCommandQueue(&queueDesc, PHI_COM_WRITE(mQueue)));
-    util::set_object_name(mQueue, "type %d queue", util::to_native(type));
+    util::set_object_name(mQueue, "%s queue", to_queue_type_literal(type));
 }

--- a/src/phantasm-hardware-interface/d3d12/Queue.hh
+++ b/src/phantasm-hardware-interface/d3d12/Queue.hh
@@ -22,8 +22,11 @@ public:
     [[nodiscard]] ID3D12CommandQueue& getQueue() const { return *mQueue.get(); }
     [[nodiscard]] shared_com_ptr<ID3D12CommandQueue> const& getQueueShared() const { return mQueue; }
 
+    ID3D12Fence& getFence() const { return *mInternalFence.get(); }
+
 private:
     shared_com_ptr<ID3D12CommandQueue> mQueue;
+    shared_com_ptr<ID3D12Fence> mInternalFence;
 };
 
 }

--- a/src/phantasm-hardware-interface/d3d12/common/d3d12_fwd.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/d3d12_fwd.hh
@@ -10,6 +10,7 @@ typedef UINT64 D3D12_GPU_VIRTUAL_ADDRESS;
 typedef struct ID3D10Blob ID3DBlob;
 
 struct ID3D12Device;
+struct ID3D12Device1;
 struct ID3D12Device5;
 struct ID3D12Fence;
 struct ID3D12Resource;

--- a/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
+++ b/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
@@ -73,12 +73,12 @@ ID3D12PipelineState* phi::d3d12::create_pipeline_state(ID3D12Device& device,
             blend_state.LogicOp = util::to_native(framebuffer_format.logic_op);
 
             blend_state.BlendEnable = true;
-            blend_state.BlendOp = util::to_native(rt.blend_op_color);
-            blend_state.SrcBlend = util::to_native(rt.blend_color_src);
-            blend_state.DestBlend = util::to_native(rt.blend_color_dest);
-            blend_state.BlendOpAlpha = util::to_native(rt.blend_op_alpha);
-            blend_state.SrcBlendAlpha = util::to_native(rt.blend_alpha_src);
-            blend_state.DestBlendAlpha = util::to_native(rt.blend_alpha_dest);
+            blend_state.BlendOp = util::to_native(rt.state.blend_op_color);
+            blend_state.SrcBlend = util::to_native(rt.state.blend_color_src);
+            blend_state.DestBlend = util::to_native(rt.state.blend_color_dest);
+            blend_state.BlendOpAlpha = util::to_native(rt.state.blend_op_alpha);
+            blend_state.SrcBlendAlpha = util::to_native(rt.state.blend_alpha_src);
+            blend_state.DestBlendAlpha = util::to_native(rt.state.blend_alpha_dest);
         }
     }
 

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -540,17 +540,38 @@ enum class blend_factor : uint8_t
     inv_dest_alpha
 };
 
-/// the blending configuration for a specific render target slot of a (graphics) handle::pipeline_state
-struct render_target_config
+struct blend_state
 {
-    format fmt = format::rgba8un;
-    bool blend_enable = false;
     blend_factor blend_color_src = blend_factor::one;
     blend_factor blend_color_dest = blend_factor::zero;
     blend_op blend_op_color = blend_op::op_add;
     blend_factor blend_alpha_src = blend_factor::one;
     blend_factor blend_alpha_dest = blend_factor::zero;
     blend_op blend_op_alpha = blend_op::op_add;
+
+    blend_state() = default;
+    blend_state(blend_factor blend_color_src,
+                blend_factor blend_color_dest,
+                blend_op blend_op_color,
+                blend_factor blend_alpha_src = blend_factor::one,
+                blend_factor blend_alpha_dest = blend_factor::zero,
+                blend_op blend_op_alpha = blend_op::op_add)
+      : blend_color_src(blend_color_src),
+        blend_color_dest(blend_color_dest),
+        blend_op_color(blend_op_color),
+        blend_alpha_src(blend_alpha_src),
+        blend_alpha_dest(blend_alpha_dest),
+        blend_op_alpha(blend_op_alpha)
+    {
+    }
+};
+
+/// the blending configuration for a specific render target slot of a (graphics) handle::pipeline_state
+struct render_target_config
+{
+    format fmt = format::rgba8un;
+    bool blend_enable = false;
+    blend_state state;
 };
 
 /// flags to configure the building process of a raytracing acceleration structure

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -137,14 +137,16 @@ public:
 
     void signalFenceGPU(handle::fence fence, uint64_t new_value, queue_type queue) override
     {
-        CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.signalGPU(fence, new_value, mDevice.getQueueDirect());
+        VkQueue target = (queue == queue_type::direct ? mDevice.getQueueDirect()
+                                                      : (queue == queue_type::compute ? mDevice.getQueueCompute() : mDevice.getQueueCopy()));
+        mPoolFences.signalGPU(fence, new_value, target);
     }
 
     void waitFenceGPU(handle::fence fence, uint64_t wait_value, queue_type queue) override
     {
-        CC_ASSERT(queue == queue_type::direct && "unimplemented queue");
-        mPoolFences.waitGPU(fence, wait_value, mDevice.getQueueDirect());
+        VkQueue target = (queue == queue_type::direct ? mDevice.getQueueDirect()
+                                                      : (queue == queue_type::compute ? mDevice.getQueueCompute() : mDevice.getQueueCopy()));
+        mPoolFences.waitGPU(fence, wait_value, target);
     }
 
     void free(cc::span<handle::fence const> fences) override { mPoolFences.free(fences); }

--- a/src/phantasm-hardware-interface/vulkan/Device.hh
+++ b/src/phantasm-hardware-interface/vulkan/Device.hh
@@ -3,6 +3,7 @@
 #include <clean-core/array.hh>
 
 #include <phantasm-hardware-interface/fwd.hh>
+#include <phantasm-hardware-interface/vulkan/queue_util.hh>
 
 #include "loader/volk.hh"
 
@@ -26,9 +27,9 @@ public:
     VkQueue getQueueCompute() const { return mQueueCompute; }
     VkQueue getQueueCopy() const { return mQueueCopy; }
 
-    int getQueueFamilyDirect() const { return mQueueFamilies.direct; }
-    int getQueueFamilyCompute() const { return mQueueFamilies.compute; }
-    int getQueueFamilyCopy() const { return mQueueFamilies.copy; }
+    int getQueueFamilyDirect() const { return mQueueIndices.direct.family_index; }
+    int getQueueFamilyCompute() const { return mQueueIndices.compute.family_index; }
+    int getQueueFamilyCopy() const { return mQueueIndices.copy.family_index; }
 
 public:
     VkPhysicalDeviceMemoryProperties const& getMemoryProperties() const { return mInformation.memory_properties; }
@@ -54,12 +55,7 @@ private:
     VkQueue mQueueCompute = nullptr;
     VkQueue mQueueCopy = nullptr;
 
-    struct
-    {
-        int direct = -1;
-        int compute = -1;
-        int copy = -1;
-    } mQueueFamilies;
+    chosen_queues mQueueIndices;
 
     // Miscellaneous info
     struct

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -44,7 +44,7 @@ phi::vk::vulkan_gpu_info phi::vk::get_vulkan_gpu_info(VkPhysicalDevice device, V
 
     // queue capability
     res.queues = get_suitable_queues(device, surface);
-    if (res.queues.indices_graphics.empty())
+    if (!res.queues.has_direct_queue)
         res.is_suitable = false;
 
     res.available_layers_extensions = get_available_device_lay_ext(device);

--- a/src/phantasm-hardware-interface/vulkan/queue_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/queue_util.hh
@@ -9,18 +9,51 @@ namespace phi::vk
 {
 struct suitable_queues
 {
-    cc::vector<int> indices_graphics;
-    cc::vector<int> indices_compute;
-    cc::vector<int> indices_copy;
-    cc::vector<int> indices_direct; ///< equivalent of D3D12 direct queue support (graphics + compute + copy)
+    enum queue_capability : uint32_t
+    {
+        none = 0,
+
+        present = 1 << 0,
+        vk_graphics = 1 << 1,
+        vk_compute = 1 << 2,
+        vk_transfer = 1 << 3,
+
+        phi_graphics = vk_graphics | present,
+        phi_compute = vk_compute | present, // we allow present_from_compute globally
+        phi_copy = vk_transfer,
+        phi_direct = phi_graphics | phi_compute | phi_copy
+    };
+
+    struct queue_family
+    {
+        uint32_t capabilities = queue_capability::none;
+        uint32_t num_queues = 0;
+
+        bool supports(uint32_t caps) const { return capabilities & caps; }
+        bool supports_exclusive(uint32_t caps, uint32_t restriction) const { return (capabilities & caps) && !(capabilities & restriction); }
+    };
+
+    // indexed 1:1 as the queues queried from Vk
+    cc::vector<queue_family> families;
+    bool has_direct_queue = false;
 };
 
 struct chosen_queues
 {
-    int direct = -1;
-    int separate_graphics = -1;
-    int separate_compute = -1;
-    int separate_copy = -1;
+    struct queue_indices
+    {
+        int family_index = -1;
+        int queue_index = 0;
+
+    public:
+        bool valid() const { return family_index != -1; }
+        bool operator==(queue_indices const& rhs) const { return family_index == rhs.family_index && queue_index == rhs.queue_index; }
+        bool operator!=(queue_indices const& rhs) const { return !this->operator==(rhs); }
+    };
+
+    queue_indices direct;
+    queue_indices compute;
+    queue_indices copy;
 };
 
 [[nodiscard]] suitable_queues get_suitable_queues(VkPhysicalDevice physical, VkSurfaceKHR surface);

--- a/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
+++ b/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
@@ -272,12 +272,12 @@ VkPipeline phi::vk::create_pipeline(VkDevice device,
         rt_attachment = {};
         rt_attachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
         rt_attachment.blendEnable = rt.blend_enable ? VK_TRUE : VK_FALSE;
-        rt_attachment.srcColorBlendFactor = util::to_native(rt.blend_color_src);
-        rt_attachment.dstColorBlendFactor = util::to_native(rt.blend_color_dest);
-        rt_attachment.colorBlendOp = util::to_native(rt.blend_op_color);
-        rt_attachment.srcAlphaBlendFactor = util::to_native(rt.blend_alpha_src);
-        rt_attachment.dstAlphaBlendFactor = util::to_native(rt.blend_alpha_dest);
-        rt_attachment.alphaBlendOp = util::to_native(rt.blend_op_alpha);
+        rt_attachment.srcColorBlendFactor = util::to_native(rt.state.blend_color_src);
+        rt_attachment.dstColorBlendFactor = util::to_native(rt.state.blend_color_dest);
+        rt_attachment.colorBlendOp = util::to_native(rt.state.blend_op_color);
+        rt_attachment.srcAlphaBlendFactor = util::to_native(rt.state.blend_alpha_src);
+        rt_attachment.dstAlphaBlendFactor = util::to_native(rt.state.blend_alpha_dest);
+        rt_attachment.alphaBlendOp = util::to_native(rt.state.blend_op_alpha);
     }
 
     VkPipelineColorBlendStateCreateInfo colorBlending = {};


### PR DESCRIPTION
- add support for `handle::fence` operations on all three queue types
- split `blend_state` into separate struct

## d3d12
- always initialize a direct, copy, and compute queue
- properly flush all queues, implement flush more efficiently

## vulkan
- fix queue query and selection process
- always initialize all three queues