### PR TITLE
Indirect Drawing, 16B root constants, fixes

### DIFF
--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -46,6 +46,8 @@ struct command_list_translator
 
     void execute(cmd::draw const& draw);
 
+    void execute(cmd::draw_indirect const& draw_indirect);
+
     void execute(cmd::dispatch const& dispatch);
 
     void execute(cmd::end_render_pass const& end_rp);
@@ -77,6 +79,9 @@ struct command_list_translator
     void execute(cmd::dispatch_rays const& dispatch_rays);
 
     void execute(cmd::clear_textures const& clear_tex);
+
+private:
+
 
 private:
     // non-owning constant (global)

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -81,9 +81,6 @@ struct command_list_translator
     void execute(cmd::clear_textures const& clear_tex);
 
 private:
-
-
-private:
     // non-owning constant (global)
     translator_global_memory _globals;
 

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -302,12 +302,18 @@ void phi::d3d12::PipelineStateObjectPool::initialize(ID3D12Device5* device_rt, u
     CC_ASSERT(max_num_psos < gc_raytracing_handle_offset && "unsupported amount of PSOs");
     CC_ASSERT(max_num_psos_raytracing < gc_raytracing_handle_offset && "unsupported amount of raytracing PSOs");
 
+    // Component init
     mDevice = device_rt;
     mPool.initialize(max_num_psos);
     mPoolRaytracing.initialize(max_num_psos_raytracing);
     mRootSigCache.initialize((max_num_psos / 2) + max_num_psos_raytracing); // almost arbitrary, revisit if this blows up
 
+    // Create empty raytracing rootsig
     mEmptyRaytraceRootSignature = mRootSigCache.getOrCreate(*mDevice, {}, false, root_signature_type::raytrace_global)->raw_root_sig;
+
+    // Create global (indirect drawing) command signatures for draw and indexed draw
+    static_assert(sizeof(D3D12_DRAW_ARGUMENTS) == sizeof(gpu_indirect_command_draw), "gpu argument type compiles to incorrect size");
+    static_assert(sizeof(D3D12_DRAW_INDEXED_ARGUMENTS) == sizeof(gpu_indirect_command_draw_indexed), "gpu argument type compiles to incorrect size");
 
     D3D12_INDIRECT_ARGUMENT_DESC indirect_arg;
     indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
@@ -317,16 +323,10 @@ void phi::d3d12::PipelineStateObjectPool::initialize(ID3D12Device5* device_rt, u
     desc.pArgumentDescs = &indirect_arg;
     desc.ByteStride = sizeof(gpu_indirect_command_draw);
     desc.NodeMask = 0;
-
-    static_assert(sizeof(D3D12_DRAW_ARGUMENTS) == sizeof(gpu_indirect_command_draw), "gpu argument type compiles to incorrect size");
-
     mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDraw));
 
     indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     desc.ByteStride = sizeof(gpu_indirect_command_draw_indexed);
-
-    static_assert(sizeof(D3D12_DRAW_INDEXED_ARGUMENTS) == sizeof(gpu_indirect_command_draw_indexed), "gpu argument type compiles to incorrect size");
-
     mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDrawIndexed));
 }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -309,15 +309,12 @@ void phi::d3d12::PipelineStateObjectPool::initialize(ID3D12Device5* device_rt, u
 
     mEmptyRaytraceRootSignature = mRootSigCache.getOrCreate(*mDevice, {}, false, root_signature_type::raytrace_global)->raw_root_sig;
 
-    cc::array<D3D12_INDIRECT_ARGUMENT_DESC> indirect_args(256);
-
-    for (auto& arg : indirect_args)
-        arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
-
+    D3D12_INDIRECT_ARGUMENT_DESC indirect_arg;
+    indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
 
     D3D12_COMMAND_SIGNATURE_DESC desc = {};
-    desc.NumArgumentDescs = UINT(indirect_args.size());
-    desc.pArgumentDescs = indirect_args.data();
+    desc.NumArgumentDescs = 1;
+    desc.pArgumentDescs = &indirect_arg;
     desc.ByteStride = sizeof(gpu_indirect_command_draw);
     desc.NodeMask = 0;
 
@@ -325,9 +322,7 @@ void phi::d3d12::PipelineStateObjectPool::initialize(ID3D12Device5* device_rt, u
 
     mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDraw));
 
