### PR TITLE
Vulkan discrete queue implementation

### DIFF
--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
@@ -167,8 +167,6 @@ void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
         thread_allocators[i]->bundle_copy.initialize(*backend.getDevice5(), D3D12_COMMAND_LIST_TYPE_COPY, num_copy_allocs, num_copy_lists_per_alloc,
                                                      cc::span{mRawListsCopy}.subspan(i * num_copy_lists_per_thread, num_copy_lists_per_thread));
     }
-
-    // backend.flushGPU(); // NOTE: Why?
 }
 
 void phi::d3d12::CommandListPool::destroy()

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -253,13 +253,13 @@ private:
     }
 
 private:
-    /// the pool itself, managing handle association as well as additional
+    /// the linked pools per cmdlist type, managing handle association as well as additional
     /// bookkeeping data structures
     cmdlist_linked_pool_t mPoolDirect;
     cmdlist_linked_pool_t mPoolCompute;
     cmdlist_linked_pool_t mPoolCopy;
 
-    /// a parallel array to the pool, identically indexed
+    /// parallel arrays to the pools, identically indexed
     /// the cmdlists must stay alive even while "unallocated"
     cc::array<ID3D12GraphicsCommandList5*> mRawListsDirect;
     cc::array<ID3D12GraphicsCommandList5*> mRawListsCompute;

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -84,8 +84,8 @@ inline constexpr shader_stage_flags_t shader_stage_mask_all_ray
 enum class queue_type : uint8_t
 {
     direct, // graphics + copy + compute + present
-    copy,
-    compute
+    compute,
+    copy
 };
 
 /// state of a handle::resource, determining legal operations

--- a/src/phantasm-hardware-interface/util.hh
+++ b/src/phantasm-hardware-interface/util.hh
@@ -3,16 +3,24 @@
 #include <clean-core/bits.hh>
 #include <clean-core/utility.hh>
 
+#include <typed-geometry/types/size.hh>
+
 namespace phi::util
 {
 /// returns the size the given texture dimension has at the specified mip level
 /// get_mip_size(1024, 3) == 128
-constexpr unsigned get_mip_size(unsigned width_height, unsigned mip_level)
+constexpr int get_mip_size(int width_height, int mip_level)
 {
-    unsigned res = unsigned(width_height / float(1 << mip_level));
+    int res = int(width_height / float(1 << mip_level));
     return res > 0 ? res : 1;
 }
 
+constexpr tg::isize2 get_mip_size(tg::isize2 size, int mip_level)
+{
+    return {get_mip_size(size.width, mip_level), get_mip_size(size.height, mip_level)};
+}
+
 /// returns the amount of levels in a full mip chain for a texture of the given size
-inline unsigned get_num_mips(unsigned width, unsigned height) { return cc::bit_log2(cc::max(width, height)) + 1u; }
+inline int get_num_mips(int width, int height) { return int(cc::bit_log2(cc::uint32(cc::max(width, height)))) + 1; }
+inline int get_num_mips(tg::isize2 size) { return get_num_mips(size.width, size.height); }
 }

