### PR TITLE
Debug label regions, minor changes

### DIFF
--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -26,9 +26,10 @@ namespace detail
     PHI_X(resolve_texture)         \
     PHI_X(begin_render_pass)       \
     PHI_X(end_render_pass)         \
-    PHI_X(debug_marker)            \
     PHI_X(write_timestamp)         \
     PHI_X(resolve_queries)         \
+    PHI_X(begin_debug_label)       \
+    PHI_X(end_debug_label)         \
     PHI_X(update_bottom_level)     \
     PHI_X(update_top_level)        \
     PHI_X(dispatch_rays)           \
@@ -360,15 +361,6 @@ public:
     }
 };
 
-/// set a debug marker for diagnostic tools like renderdoc, nsight, or pix
-PHI_DEFINE_CMD(debug_marker)
-{
-    char const* string = "UNLABELED_DEBUG_MARKER";
-
-    debug_marker() = default;
-    debug_marker(char const* s) : string(s) {}
-};
-
 PHI_DEFINE_CMD(write_timestamp)
 {
     handle::query_range query_range = handle::null_query_range; ///< the query_range in which to write a timestamp query
@@ -395,6 +387,21 @@ PHI_DEFINE_CMD(resolve_queries)
         num_queries = num;
         this->dest_offset = dest_offset;
     }
+};
+
+/// begin a debug label on the cmdlist
+/// for diagnostic tools like renderdoc, nsight, gpa, pix
+/// close it using cmd::end_debug_label
+PHI_DEFINE_CMD(begin_debug_label)
+{
+    char const* string = "UNLABELED_DEBUG_MARKER";
+
+    begin_debug_label() = default;
+    begin_debug_label(char const* s) : string(s) {}
+};
+
+PHI_DEFINE_CMD(end_debug_label){
+    // empty
 };
 
 /// update a bottom level raytracing acceleration structure (BLAS)

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -407,8 +407,6 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::resolve_textur
     _cmd_list->ResolveSubresource(dest_raw, dest_subres_index, src_raw, src_subres_index, util::to_dxgi_format(dest_info.pixel_format));
 }
 
-void phi::d3d12::command_list_translator::execute(const phi::cmd::debug_marker& marker) { util::set_pix_marker(_cmd_list, 0, marker.string); }
-
 void phi::d3d12::command_list_translator::execute(const phi::cmd::write_timestamp& timestamp)
 {
     ID3D12QueryHeap* heap;
@@ -426,6 +424,10 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::resolve_querie
     ID3D12Resource* const raw_dest_buffer = _globals.pool_resources->getRawResource(resolve.dest_buffer);
     _cmd_list->ResolveQueryData(heap, util::to_query_type(type), query_index_start, resolve.num_queries, raw_dest_buffer, resolve.dest_offset);
 }
+
+void phi::d3d12::command_list_translator::execute(const phi::cmd::begin_debug_label& label) { util::begin_pix_marker(_cmd_list, 0, label.string); }
+
+void phi::d3d12::command_list_translator::execute(const phi::cmd::end_debug_label&) { util::end_pix_marker(_cmd_list); }
 
 void phi::d3d12::command_list_translator::execute(const phi::cmd::update_bottom_level& blas_update)
 {

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -62,11 +62,13 @@ struct command_list_translator
 
     void execute(cmd::resolve_texture const& resolve);
 
-    void execute(cmd::debug_marker const& marker);
-
     void execute(cmd::write_timestamp const& timestamp);
 
     void execute(cmd::resolve_queries const& resolve);
+
+    void execute(cmd::begin_debug_label const& label);
+
+    void execute(cmd::end_debug_label const&);
 
     void execute(cmd::update_bottom_level const& blas_update);
 

--- a/src/phantasm-hardware-interface/d3d12/common/diagnostic_util.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/diagnostic_util.cc
@@ -103,37 +103,26 @@ bool phi::d3d12::util::diagnostic_state::end_capture()
     return false;
 }
 