-    for (auto& arg : indirect_args)
-        arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
-
+    indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     desc.ByteStride = sizeof(gpu_indirect_command_draw_indexed);
 
     static_assert(sizeof(D3D12_DRAW_INDEXED_ARGUMENTS) == sizeof(gpu_indirect_command_draw_indexed), "gpu argument type compiles to incorrect size");

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -66,11 +66,16 @@ public:
 
     bool isRaytracingPipeline(handle::pipeline_state ps) const;
 
+    ID3D12CommandSignature* getGlobalComSigDraw() const { return mGlobalComSigDraw; }
+    ID3D12CommandSignature* getGlobalComSigDrawIndexed() const { return mGlobalComSigDrawIndexed; }
+
 private:
     ID3D12Device5* mDevice = nullptr;
 
     RootSignatureCache mRootSigCache;
     ID3D12RootSignature* mEmptyRaytraceRootSignature = nullptr;
+    ID3D12CommandSignature* mGlobalComSigDraw = nullptr;
+    ID3D12CommandSignature* mGlobalComSigDrawIndexed = nullptr;
 
     phi::detail::linked_pool<pso_node, unsigned> mPool;
     phi::detail::linked_pool<rt_pso_node, unsigned> mPoolRaytracing;

--- a/src/phantasm-hardware-interface/detail/unique_buffer.cc
+++ b/src/phantasm-hardware-interface/detail/unique_buffer.cc
@@ -13,3 +13,14 @@ phi::detail::unique_buffer phi::detail::unique_buffer::create_from_binary_file(c
     file.read(res.get_as_char(), long(size));
     return res;
 }
+
+bool phi::detail::unique_buffer::write_to_binary_file(const char* filename)
+{
+    std::ofstream file(filename, std::ios::binary);
+    if (!file.good())
+        return false;
+
+    file.write(get_as_char(), size());
+    file.close();
+    return !file.fail();
+}

--- a/src/phantasm-hardware-interface/detail/unique_buffer.hh
+++ b/src/phantasm-hardware-interface/detail/unique_buffer.hh
@@ -58,6 +58,8 @@ struct unique_buffer
 
     [[nodiscard]] static unique_buffer create_from_binary_file(char const* filename);
 
+    bool write_to_binary_file(char const* filename);
+
 private:
     std::byte* _ptr = nullptr;
     size_t _size = 0;

--- a/src/phantasm-hardware-interface/handles.hh
+++ b/src/phantasm-hardware-interface/handles.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cstdint>
+
+namespace phi::handle
+{
+using index_t = int32_t;
+inline constexpr index_t null_handle_index = index_t(-1);
+
+#define PHI_DEFINE_HANDLE(_type_)                                                                         \
+    struct _type_                                                                                         \
+    {                                                                                                     \
+        index_t index;                                                                                    \
+        [[nodiscard]] constexpr bool is_valid() const noexcept { return index != null_handle_index; }     \
+        [[nodiscard]] constexpr bool operator==(_type_ rhs) const noexcept { return index == rhs.index; } \
+        [[nodiscard]] constexpr bool operator!=(_type_ rhs) const noexcept { return index != rhs.index; } \
+    };                                                                                                    \
+    inline constexpr _type_ null_##_type_ = {null_handle_index}
+
+
+/// generic resource (buffer, texture, render target)
+PHI_DEFINE_HANDLE(resource);
+
+/// pipeline state (vertex layout, primitive config, shaders, framebuffer formats, ...)
+PHI_DEFINE_HANDLE(pipeline_state);
+
+/// shader_view := (SRVs + UAVs + Samplers)
+/// shader argument := handle::shader_view + handle::resource (CBV) + uint (CBV offset)
+PHI_DEFINE_HANDLE(shader_view);
+
+/// recorded command list, ready to submit or discard
+PHI_DEFINE_HANDLE(command_list);
+
+/// synchronization primitive storing a uint64, can be signalled and waited on from both CPU and GPU
+PHI_DEFINE_HANDLE(fence);
+
+/// multiple contiguous queries for timestamps, occlusion or pipeline statistics
+PHI_DEFINE_HANDLE(query_range);
+
+/// raytracing acceleration structure handle
+PHI_DEFINE_HANDLE(accel_struct);
+
+#undef PHI_DEFINE_HANDLE
+}