--- a/src/phantasm-hardware-interface/util.hh
+++ b/src/phantasm-hardware-interface/util.hh
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <clean-core/bits.hh>
+#include <clean-core/utility.hh>
+
+namespace phi::util
+{
+/// returns the size the given texture dimension has at the specified mip level
+/// get_mip_size(1024, 3) == 128
+constexpr unsigned get_mip_size(unsigned width_height, unsigned mip_level)
+{
+    unsigned res = unsigned(width_height / float(1 << mip_level));
+    return res > 0 ? res : 1;
+}
+
+/// returns the amount of levels in a full mip chain for a texture of the given size
+inline unsigned get_num_mips(unsigned width, unsigned height) { return cc::bit_log2(cc::max(width, height)) + 1u; }
+}

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -193,8 +193,9 @@ phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer()
     else
     {
         resource_state prev_state;
+        auto const backbuf_size = mSwapchain.getBackbufferSize();
         auto const res = mPoolResources.injectBackbufferResource(mSwapchain.getCurrentBackbuffer(), mSwapchain.getCurrentBackbufferState(),
-                                                                 mSwapchain.getCurrentBackbufferView(), prev_state);
+                                                                 mSwapchain.getCurrentBackbufferView(), backbuf_size.width, backbuf_size.height, prev_state);
 
         mSwapchain.setBackbufferState(prev_backbuffer_index, prev_state);
         return res;

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -222,7 +222,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::draw& draw)
     // Draw command
     if (draw.index_buffer.is_valid())
     {
-        vkCmdDrawIndexed(_cmd_list, draw.num_indices, 1, draw.index_offset, static_cast<int32_t>(draw.vertex_offset), 0);
+        vkCmdDrawIndexed(_cmd_list, draw.num_indices, 1, draw.index_offset, int32_t(draw.vertex_offset), 0);
     }
     else
     {

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -401,7 +401,7 @@ phi::handle::resource phi::vk::ResourcePool::acquireBuffer(
     return {static_cast<handle::index_t>(res)};
 }
 phi::handle::resource phi::vk::ResourcePool::acquireImage(
-    VmaAllocation alloc, VkImage image, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, unsigned width, unsigned height)
+    VmaAllocation alloc, VkImage image, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, int width, int height)
 {
     unsigned res;
     {

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -74,6 +74,8 @@ public:
             unsigned num_mips;
             unsigned num_array_layers;
             unsigned num_samples;
+            unsigned width;
+            unsigned height;
         };
 
     public:
@@ -116,9 +118,6 @@ public:
 
     [[nodiscard]] int getNumImageSamples(handle::resource res) const
     {
-        if (isBackbuffer(res))
-            return 1;
-
         auto const& node = internalGet(res);
         CC_ASSERT(node.type == resource_node::resource_type::image && "queried amount of image samples from non-image");
         return node.image.num_samples;
@@ -152,7 +151,8 @@ public:
     // the first of either phi::present or phi::resize
     //
 
-    [[nodiscard]] handle::resource injectBackbufferResource(VkImage raw_image, resource_state state, VkImageView backbuffer_view, resource_state& out_prev_state);
+    [[nodiscard]] handle::resource injectBackbufferResource(
+        VkImage raw_image, resource_state state, VkImageView backbuffer_view, unsigned width, unsigned height, resource_state& out_prev_state);
 
     [[nodiscard]] bool isBackbuffer(handle::resource res) const { return res == mInjectedBackbufferResource; }
 
@@ -162,7 +162,8 @@ private:
     [[nodiscard]] handle::resource acquireBuffer(
         VmaAllocation alloc, VkBuffer buffer, VkBufferUsageFlags usage, uint64_t buffer_width = 0, unsigned buffer_stride = 0, std::byte* buffer_map = nullptr);
 
-    [[nodiscard]] handle::resource acquireImage(VmaAllocation alloc, VkImage buffer, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples);
+    [[nodiscard]] handle::resource acquireImage(
+        VmaAllocation alloc, VkImage buffer, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, unsigned width, unsigned height);
 
     [[nodiscard]] resource_node const& internalGet(handle::resource res) const { return mPool.get(static_cast<unsigned>(res.index)); }
     [[nodiscard]] resource_node& internalGet(handle::resource res) { return mPool.get(static_cast<unsigned>(res.index)); }

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -74,8 +74,8 @@ public:
             unsigned num_mips;
             unsigned num_array_layers;
             unsigned num_samples;
-            unsigned width;
-            unsigned height;
+            int width;
+            int height;
         };
 
     public:
@@ -163,7 +163,7 @@ private:
         VmaAllocation alloc, VkBuffer buffer, VkBufferUsageFlags usage, uint64_t buffer_width = 0, unsigned buffer_stride = 0, std::byte* buffer_map = nullptr);
 
     [[nodiscard]] handle::resource acquireImage(
-        VmaAllocation alloc, VkImage buffer, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, unsigned width, unsigned height);
+        VmaAllocation alloc, VkImage buffer, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, int width, int height);
 
     [[nodiscard]] resource_node const& internalGet(handle::resource res) const { return mPool.get(static_cast<unsigned>(res.index)); }
     [[nodiscard]] resource_node& internalGet(handle::resource res) { return mPool.get(static_cast<unsigned>(res.index)); }

--- a/src/phantasm-hardware-interface/vulkan/queue_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/queue_util.hh
@@ -29,8 +29,8 @@ struct suitable_queues
         uint32_t capabilities = queue_capability::none;
         uint32_t num_queues = 0;
 
-        bool supports(uint32_t caps) const { return capabilities & caps; }
-        bool supports_exclusive(uint32_t caps, uint32_t restriction) const { return (capabilities & caps) && !(capabilities & restriction); }
+        bool supports(uint32_t caps) const { return (capabilities & caps) == caps; }
+        bool supports_exclusive(uint32_t caps, uint32_t restriction) const { return supports(caps) && !supports(restriction); }
     };
 
     // indexed 1:1 as the queues queried from Vk


### PR DESCRIPTION
- Add vulkan implementation for discrete queue recording and submission
- Fix vulkan compute queue selection always falling back to direct/graphics family
- Fix vulkan clears only affecting the viewport area specified in `cmd::begin_render_pass`
- Add unified optimized mip size utilities