-void phi::d3d12::util::set_pix_marker(ID3D12GraphicsCommandList* cmdlist, UINT64 color, const char* string)
+void phi::d3d12::util::begin_pix_marker(ID3D12GraphicsCommandList* cmdlist, UINT64 color, const char* string)
 {
 #ifdef PHI_HAS_PIX
-    ::PIXSetMarker(cmdlist, color, string);
+    ::PIXBeginEvent(cmdlist, color, string);
 #else
     (void)cmdlist;
     (void)color;
     (void)string;
-    PHI_LOG_ERROR("PIX integration missing, enable the PHI_ENABLE_D3D12_PIX CMake option");
+    PHI_LOG_WARN("PIX integration missing, enable the PHI_ENABLE_D3D12_PIX CMake option");
 #endif
 }
 
-void phi::d3d12::util::set_pix_marker(ID3D12CommandQueue* cmdqueue, UINT64 color, const char* string)
+void phi::d3d12::util::end_pix_marker(ID3D12GraphicsCommandList* cmdlist)
 {
 #ifdef PHI_HAS_PIX
-    ::PIXSetMarker(cmdqueue, color, string);
+    ::PIXEndEvent(cmdlist);
 #else
-    (void)cmdqueue;
+    (void)cmdlist;
     (void)color;
     (void)string;
-    PHI_LOG_ERROR("PIX integration missing, enable the PHI_ENABLE_D3D12_PIX CMake option");
-#endif
-}
-
-void phi::d3d12::util::set_pix_marker_cpu(UINT64 color, const char* string)
-{
-#ifdef PHI_HAS_PIX
-    ::PIXSetMarker(color, string);
-#else
-    (void)color;
-    (void)string;
-    PHI_LOG_ERROR("PIX integration missing, enable the PHI_ENABLE_D3D12_PIX CMake option");
+    PHI_LOG_WARN("PIX integration missing, enable the PHI_ENABLE_D3D12_PIX CMake option");
 #endif
 }

--- a/src/phantasm-hardware-interface/d3d12/common/diagnostic_util.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/diagnostic_util.hh
@@ -22,9 +22,7 @@ private:
     bool _renderdoc_capture_running = false;
 };
 
