### PR TITLE
Add wireframe and frontface c/ccw options to pipeline config

### DIFF
--- a/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
+++ b/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
@@ -42,10 +42,12 @@ ID3D12PipelineState* phi::d3d12::create_pipeline_state(ID3D12Device& device,
         }
     }
 
+    CC_ASSERT(framebuffer_format.render_targets.empty() ? true : pso_desc.PS.pShaderBytecode != nullptr && "creating a PSO with rendertargets, but missing pixel shader");
 
     pso_desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     pso_desc.RasterizerState.CullMode = util::to_native(config.cull);
-    pso_desc.RasterizerState.FrontCounterClockwise = true;
+    pso_desc.RasterizerState.FillMode = config.wireframe ? D3D12_FILL_MODE_WIREFRAME : D3D12_FILL_MODE_SOLID;
+    pso_desc.RasterizerState.FrontCounterClockwise = config.frontface_counterclockwise;
     pso_desc.RasterizerState.ConservativeRaster = config.conservative_raster ? D3D12_CONSERVATIVE_RASTERIZATION_MODE_ON : D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 
     pso_desc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -460,6 +460,8 @@ struct pipeline_config
     cull_mode cull = cull_mode::none;
     int samples = 1;
     bool conservative_raster = false;
+    bool frontface_counterclockwise = true;
+    bool wireframe = false;
 };
 
 /// operation to perform on render targets upon render pass begin

--- a/src/phantasm-hardware-interface/vulkan/Swapchain.cc
+++ b/src/phantasm-hardware-interface/vulkan/Swapchain.cc
@@ -250,6 +250,8 @@ void phi::vk::Swapchain::createSwapchain(int width_hint, int height_hint)
         swapchain_info.clipped = true;
         swapchain_info.oldSwapchain = nullptr;
 
+        // NOTE: on some linux wms this causes false positive validation warnings, there is no workaround
+        // see https://github.com/project-arcana/phantasm-hardware-interface/issues/26
         PHI_VK_VERIFY_SUCCESS(vkCreateSwapchainKHR(mDevice, &swapchain_info, nullptr, &mSwapchain));
     }
 


### PR DESCRIPTION
- Add wireframe fillmode and frontface clockwise / counterclockwise settings to `pipeline_config`
    (not breaking, default to previous unexposed defaults)
- Assert when creating a PSO with rendertargets but without a pixel shader