--- a/src/phantasm-hardware-interface/limits.hh
+++ b/src/phantasm-hardware-interface/limits.hh
@@ -21,7 +21,7 @@ inline constexpr unsigned max_shader_samplers = 16u;
 
 /// the maximum size for root constants
 /// configurable in increments of sizeof(DWORD32)
-inline constexpr unsigned max_root_constant_bytes = 8u;
+inline constexpr unsigned max_root_constant_bytes = 16u;
 
 /// the maximum amount of argument associations
 /// configurable

--- a/src/phantasm-hardware-interface/limits.hh
+++ b/src/phantasm-hardware-interface/limits.hh
@@ -20,7 +20,7 @@ inline constexpr unsigned max_shader_arguments = 4u;
 inline constexpr unsigned max_shader_samplers = 16u;
 
 /// the maximum size for root constants
-/// configurable in increments of sizeof(DWORD32)
+/// configurable in increments of 4, also concerns CPU memory (cmd::draw, cmd::dispatch)
 inline constexpr unsigned max_root_constant_bytes = 16u;
 
 /// the maximum amount of argument associations

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -303,12 +303,12 @@ public:
         texture_info.array_size = 1;
     }
 
-    void init_as_structured_buffer(handle::resource res, unsigned num_elements, unsigned stride_bytes)
+    void init_as_structured_buffer(handle::resource res, unsigned num_elements, unsigned stride_bytes, unsigned element_start = 0)
     {
         resource = res;
         dimension = resource_view_dimension::buffer;
         buffer_info.num_elements = num_elements;
-        buffer_info.element_start = 0;
+        buffer_info.element_start = element_start;
         buffer_info.element_stride_bytes = stride_bytes;
     }
 

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -601,6 +601,25 @@ enum class query_type : uint8_t
     pipeline_stats
 };
 
