### PR TITLE
Minor Vulkan Fixes

### DIFF
--- a/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
@@ -41,7 +41,7 @@ VkBool32 phi::vk::detail::debug_callback(VkDebugUtilsMessageSeverityFlagBitsEXT 
                                          const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
                                          void* /*user_data*/)
 {
-    // if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
+    if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
     {
         RICH_LOG_IMPL(phi::detail::vulkan_log)("{}", callback_data->pMessage);
     }

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -254,6 +254,15 @@ phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_s
         PHI_LOG_ERROR << "missing timeline semaphore extension, try updating GPU drivers";
     }
 
+    // VK_KHR_relaxed_block_layout
+    // prevents debug layers from warning about non-std430 layouts,
+    // which occur ie. with the -fvk-use-dx-layout DXC flag
+    // spec: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_relaxed_block_layout.html
+    if (!add_ext(VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME))
+    {
+        PHI_LOG_WARN("missing relaxed block layout extension");
+    }
+
     // additional extensions
     has_conservative_raster = false;
     if (add_ext(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME))

--- a/src/phantasm-hardware-interface/vulkan/loader/volk.hh
+++ b/src/phantasm-hardware-interface/vulkan/loader/volk.hh
@@ -2,3 +2,7 @@
 
 #include "detail/platform_defines.hh"
 #include "detail/volk.h"
+
+#ifndef VK_VERSION_1_2
+#error "Vulkan version lower than 1.2, update your SDK"
+#endif


### PR DESCRIPTION
- Improve compilation error for out of date Vulkan SDK
- Filter verbose vulkan debug layer outputs
- Fix vulkan compatibility with nonstandard SPIR-V layouts