-void set_pix_marker(ID3D12GraphicsCommandList* cmdlist, UINT64 color, char const* string);
-void set_pix_marker(ID3D12CommandQueue* cmdqueue, UINT64 color, char const* string);
-
-void set_pix_marker_cpu(UINT64 color, char const* string);
+void begin_pix_marker(ID3D12GraphicsCommandList* cmdlist, UINT64 color, char const* string);
+void end_pix_marker(ID3D12GraphicsCommandList* cmdlist);
 
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -145,15 +145,6 @@ struct CommandAllocatorsPerThread
 class CommandListPool
 {
 private:
-    struct internal_handle_data
-    {
-        uint8_t pad;
-        queue_type type;
-        uint16_t pool_index;
-    };
-
-    static_assert(sizeof(internal_handle_data) == sizeof(handle::command_list));
-
     struct cmd_list_node
     {
         // an allocated node is always in the following state:
@@ -163,7 +154,83 @@ private:
         d3d12_incomplete_state_cache state_cache;
     };
 
-    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node, uint16_t>;
+    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node, unsigned>;
+
+    static constexpr int mcIndexOffsetStep = 1'000'000;
+
+    static constexpr int mcIndexOffsetDirect = mcIndexOffsetStep * 0;
+    static constexpr int mcIndexOffsetCompute = mcIndexOffsetStep * 1;
+    static constexpr int mcIndexOffsetCopy = mcIndexOffsetStep * 2;
+
+    static constexpr queue_type HandleToQueueType(handle::command_list cl)
+    {
+        if (cl.index >= mcIndexOffsetCopy)
+            return queue_type::copy;
+        else if (cl.index >= mcIndexOffsetCompute)
+            return queue_type::compute;
+        else
+            return queue_type::direct;
+    }
+
+    static constexpr handle::command_list IndexToHandle(unsigned pool_index, queue_type type)
+    {
+        // we rely on underlying values here
+        static_assert(int(queue_type::direct) == 0, "unexpected enum ordering");
+        static_assert(int(queue_type::compute) == 1, "unexpected enum ordering");
+        static_assert(int(queue_type::copy) == 2, "unexpected enum ordering");
+        return {int(pool_index) + mcIndexOffsetStep * int(type)};
+    }
+
+    static constexpr unsigned HandleToIndex(handle::command_list cl, queue_type type)
+    {
+        //
+        return unsigned(cl.index - mcIndexOffsetStep * int(type));
+    }
+
+    cmdlist_linked_pool_t& getPool(queue_type type)
+    {
+        switch (type)
+        {
+        case queue_type::direct:
+            return mPoolDirect;
+        case queue_type::compute:
+            return mPoolCompute;
+        case queue_type::copy:
+            return mPoolCopy;
+        }
+
+        CC_UNREACHABLE("invalid queue_type");
+    }
+
+    cmdlist_linked_pool_t const& getPool(queue_type type) const
+    {
+        switch (type)
+        {
+        case queue_type::direct:
+            return mPoolDirect;
+        case queue_type::compute:
+            return mPoolCompute;
+        case queue_type::copy:
+            return mPoolCopy;
+        }
+
+        CC_UNREACHABLE("invalid queue_type");
+    }
+
+    ID3D12GraphicsCommandList5* getList(unsigned index, queue_type type) const
+    {
+        switch (type)
+        {
+        case queue_type::direct:
+            return mRawListsDirect[index];
+        case queue_type::compute:
+            return mRawListsCompute[index];
+        case queue_type::copy:
+            return mRawListsCopy[index];
+        }
+
+        CC_UNREACHABLE("invalid queue_type");
+    }
 
 public:
     // frontend-facing API (not quite, command_list can only be compiled immediately)
@@ -217,7 +284,12 @@ public:
     }
 
 public:
-    ID3D12GraphicsCommandList5* getRawList(handle::command_list cl) { return getListInternal(cl); }
+    ID3D12GraphicsCommandList5* getRawList(handle::command_list cl)
+    {
+        auto const type = HandleToQueueType(cl);
+        return getList(HandleToIndex(cl, type), type);
+    }
+
     d3d12_incomplete_state_cache* getStateCache(handle::command_list cl) { return &getNodeInternal(cl)->state_cache; }
 
 public:
@@ -235,21 +307,19 @@ public:
 private:
     handle::command_list acquireNodeInternal(queue_type type, cmd_list_node*& out_node, ID3D12GraphicsCommandList5*& out_cmdlist);
 
-    cmd_list_node* getNodeInternal(handle::command_list cl, cmdlist_linked_pool_t*& out_pool, ID3D12GraphicsCommandList5*& out_cmdlist);
-
-    cmd_list_node* getNodeInternal(handle::command_list cl)
+    [[nodiscard]] cmd_list_node* getNodeInternal(handle::command_list cl)
     {
-        cmdlist_linked_pool_t* pool;
-        ID3D12GraphicsCommandList5* list;
-        return getNodeInternal(cl, pool, list);
+        queue_type const type = HandleToQueueType(cl);
+        return &getPool(type).get(HandleToIndex(cl, type));
     }
 
-    ID3D12GraphicsCommandList5* getListInternal(handle::command_list cl)
+    cmd_list_node* getNodeInternal(handle::command_list cl, cmdlist_linked_pool_t*& out_pool, ID3D12GraphicsCommandList5*& out_cmdlist)
     {
-        cmdlist_linked_pool_t* pool;
-        ID3D12GraphicsCommandList5* list;
-        getNodeInternal(cl, pool, list);
-        return list;
+        queue_type const type = HandleToQueueType(cl);
+        auto const index = HandleToIndex(cl, type);
+        out_pool = &getPool(type);
+        out_cmdlist = getList(index, type);
+        return &out_pool->get(index);
     }
 
 private:

--- a/src/phantasm-hardware-interface/detail/gpu_stats.cc
+++ b/src/phantasm-hardware-interface/detail/gpu_stats.cc
@@ -1,0 +1,204 @@
+#include "gpu_stats.hh"
+
+#include <type_traits>
+
+#ifdef __linux__
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <unistd.h>
+#else
+#include <clean-core/native/win32_sanitized.hh>
+#endif
+
+#include <clean-core/assert.hh>
+
+#include <phantasm-hardware-interface/detail/log.hh>
+
+namespace
+{
+#ifdef CC_OS_WINDOWS
+
+using platform_dll_t = ::HMODULE;
+
+void* load_address(platform_dll_t dll, char const* funcname) { return reinterpret_cast<void*>(GetProcAddress(dll, funcname)); }
+void close_dll(platform_dll_t dll) { FreeLibrary(dll); }
+
+#elif defined(CC_OS_LINUX)
+
+using platform_dll_t = void*;
+
+void* load_address(platform_dll_t dll, char const* funcname) { return ::dlsym(dll, funcname); }
+void close_dll(platform_dll_t dll) { ::dlclose(dll); }
+
+#else
+#error "Unsupported platform"
+#endif
+
+template <class T>
+bool load_address_t(platform_dll_t dll, char const* name, T& out_func_ptr)
+{
+    static_assert(std::is_pointer_v<T>, "provide a reference to the function pointer");
+    void* const loaded_raw = load_address(dll, name);
+    if (!loaded_raw)
+    {
+        LOG_WARN("failed to load dll function {}", name);
+        return false;
+    }
+    else
+    {
+        out_func_ptr = reinterpret_cast<T>(loaded_raw);
+        return true;
+    }
+}
+
+
+typedef struct nvmlDevice_st* nvmlDevice_t;
+typedef struct nvmlPciInfo_st* nvmlPciInfo_t;
+typedef int nvmlTemperatureSensors_t;
+typedef int nvmlReturn_t;
+
+struct nvml_dll_state
+{
+    platform_dll_t _dll = nullptr;
+    char* (*_nvmlErrorString)();
+    nvmlReturn_t (*_nvmlInit)();
+    nvmlReturn_t (*_nvmlDeviceGetCount)(unsigned*);
+    nvmlReturn_t (*_nvmlDeviceGetHandleByIndex)(unsigned, nvmlDevice_t*);
+    nvmlReturn_t (*_nvmlDeviceGetName)(nvmlDevice_t, char*, unsigned);
+    nvmlReturn_t (*_nvmlDeviceGetPciInfo)(nvmlDevice_t, nvmlPciInfo_t*);
+    nvmlReturn_t (*_nvmlDeviceGetTemperature)(nvmlDevice_t, nvmlTemperatureSensors_t, unsigned*);
+    nvmlReturn_t (*_nvmlDeviceGetFanSpeed)(nvmlDevice_t, unsigned*);
+    nvmlReturn_t (*_nvmlShutdown)();
+
+    bool load()
+    {
+        // early out on double init
+        if (_dll)
+            return true;
+
+#ifdef CC_OS_WINDOWS
+        // Try locally or in PATH (would be an override)
+        _dll = LoadLibrary("nvml.dll");
+        if (!_dll)
+        {
+            // Try in the canonical install directory (this is the more likely one)
+            char expanded_path[512];
+            ::ExpandEnvironmentStringsA("%ProgramW6432%\\NVIDIA Corporation\\NVSMI\\nvml.dll", expanded_path, sizeof(expanded_path));
+            _dll = LoadLibrary(expanded_path);
+        }
+#elif defined(CC_OS_LINUX)
+        // Available globally
+        dll = dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_GLOBAL);
+#endif
+
+        if (!_dll)
+        {
+            LOG_WARN("Unable to load NVML .dll/.so");
+            return false;
+        }
+
+
+        auto const success = load_address_t(_dll, "nvmlInit_v2", _nvmlInit);
+        if (!success)
+        {
+            // V1 API, differences are marginal
+            auto const success = load_address_t(_dll, "nvmlInit", _nvmlInit);
+            if (!success)
+            {
+                LOG_WARN("Unable to load nvmlInit address");
+                return false;
+            }
+            else
+            {
+                load_address_t(_dll, "nvmlDeviceGetCount", _nvmlDeviceGetCount);
+                load_address_t(_dll, "nvmlDeviceGetHandleByIndex", _nvmlDeviceGetHandleByIndex);
+                load_address_t(_dll, "nvmlDeviceGetPciInfo", _nvmlDeviceGetPciInfo);
+            }
+        }
+        else
+        {
+            // V2 API, recommended
+            load_address_t(_dll, "nvmlDeviceGetCount_v2", _nvmlDeviceGetCount);
+            load_address_t(_dll, "nvmlDeviceGetHandleByIndex_v2", _nvmlDeviceGetHandleByIndex);
+            load_address_t(_dll, "nvmlDeviceGetPciInfo_v2", _nvmlDeviceGetPciInfo);
+        }
+
+        load_address_t(_dll, "nvmlShutdown", _nvmlShutdown);
+        load_address_t(_dll, "nvmlErrorString", _nvmlErrorString);
+        load_address_t(_dll, "nvmlDeviceGetName", _nvmlDeviceGetName);
+        load_address_t(_dll, "nvmlDeviceGetTemperature", _nvmlDeviceGetTemperature);
+        load_address_t(_dll, "nvmlDeviceGetFanSpeed", _nvmlDeviceGetFanSpeed);
+        load_address_t(_dll, "nvmlDeviceGetCount_v2", _nvmlDeviceGetCount);
+
+        auto const ret = _nvmlInit();
+        if (ret != 0)
+        {
+            LOG_WARN("nvmlInit call unsuccessful (returned {})", ret);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool unload()
+    {
+        if (!_dll)
+            return true;
+
+        auto const ret = _nvmlShutdown();
+        if (ret != 0)
+        {
+            LOG_WARN("nvmlShutdown unsuccessful");
+        }
+
+        close_dll(_dll);
+        _dll = nullptr;
+        return true;
+    }
+};
+
+nvml_dll_state g_nvml;
+}
+
+bool phi::gpustats::initialize() { return g_nvml.load(); }
+
+phi::gpustats::gpu_handle_t phi::gpustats::get_gpu_by_index(unsigned index)
+{
+    CC_ASSERT(g_nvml._dll != nullptr && "gpustats not initialized");
+    nvmlDevice_t ret;
+    if (g_nvml._nvmlDeviceGetHandleByIndex(index, &ret) == 0)
+    {
+        return static_cast<void*>(ret);
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
+int phi::gpustats::get_temperature(phi::gpustats::gpu_handle_t handle)
+{
+    CC_ASSERT(g_nvml._dll != nullptr && "gpustats not initialized");
+
+    if (!handle)
+        return -1;
+
+    unsigned ret;
+    // magical 0 as second arg: only valid enum value at time of writing, represents main GPU die sensor
+    g_nvml._nvmlDeviceGetTemperature(static_cast<nvmlDevice_t>(handle), 0, &ret);
+    return int(ret);
+}
+
+int phi::gpustats::get_fanspeed_percent(phi::gpustats::gpu_handle_t handle)
+{
+    CC_ASSERT(g_nvml._dll != nullptr && "gpustats not initialized");
+
+    if (!handle)
+        return -1;
+
+    unsigned ret;
+    g_nvml._nvmlDeviceGetFanSpeed(static_cast<nvmlDevice_t>(handle), &ret);
+    return int(ret);
+}
+
+void phi::gpustats::shutdown() { g_nvml.unload(); }

--- a/src/phantasm-hardware-interface/detail/gpu_stats.hh
+++ b/src/phantasm-hardware-interface/detail/gpu_stats.hh
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace phi::gpustats
+{
+using gpu_handle_t = void*;
+
+// initialize and shut down GPU stat subsystem (loading NVML or AMD GPUinfo)
+// everything but these two calls are threadsafe
+bool initialize();
+void shutdown();
+
+/// retrieve a GPU handle by the device index, nullptr if invalid
+gpu_handle_t get_gpu_by_index(unsigned index);
+
+/// returns the GPU die temperature in degrees celsius, -1 for invalid handles
+int get_temperature(gpu_handle_t handle);
+/// returns the GPU fanspeed in percent, -1 for invalid handles
+int get_fanspeed_percent(gpu_handle_t handle);
+
+}

--- a/src/phantasm-hardware-interface/gpu_info.hh
+++ b/src/phantasm-hardware-interface/gpu_info.hh
@@ -34,14 +34,17 @@ enum class gpu_capabilities : uint8_t
 // explicit GPU features
 enum class gpu_feature : uint8_t
 {
-    raytracing,
-    shading_rate_t1,
-    shading_rate_t2,
-    hlsl_sm6,
-    hlsl_wave_ops
+    raytracing,               ///< raytracing (tier 1 or higher)
+    conservative_raster,      ///< conservative rasterization (tier 1 or higher)
+    mesh_shaders,             ///< task/mesh shading pipeline (tier 1 or higher)
+    rasterizer_ordered_views, ///< rasterizer ordered views (ROVs)
+    shading_rate_t1,          ///< variable rate shading tier 1 or higher
+    shading_rate_t2,          ///< variable rate shading tier 2 or higher
+    hlsl_sm6,                 ///< shader model 6.0 or higher
+    hlsl_wave_ops             ///< HLSL SM6 wave ops
 };
 
-using gpu_feature_flags = cc::flags<gpu_feature, 16>;
+using gpu_feature_flags = cc::flags<gpu_feature, 32>;
 
 struct gpu_info
 {

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -70,11 +70,13 @@ struct command_list_translator
 
     void execute(cmd::resolve_texture const& resolve);
 
-    void execute(cmd::debug_marker const& marker);
-
     void execute(cmd::write_timestamp const& timestamp);
 
     void execute(cmd::resolve_queries const& resolve);
+
+    void execute(cmd::begin_debug_label const& label);
+
+    void execute(cmd::end_debug_label const&);
 
     void execute(cmd::update_bottom_level const& blas_update);
 

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -184,11 +184,6 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
                              "  VULKAN_SDK - <sdk>/x86_64/bin\n"
                              "  LD_LIBRARY_PATH - <VALUE>:<sdk>/x86_64/lib (append)";
         }
-
-        if (!add_ext(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
-        {
-            PHI_LOG_ERROR << "missing debug utils extension";
-        }
     }
 
     if (config.validation >= validation_level::on_extended)
@@ -205,6 +200,15 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
         {
             PHI_LOG_ERROR << "missing API dump layer";
         }
+    }
+
+    // VK_EXT_debug_utils
+    // for cmd::debug_marker, object debug names
+    // spec: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_EXT_debug_utils.html
+    // this is the revised version of VK_EXT_DEBUG_MARKER_EXTENSION_NAME (which is more or less deprecated)
+    if (!add_ext(VK_EXT_DEBUG_UTILS_EXTENSION_NAME))
+    {
+        PHI_LOG_ERROR << "missing debug utils extension";
     }
 
     // platform extensions


### PR DESCRIPTION
- Add `cmd::begin_debug_label`, `cmd::end_debug_label`
    - replaces `cmd::debug_marker` (breaking)
    - these display as proper regions in diagnostic tools
- Add unused gpu stats header
    - wraps NVML (and eventually AMD, Intel equivalents)
    - query GPU temperature, fanspeed

- Fix debug markers not being available with disabled validation in vulkan
- Add unused mesh shading support check for d3d12
- Simplify command list pool in d3d12