+/// indirect draw command, as it is laid out in a GPU buffer
+struct gpu_indirect_command_draw
+{
+    uint32_t num_vertices;
+    uint32_t num_instances;
+    uint32_t vertex_offset;
+    uint32_t instance_offset;
+};
+
+/// indirect indexed draw command, as it is laid out in a GPU buffer
+struct gpu_indirect_command_draw_indexed
+{
+    uint32_t num_indices;
+    uint32_t num_instances;
+    uint32_t index_offset;
+    int32_t vertex_offset;
+    uint32_t instance_offset;
+};
+
 /// flags to configure the building process of a raytracing acceleration structure
 enum class accel_struct_build_flags : uint8_t
 {

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -1,52 +1,11 @@
 #pragma once
 
-#include <cstdint>
-
 #include <clean-core/flags.hh>
+
+#include <phantasm-hardware-interface/handles.hh>
 
 namespace phi
 {
-namespace handle
-{
-using index_t = int32_t;
-inline constexpr index_t null_handle_index = index_t(-1);
-
-#define PHI_DEFINE_HANDLE(_type_)                                                                         \
-    struct _type_                                                                                         \
-    {                                                                                                     \
-        index_t index;                                                                                    \
-        [[nodiscard]] constexpr bool is_valid() const noexcept { return index != null_handle_index; }     \
-        [[nodiscard]] constexpr bool operator==(_type_ rhs) const noexcept { return index == rhs.index; } \
-        [[nodiscard]] constexpr bool operator!=(_type_ rhs) const noexcept { return index != rhs.index; } \
-    };                                                                                                    \
-    inline constexpr _type_ null_##_type_ = {null_handle_index}
-
-
-/// generic resource (buffer, texture, render target)
-PHI_DEFINE_HANDLE(resource);
-
-/// pipeline state (vertex layout, primitive config, shaders, framebuffer formats, ...)
-PHI_DEFINE_HANDLE(pipeline_state);
-
-/// shader_view := (SRVs + UAVs + Samplers)
-/// shader argument := handle::shader_view + handle::resource (CBV) + uint (CBV offset)
-PHI_DEFINE_HANDLE(shader_view);
-
-/// recorded command list, ready to submit or discard
-PHI_DEFINE_HANDLE(command_list);
-
-/// synchronization primitive storing a uint64, can be signalled and waited on from both CPU and GPU
-PHI_DEFINE_HANDLE(fence);
-
-/// multiple contiguous queries for timestamps, occlusion or pipeline statistics
-PHI_DEFINE_HANDLE(query_range);
-
-/// raytracing acceleration structure handle
-PHI_DEFINE_HANDLE(accel_struct);
-
-#undef PHI_DEFINE_HANDLE
-}
-
 /// resources bound to a shader, up to 4 per draw or dispatch command
 struct shader_argument
 {

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -643,7 +643,9 @@ void phi::vk::command_list_translator::bind_shader_arguments(phi::handle::pipeli
         {
             if (bound_arg.update_cbv(arg.constant_buffer, arg.constant_buffer_offset))
             {
-                auto const cbv_desc_set = _globals.pool_resources->getRawCBVDescriptorSet(arg.constant_buffer);
+                auto const cbv_desc_set = bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS
+                                              ? _globals.pool_resources->getRawCBVDescriptorSet(arg.constant_buffer)
+                                              : _globals.pool_resources->getRawCBVDescriptorSetCompute(arg.constant_buffer);
                 vkCmdBindDescriptorSets(_cmd_list, bind_point, pipeline_layout.raw_layout, i + limits::max_shader_arguments, 1, &cbv_desc_set, 1,
                                         &arg.constant_buffer_offset);
             }

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -249,6 +249,61 @@ void phi::vk::command_list_translator::execute(const phi::cmd::draw& draw)
     }
 }
 
+void phi::vk::command_list_translator::execute(const phi::cmd::draw_indirect& draw_indirect)
+{
+    if (_bound.update_pso(draw_indirect.pipeline_state))
+    {
+        // a new handle::pipeline_state invalidates (!= always changes)
+        //      - The bound pipeline layout
+        //      - The bound pipeline
+        auto const& pso_node = _globals.pool_pipeline_states->get(draw_indirect.pipeline_state);
+        _bound.update_pipeline_layout(pso_node.associated_pipeline_layout->raw_layout);
+        vkCmdBindPipeline(_cmd_list, VK_PIPELINE_BIND_POINT_GRAPHICS, pso_node.raw_pipeline);
+    }
+
+    // Index buffer (optional)
+    if (draw_indirect.index_buffer != _bound.index_buffer)
+    {
+        _bound.index_buffer = draw_indirect.index_buffer;
+        if (draw_indirect.index_buffer.is_valid())
+        {
+            auto const& ind_buf_info = _globals.pool_resources->getBufferInfo(draw_indirect.index_buffer);
+            vkCmdBindIndexBuffer(_cmd_list, ind_buf_info.raw_buffer, 0, (ind_buf_info.stride == 4) ? VK_INDEX_TYPE_UINT32 : VK_INDEX_TYPE_UINT16);
+        }
+    }
+
+    // Vertex buffer
+    if (draw_indirect.vertex_buffer != _bound.vertex_buffer)
+    {
+        _bound.vertex_buffer = draw_indirect.vertex_buffer;
+        if (draw_indirect.vertex_buffer.is_valid())
+        {
+            VkBuffer vertex_buffers[] = {_globals.pool_resources->getRawBuffer(draw_indirect.vertex_buffer)};
+            VkDeviceSize offsets[] = {0};
+            vkCmdBindVertexBuffers(_cmd_list, 0, 1, vertex_buffers, offsets);
+        }
+    }
+
+    // Shader arguments
+    bind_shader_arguments(draw_indirect.pipeline_state, draw_indirect.root_constants, draw_indirect.shader_arguments, VK_PIPELINE_BIND_POINT_GRAPHICS);
+
+    // Indirect draw command
+    auto const raw_argument_buffer = _globals.pool_resources->getRawBuffer(draw_indirect.indirect_argument_buffer);
+    if (draw_indirect.index_buffer.is_valid())
+    {
+        static_assert(sizeof(VkDrawIndexedIndirectCommand) == sizeof(gpu_indirect_command_draw_indexed), "gpu argument type compiles to incorrect "
+                                                                                                         "size");
+        vkCmdDrawIndexedIndirect(_cmd_list, raw_argument_buffer, VkDeviceSize(draw_indirect.argument_buffer_offset), draw_indirect.num_arguments,
+                                 sizeof(VkDrawIndexedIndirectCommand));
+    }
+    else
+    {
+        static_assert(sizeof(VkDrawIndirectCommand) == sizeof(gpu_indirect_command_draw), "gpu argument type compiles to incorrect size");
+        vkCmdDrawIndirect(_cmd_list, raw_argument_buffer, VkDeviceSize(draw_indirect.argument_buffer_offset), draw_indirect.num_arguments,
+                          sizeof(VkDrawIndirectCommand));
+    }
+}
+
 void phi::vk::command_list_translator::execute(const phi::cmd::dispatch& dispatch)
 {
     auto const& pso_node = _globals.pool_pipeline_states->get(dispatch.pipeline_state);

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -54,6 +54,8 @@ struct command_list_translator
 
     void execute(cmd::draw const& draw);
 
+    void execute(cmd::draw_indirect const& draw_indirect);
+
     void execute(cmd::dispatch const& dispatch);
 
     void execute(cmd::end_render_pass const& end_rp);

--- a/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
@@ -43,7 +43,7 @@ VkBool32 phi::vk::detail::debug_callback(VkDebugUtilsMessageSeverityFlagBitsEXT 
 {
     // if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
     {
-        RICH_LOG_IMPL(phi::detail::vulkan_log)("[API][{}][{}] {}", to_literal(type), to_literal(severity), callback_data->pMessage);
+        RICH_LOG_IMPL(phi::detail::vulkan_log)("{}", callback_data->pMessage);
     }
     return VK_FALSE;
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -162,8 +162,9 @@ phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, u
 
     // right now we'll just take all usages this thing might have in API semantics
     // it might be required down the line to restrict this (as in, make it part of API)
-    buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
-                        | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
+                        | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT
+                        | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
     // NOTE: we currently do not make use of allow_uav or the heap type to restrict usage flags at all
     // allow_uav might have been a poor API decision, we might need something more finegrained instead, and have the default be allowing everything

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -146,11 +146,14 @@ phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, u
 
     // right now we'll just take all usages this thing might have in API semantics
     // it might be required down the line to restrict this (as in, make it part of API)
-    buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT
-                        | VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT
+                        | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
 
-    if (allow_uav || heap == resource_heap::upload) // NOTE: not quite sure why upload buffers require these two flags as well
-        buffer_info.usage |= VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+    // NOTE: we currently do not make use of allow_uav or the heap type to restrict usage flags at all
+    // allow_uav might have been a poor API decision, we might need something more finegrained instead, and have the default be allowing everything
+    // problem is, in d3d12 ALLOW_UNORDERED_ACCESS is exclusive with ALLOW_DEPTH_STENCIL, so defaulting right away is not possible
+    (void)allow_uav;
+    // if (allow_uav || heap == resource_heap::upload) { ... }
 
     VmaAllocationCreateInfo alloc_info = {};
     alloc_info.usage = vk_heap_to_vma(heap);


### PR DESCRIPTION
## General
- Added indirect drawing (`cmd::draw_indirect`, `gpu_indirect_command_*`)
- Root constant size doubled from 8 to 16B

## Vulkan
- Fixed Vulkan compute CBVs
- Improved Vulkan debug object names (same level as d3d12 now)
- Fixed various Vulkan buffer usage scenarios

## Minor
- Handles in separate header (not breaking)
- Minor changes in convenience initializer, auxilliary classes