### PR TITLE
Generational Handle Checks

### DIFF
--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -3,6 +3,8 @@
 #include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
 
+#include <typed-geometry/types/size.hh>
+
 #include <phantasm-hardware-interface/detail/trivial_capped_vector.hh>
 
 #include "limits.hh"
@@ -151,9 +153,10 @@ struct create_render_target_info
     rt_clear_value clear_value;
 
 public:
-    static create_render_target_info create(phi::format fmt, int w, int h, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
+    static create_render_target_info create(
+        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
     {
-        return create_render_target_info{fmt, w, h, num_samples, array_size, clear_val};
+        return create_render_target_info{fmt, size.width, size.height, num_samples, array_size, clear_val};
     }
     constexpr bool operator==(create_render_target_info const& rhs) const noexcept
     {
@@ -172,10 +175,14 @@ struct create_texture_info
     unsigned num_mips;
 
 public:
-    static create_texture_info create(
-        phi::format fmt, int w, int h, unsigned num_mips = 1, phi::texture_dimension dim = phi::texture_dimension::t2d, unsigned depth_or_array_size = 1, bool allow_uav = false)
+    static create_texture_info create(phi::format fmt,
+                                      tg::isize2 size,
+                                      unsigned num_mips = 1,
+                                      phi::texture_dimension dim = phi::texture_dimension::t2d,
+                                      unsigned depth_or_array_size = 1,
+                                      bool allow_uav = false)
     {
-        return create_texture_info{fmt, dim, allow_uav, w, h, depth_or_array_size, num_mips};
+        return create_texture_info{fmt, dim, allow_uav, size.width, size.height, depth_or_array_size, num_mips};
     }
 
     constexpr bool operator==(create_texture_info const& rhs) const noexcept
@@ -246,15 +253,20 @@ public:
         return res;
     }
 
-    static create_resource_info render_target(phi::format fmt, int w, int h, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0, 0, 0, 255})
+    static create_resource_info render_target(
+        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0, 0, 0, 255})
     {
-        return create(create_render_target_info::create(fmt, w, h, num_samples, array_size, clear_val));
+        return create(create_render_target_info::create(fmt, size, num_samples, array_size, clear_val));
     }
 
-    static create_resource_info texture(
-        phi::format fmt, int w, int h, unsigned num_mips = 1, phi::texture_dimension dim = phi::texture_dimension::t2d, unsigned depth_or_array_size = 1, bool allow_uav = false)
+    static create_resource_info texture(phi::format fmt,
+                                        tg::isize2 size,
+                                        unsigned num_mips = 1,
+                                        phi::texture_dimension dim = phi::texture_dimension::t2d,
+                                        unsigned depth_or_array_size = 1,
+                                        bool allow_uav = false)
     {
-        return create(create_texture_info::create(fmt, w, h, num_mips, dim, depth_or_array_size, allow_uav));
+        return create(create_texture_info::create(fmt, size, num_mips, dim, depth_or_array_size, allow_uav));
     }
 
     static create_resource_info buffer(unsigned size_bytes, unsigned stride_bytes, phi::resource_heap heap = phi::resource_heap::gpu, bool allow_uav = false)

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -103,8 +103,8 @@ struct backend_config
     unsigned num_copy_cmdlists_per_allocator = 3;
 
     /// query heap sizes
-    unsigned num_timestamp_queries = 128;
-    unsigned num_occlusion_queries = 128;
-    unsigned num_pipeline_stat_queries = 32;
+    unsigned num_timestamp_queries = 512;
+    unsigned num_occlusion_queries = 512;
+    unsigned num_pipeline_stat_queries = 128;
 };
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
@@ -119,12 +119,12 @@ void phi::d3d12::AccelStructPool::free(phi::handle::accel_struct as)
     if (!as.is_valid())
         return;
 
-    accel_struct_node& freed_node = mPool.get(static_cast<unsigned>(as.index));
+    accel_struct_node& freed_node = mPool.get(as._value);
     internalFree(freed_node);
 
     {
         auto lg = std::lock_guard(mMutex);
-        mPool.release(static_cast<unsigned>(as.index));
+        mPool.release(as._value);
     }
 }
 
@@ -136,9 +136,9 @@ void phi::d3d12::AccelStructPool::free(cc::span<const phi::handle::accel_struct>
     {
         if (as.is_valid())
         {
-            accel_struct_node& freed_node = mPool.get(static_cast<unsigned>(as.index));
+            accel_struct_node& freed_node = mPool.get(as._value);
             internalFree(freed_node);
-            mPool.release(static_cast<unsigned>(as.index));
+            mPool.release(as._value);
         }
     }
 }
@@ -156,7 +156,7 @@ void phi::d3d12::AccelStructPool::destroy()
     if (mDevice != nullptr)
     {
         auto num_leaks = 0;
-        mPool.iterate_allocated_nodes([&](accel_struct_node& leaked_node, unsigned) {
+        mPool.iterate_allocated_nodes([&](accel_struct_node& leaked_node) {
             ++num_leaks;
             internalFree(leaked_node);
         });
@@ -171,7 +171,7 @@ void phi::d3d12::AccelStructPool::destroy()
 phi::d3d12::AccelStructPool::accel_struct_node& phi::d3d12::AccelStructPool::getNode(phi::handle::accel_struct as)
 {
     CC_ASSERT(as.is_valid());
-    return mPool.get(static_cast<unsigned>(as.index));
+    return mPool.get(as._value);
 }
 
 phi::d3d12::AccelStructPool::accel_struct_node& phi::d3d12::AccelStructPool::acquireAccelStruct(handle::accel_struct& out_handle)

--- a/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.hh
@@ -68,7 +68,7 @@ private:
     ID3D12Device5* mDevice = nullptr;
     ResourcePool* mResourcePool = nullptr;
 
-    phi::detail::linked_pool<accel_struct_node, unsigned> mPool;
+    phi::detail::linked_pool<accel_struct_node> mPool;
 
     std::mutex mMutex;
 };

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
@@ -191,8 +191,9 @@ phi::handle::command_list phi::d3d12::CommandListPool::acquireNodeInternal(phi::
     }
 
     out_node = &pool.get(res_index);
-    out_cmdlist = getList(res_index, type);
-    return IndexToHandle(res_index, type);
+    auto const res_handle = IndexToHandle(res_index, type);
+    out_cmdlist = getList(res_handle, type);
+    return res_handle;
 }
 
 void phi::d3d12::CommandAllocatorBundle::initialize(

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <mutex>
 
+#include <clean-core/array.hh>
 #include <clean-core/capped_array.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
@@ -154,7 +155,7 @@ private:
         d3d12_incomplete_state_cache state_cache;
     };
 
-    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node, unsigned>;
+    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node>;
 
     static constexpr int mcIndexOffsetStep = 1'000'000;
 

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -5,6 +5,7 @@
 #include <mutex>
 
 #include <clean-core/array.hh>
+#include <clean-core/bits.hh>
 #include <clean-core/capped_array.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
@@ -157,35 +158,20 @@ private:
 
     using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node>;
 
-    static constexpr int mcIndexOffsetStep = 1'000'000;
-
-    static constexpr int mcIndexOffsetDirect = mcIndexOffsetStep * 0;
-    static constexpr int mcIndexOffsetCompute = mcIndexOffsetStep * 1;
-    static constexpr int mcIndexOffsetCopy = mcIndexOffsetStep * 2;
-
-    static constexpr queue_type HandleToQueueType(handle::command_list cl)
+    static queue_type HandleToQueueType(handle::command_list cl)
     {
-        if (cl.index >= mcIndexOffsetCopy)
-            return queue_type::copy;
-        else if (cl.index >= mcIndexOffsetCompute)
-            return queue_type::compute;
-        else
-            return queue_type::direct;
+        int const num_leading_zeroes = cc::count_leading_zeros(cl._value);
+        CC_ASSERT(num_leading_zeroes <= 2 && "invalid commandlist handle"); // one of the three MSBs must be set
+        return queue_type(num_leading_zeroes);
     }
 
-    static constexpr handle::command_list IndexToHandle(unsigned pool_index, queue_type type)
+    static constexpr handle::command_list IndexToHandle(uint32_t pool_handle, queue_type type)
     {
         // we rely on underlying values here
         static_assert(int(queue_type::direct) == 0, "unexpected enum ordering");
         static_assert(int(queue_type::compute) == 1, "unexpected enum ordering");
         static_assert(int(queue_type::copy) == 2, "unexpected enum ordering");
-        return {int(pool_index) + mcIndexOffsetStep * int(type)};
-    }
-
-    static constexpr unsigned HandleToIndex(handle::command_list cl, queue_type type)
-    {
-        //
-        return unsigned(cl.index - mcIndexOffsetStep * int(type));
+        return {pool_handle | uint32_t(1) << (31 - int(type))};
     }
 
     cmdlist_linked_pool_t& getPool(queue_type type)
@@ -218,16 +204,16 @@ private:
         CC_UNREACHABLE("invalid queue_type");
     }
 
-    ID3D12GraphicsCommandList5* getList(unsigned index, queue_type type) const
+    ID3D12GraphicsCommandList5* getList(handle::command_list cl, queue_type type) const
     {
         switch (type)
         {
         case queue_type::direct:
-            return mRawListsDirect[index];
+            return mRawListsDirect[mPoolDirect.get_handle_index(cl._value)];
         case queue_type::compute:
-            return mRawListsCompute[index];
+            return mRawListsCompute[mPoolCompute.get_handle_index(cl._value)];
         case queue_type::copy:
-            return mRawListsCopy[index];
+            return mRawListsCopy[mPoolCopy.get_handle_index(cl._value)];
         }
 
         CC_UNREACHABLE("invalid queue_type");
@@ -288,7 +274,7 @@ public:
     ID3D12GraphicsCommandList5* getRawList(handle::command_list cl)
     {
         auto const type = HandleToQueueType(cl);
-        return getList(HandleToIndex(cl, type), type);
+        return getList(cl, type);
     }
 
     d3d12_incomplete_state_cache* getStateCache(handle::command_list cl) { return &getNodeInternal(cl)->state_cache; }
@@ -311,16 +297,15 @@ private:
     [[nodiscard]] cmd_list_node* getNodeInternal(handle::command_list cl)
     {
         queue_type const type = HandleToQueueType(cl);
-        return &getPool(type).get(HandleToIndex(cl, type));
+        return &getPool(type).get(cl._value);
     }
 
     cmd_list_node* getNodeInternal(handle::command_list cl, cmdlist_linked_pool_t*& out_pool, ID3D12GraphicsCommandList5*& out_cmdlist)
     {
         queue_type const type = HandleToQueueType(cl);
-        auto const index = HandleToIndex(cl, type);
         out_pool = &getPool(type);
-        out_cmdlist = getList(index, type);
-        return &out_pool->get(index);
+        out_cmdlist = getList(cl, type);
+        return &out_pool->get(cl._value);
     }
 
 private:

--- a/src/phantasm-hardware-interface/d3d12/pools/fence_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/fence_pool.cc
@@ -24,11 +24,11 @@ void phi::d3d12::FencePool::free(phi::handle::fence fence)
     if (!fence.is_valid())
         return;
 
-    mPool.get(static_cast<unsigned>(fence.index)).free();
+    mPool.get(fence._value).free();
 
     {
         auto lg = std::lock_guard(mMutex);
-        mPool.release(static_cast<unsigned>(fence.index));
+        mPool.release(fence._value);
     }
 }
 
@@ -40,8 +40,8 @@ void phi::d3d12::FencePool::free(cc::span<const phi::handle::fence> fence_span)
     {
         if (as.is_valid())
         {
-            mPool.get(static_cast<unsigned>(as.index)).free();
-            mPool.release(static_cast<unsigned>(as.index));
+            mPool.get(as._value).free();
+            mPool.release(as._value);
         }
     }
 }
@@ -58,7 +58,7 @@ void phi::d3d12::FencePool::destroy()
     if (mDevice != nullptr)
     {
         auto num_leaks = 0;
-        mPool.iterate_allocated_nodes([&](node& leaked_fence, unsigned) {
+        mPool.iterate_allocated_nodes([&](node& leaked_fence) {
             ++num_leaks;
             leaked_fence.free();
         });

--- a/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
@@ -56,7 +56,7 @@ private:
 private:
     ID3D12Device* mDevice = nullptr;
 
-    phi::detail::linked_pool<node, unsigned> mPool;
+    phi::detail::linked_pool<node> mPool;
     std::mutex mMutex;
 };
 

--- a/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
@@ -44,13 +44,13 @@ private:
     [[nodiscard]] node& internalGet(handle::fence fence)
     {
         CC_ASSERT(fence.is_valid() && "invalid handle::fence");
-        return mPool.get(static_cast<unsigned>(fence.index));
+        return mPool.get(fence._value);
     }
 
     [[nodiscard]] node const& internalGet(handle::fence fence) const
     {
         CC_ASSERT(fence.is_valid() && "invalid handle::fence");
-        return mPool.get(static_cast<unsigned>(fence.index));
+        return mPool.get(fence._value);
     }
 
 private:

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -77,8 +77,8 @@ private:
     ID3D12CommandSignature* mGlobalComSigDraw = nullptr;
     ID3D12CommandSignature* mGlobalComSigDrawIndexed = nullptr;
 
-    phi::detail::linked_pool<pso_node, unsigned> mPool;
-    phi::detail::linked_pool<rt_pso_node, unsigned> mPoolRaytracing;
+    phi::detail::linked_pool<pso_node> mPool;
+    phi::detail::linked_pool<rt_pso_node> mPoolRaytracing;
     std::mutex mMutex;
 };
 

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -60,7 +60,7 @@ public:
     void initialize(ID3D12Device5* device_rt, unsigned max_num_psos, unsigned max_num_psos_raytracing);
     void destroy();
 
-    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(static_cast<unsigned>(ps.index)); }
+    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(ps._value); }
 
     [[nodiscard]] rt_pso_node const& getRaytrace(handle::pipeline_state ps) const;
 

--- a/src/phantasm-hardware-interface/d3d12/pools/query_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/query_pool.hh
@@ -74,9 +74,9 @@ public:
 
     static constexpr query_type HandleToQueryType(handle::query_range qr)
     {
-        if (qr.index >= mcIndexOffsetPipelineStats)
+        if (qr._value >= mcIndexOffsetPipelineStats)
             return query_type::pipeline_stats;
-        else if (qr.index >= mcIndexOffsetOcclusion)
+        else if (qr._value >= mcIndexOffsetOcclusion)
             return query_type::occlusion;
         else
             return query_type::timestamp;
@@ -88,13 +88,13 @@ public:
         static_assert(int(query_type::timestamp) == 0, "unexpected enum ordering");
         static_assert(int(query_type::occlusion) == 1, "unexpected enum ordering");
         static_assert(int(query_type::pipeline_stats) == 2, "unexpected enum ordering");
-        return {index + mcIndexOffsetStep * int(type)};
+        return {unsigned(index + mcIndexOffsetStep * int(type))};
     }
 
     static constexpr int HandleToIndex(handle::query_range qr, query_type type)
     {
         //
-        return qr.index - mcIndexOffsetStep * int(type);
+        return qr._value - mcIndexOffsetStep * int(type);
     }
 
     QueryPageAllocator& getHeap(query_type type)

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -150,12 +150,12 @@ private:
     [[nodiscard]] resource_node const& internalGet(handle::resource res) const
     {
         CC_ASSERT(res.is_valid() && "invalid resource handle");
-        return mPool.get(static_cast<unsigned>(res.index));
+        return mPool.get(res._value);
     }
     [[nodiscard]] resource_node& internalGet(handle::resource res)
     {
         CC_ASSERT(res.is_valid() && "invalid resource handle");
-        return mPool.get(static_cast<unsigned>(res.index));
+        return mPool.get(res._value);
     }
 
 private:

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -160,7 +160,7 @@ private:
 
 private:
     /// The main pool data
-    phi::detail::linked_pool<resource_node, unsigned> mPool;
+    phi::detail::linked_pool<resource_node> mPool;
 
     handle::resource mInjectedBackbufferResource = handle::null_resource;
 

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -105,12 +105,12 @@ phi::handle::shader_view phi::d3d12::ShaderViewPool::create(cc::span<resource_vi
 
 void phi::d3d12::ShaderViewPool::free(phi::handle::shader_view sv)
 {
-    auto& data = mPool.get(unsigned(sv.index));
+    auto& data = mPool.get(unsigned(sv._value));
     {
         auto lg = std::lock_guard(mMutex);
         mSRVUAVAllocator.free(data.srv_uav_alloc_handle);
         mSamplerAllocator.free(data.sampler_alloc_handle);
-        mPool.release(unsigned(sv.index));
+        mPool.release(unsigned(sv._value));
     }
 }
 
@@ -119,10 +119,10 @@ void phi::d3d12::ShaderViewPool::free(cc::span<const phi::handle::shader_view> s
     auto lg = std::lock_guard(mMutex);
     for (auto sv : svs)
     {
-        auto& data = mPool.get(unsigned(sv.index));
+        auto& data = mPool.get(unsigned(sv._value));
         mSRVUAVAllocator.free(data.srv_uav_alloc_handle);
         mSamplerAllocator.free(data.sampler_alloc_handle);
-        mPool.release(unsigned(sv.index));
+        mPool.release(unsigned(sv._value));
     }
 }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
@@ -156,7 +156,7 @@ private:
     ID3D12Device* mDevice;
     ResourcePool* mResourcePool;
 
-    phi::detail::linked_pool<shader_view_data, unsigned> mPool;
+    phi::detail::linked_pool<shader_view_data> mPool;
     DescriptorPageAllocator mSRVUAVAllocator;
     DescriptorPageAllocator mSamplerAllocator;
     std::mutex mMutex;

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
@@ -143,12 +143,12 @@ private:
     [[nodiscard]] shader_view_data const& internalGet(handle::shader_view res) const
     {
         CC_ASSERT(res.is_valid() && "invalid shader_view handle");
-        return mPool.get(static_cast<unsigned>(res.index));
+        return mPool.get(res._value);
     }
     [[nodiscard]] shader_view_data& internalGet(handle::shader_view res)
     {
         CC_ASSERT(res.is_valid() && "invalid shader_view handle");
-        return mPool.get(static_cast<unsigned>(res.index));
+        return mPool.get(res._value);
     }
 
 private:

--- a/src/phantasm-hardware-interface/detail/linked_pool.hh
+++ b/src/phantasm-hardware-interface/detail/linked_pool.hh
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 
-#include <clean-core/array.hh>
 #include <clean-core/new.hh>
 #include <clean-core/vector.hh>
 
@@ -10,11 +10,11 @@ namespace phi::detail
 {
 /// Fixed-size object pool
 /// Uses an in-place linked list in free nodes, for O(1) acquire, release and size overhead
-template <class T, class IdxT = size_t>
+template <class T>
 struct linked_pool
 {
     static_assert(sizeof(T) >= sizeof(T*), "linked_pool element type must be large enough to accomodate a pointer");
-    using index_t = IdxT;
+    using index_t = uint32_t;
 
     linked_pool() = default;
     linked_pool(linked_pool const&) = delete;
@@ -89,18 +89,20 @@ struct linked_pool
         _first_free_node = node;
     }
 
-    [[nodiscard]] T& get(index_t index)
+    T& get(index_t index)
     {
-        CC_ASSERT(index < _pool_size);
+        CC_CONTRACT(index < _pool_size);
         return _pool[static_cast<size_t>(index)];
     }
-    [[nodiscard]] T const& get(index_t index) const
+    T const& get(index_t index) const
     {
-        CC_ASSERT(index < _pool_size);
+        CC_CONTRACT(index < _pool_size);
         return _pool[static_cast<size_t>(index)];
     }
 
-    [[nodiscard]] bool is_full() const { return _first_free_node == nullptr; }
+    bool is_full() const { return _first_free_node == nullptr; }
+
+    size_t max_size() const { return _pool_size; }
 
     /// pass a lambda that is called with a T& of each allocated node
     /// acquire and release CAN be called from within the lambda

--- a/src/phantasm-hardware-interface/detail/linked_pool.hh
+++ b/src/phantasm-hardware-interface/detail/linked_pool.hh
@@ -6,7 +6,11 @@
 #include <clean-core/new.hh>
 #include <clean-core/vector.hh>
 
+#ifdef CC_ENABLE_ASSERTIONS
 #define PHI_ENABLE_HANDLE_GEN_CHECK 1
+#else
+#define PHI_ENABLE_HANDLE_GEN_CHECK 0
+#endif
 
 #if PHI_ENABLE_HANDLE_GEN_CHECK
 #include <clean-core/bit_cast.hh>

--- a/src/phantasm-hardware-interface/detail/linked_pool.hh
+++ b/src/phantasm-hardware-interface/detail/linked_pool.hh
@@ -6,6 +6,12 @@
 #include <clean-core/new.hh>
 #include <clean-core/vector.hh>
 
+#define PHI_ENABLE_HANDLE_GEN_CHECK 1
+
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+#include <clean-core/bit_cast.hh>
+#endif
+
 namespace phi::detail
 {
 /// Fixed-size object pool
@@ -14,7 +20,17 @@ template <class T>
 struct linked_pool
 {
     static_assert(sizeof(T) >= sizeof(T*), "linked_pool element type must be large enough to accomodate a pointer");
-    using index_t = uint32_t;
+    using handle_t = uint32_t;
+
+    static constexpr size_t sc_num_padding_bits = 3;
+    static constexpr size_t sc_num_index_bits = 16;
+    struct internal_handle_t
+    {
+        uint32_t index : sc_num_index_bits;
+        uint32_t generation : 32 - (sc_num_padding_bits + sc_num_index_bits);
+        uint32_t padding : sc_num_padding_bits;
+    };
+    static_assert(sizeof(internal_handle_t) == sizeof(handle_t));
 
     linked_pool() = default;
     linked_pool(linked_pool const&) = delete;
@@ -25,7 +41,12 @@ struct linked_pool
     ~linked_pool()
     {
         if (_pool)
+        {
             std::free(_pool);
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+            std::free(_generation);
+#endif
+        }
     }
 
     void initialize(size_t size)
@@ -33,7 +54,7 @@ struct linked_pool
         if (size == 0)
             return;
 
-        CC_ASSERT(size < index_t(-1) && "linked_pool size too large for index type");
+        CC_ASSERT(size < 1u << sc_num_index_bits && "linked_pool size too large for index type");
         CC_ASSERT(_pool == nullptr && "re-initialized linked_pool");
 
         _pool_size = size;
@@ -52,10 +73,16 @@ struct linked_pool
             new (cc::placement_new, tail_ptr) T*(nullptr);
         }
 
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+        // initialize generation handles
+        _generation = static_cast<internal_handle_t*>(std::malloc(sizeof(internal_handle_t) * _pool_size));
+        std::memset(_generation, 0, sizeof(internal_handle_t) * _pool_size);
+#endif
+
         _first_free_node = &_pool[0];
     }
 
-    [[nodiscard]] index_t acquire()
+    [[nodiscard]] handle_t acquire()
     {
         CC_ASSERT(!is_full() && "linked_pool full");
 
@@ -65,12 +92,15 @@ struct linked_pool
         // call the constructor
         new (cc::placement_new, acquired_node) T();
 
-        return static_cast<index_t>(acquired_node - _pool);
+        uint32_t const res_index = uint32_t(acquired_node - _pool);
+        return acquire_handle(res_index);
     }
 
-    void release(index_t index)
+    void release(handle_t handle)
     {
-        T* const released_node = &_pool[static_cast<size_t>(index)];
+        uint32_t real_index = read_index_on_release(handle);
+
+        T* const released_node = &_pool[real_index];
         // call the destructor
         released_node->~T();
         // write the in-place next pointer of this node
@@ -81,6 +111,11 @@ struct linked_pool
     void release_node(T* node)
     {
         CC_ASSERT(node >= &_pool[0] && node < &_pool[_pool_size] && "node outside of pool");
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+        // release not based on handle, so we can't check the generation
+        ++_generation[node - _pool].generation; // increment generation on release
+#endif
+
         // call the destructor
         node->~T();
         // write the in-place next pointer of this node
@@ -89,16 +124,27 @@ struct linked_pool
         _first_free_node = node;
     }
 
-    T& get(index_t index)
+    T& get(handle_t handle)
     {
+        uint32_t index = read_index(handle);
         CC_CONTRACT(index < _pool_size);
-        return _pool[static_cast<size_t>(index)];
+        return _pool[index];
     }
-    T const& get(index_t index) const
+
+    T const& get(handle_t handle) const
     {
+        uint32_t index = read_index(handle);
         CC_CONTRACT(index < _pool_size);
-        return _pool[static_cast<size_t>(index)];
+        return _pool[index];
     }
+
+    uint32_t get_node_index(T const* node) const
+    {
+        CC_ASSERT(node >= &_pool[0] && node < &_pool[_pool_size] && "node outside of pool");
+        return node - _pool;
+    }
+
+    uint32_t get_handle_index(handle_t handle) const { return read_index(handle); }
 
     bool is_full() const { return _first_free_node == nullptr; }
 
@@ -114,16 +160,16 @@ struct linked_pool
         // sort ascending
         std::qsort(
             free_indices.data(), free_indices.size(), sizeof(free_indices[0]),
-            +[](void const* a, void const* b) -> int { return int(*(index_t*)a) - int(*(index_t*)b); });
+            +[](void const* a, void const* b) -> int { return int(*(handle_t*)a) - int(*(handle_t*)b); });
 
         unsigned num_iterated_nodes = 0;
         unsigned free_list_index = 0;
-        for (index_t i = 0u; i < _pool_size; ++i)
+        for (handle_t i = 0u; i < _pool_size; ++i)
         {
             if (free_list_index >= free_indices.size() || i < free_indices[free_list_index])
             {
                 // no free indices left, or before the next free index
-                func(_pool[i], i);
+                func(_pool[i]);
                 ++num_iterated_nodes;
             }
             else
@@ -140,27 +186,72 @@ struct linked_pool
     /// This operation is slow and should not occur in normal operation
     unsigned release_all()
     {
-        return iterate_allocated_nodes([this](T&, index_t i) { release(i); });
+        return iterate_allocated_nodes([this](T& node) { release_node(&node); });
     }
 
 private:
-    cc::vector<index_t> get_free_node_indices() const
+    cc::vector<handle_t> get_free_node_indices() const
     {
-        cc::vector<index_t> free_indices;
+        cc::vector<handle_t> free_indices;
         free_indices.reserve(_pool_size);
 
         T* cursor = _first_free_node;
         while (cursor != nullptr)
         {
-            free_indices.push_back(static_cast<index_t>(cursor - _pool));
+            free_indices.push_back(static_cast<handle_t>(cursor - _pool));
             cursor = *reinterpret_cast<T**>(cursor);
         }
 
         return free_indices;
     }
 
+    handle_t acquire_handle(uint32_t real_index)
+    {
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+        internal_handle_t res;
+        res.padding = 0;
+        res.index = real_index;
+        res.generation = _generation[real_index].generation;
+        return cc::bit_cast<uint32_t>(res);
+#else
+        return real_index;
+#endif
+    }
+
+    handle_t read_index(uint32_t handle) const
+    {
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+        CC_ASSERT(handle != uint32_t(-1) && "accessed null handle");
+        internal_handle_t const parsed_handle = cc::bit_cast<internal_handle_t>(handle);
+        uint32_t const real_index = parsed_handle.index;
+        CC_ASSERT(parsed_handle.generation == _generation[real_index].generation && "accessed a stale handle");
+        return real_index;
+#else
+        // we use the handle as-is, but mask out the padding
+        // mask is
+        // 0b00<..#sc_num_padding_bits..>00111<..rest of uint32..>1111
+        constexpr uint32_t mask = ((uint32_t(1) << (32 - sc_num_padding_bits)) - 1);
+        return handle & mask;
+#endif
+    }
+
+    handle_t read_index_on_release(uint32_t handle) const
+    {
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+        uint32_t const real_index = read_index(handle);
+        ++_generation[real_index].generation; // increment generation on release
+        return real_index;
+#else
+        return read_index(handle);
+#endif
+    }
+
+private:
     T* _first_free_node = nullptr;
     T* _pool = nullptr;
+#if PHI_ENABLE_HANDLE_GEN_CHECK
+    internal_handle_t* _generation = nullptr;
+#endif
     size_t _pool_size = 0;
 };
 

--- a/src/phantasm-hardware-interface/handles.hh
+++ b/src/phantasm-hardware-interface/handles.hh
@@ -4,17 +4,17 @@
 
 namespace phi::handle
 {
-using index_t = int32_t;
+using index_t = uint32_t;
 inline constexpr index_t null_handle_index = index_t(-1);
 
-#define PHI_DEFINE_HANDLE(_type_)                                                                         \
-    struct _type_                                                                                         \
-    {                                                                                                     \
-        index_t index;                                                                                    \
-        [[nodiscard]] constexpr bool is_valid() const noexcept { return index != null_handle_index; }     \
-        [[nodiscard]] constexpr bool operator==(_type_ rhs) const noexcept { return index == rhs.index; } \
-        [[nodiscard]] constexpr bool operator!=(_type_ rhs) const noexcept { return index != rhs.index; } \
-    };                                                                                                    \
+#define PHI_DEFINE_HANDLE(_type_)                                                                           \
+    struct _type_                                                                                           \
+    {                                                                                                       \
+        index_t _value;                                                                                     \
+        [[nodiscard]] constexpr bool is_valid() const noexcept { return _value != null_handle_index; }      \
+        [[nodiscard]] constexpr bool operator==(_type_ rhs) const noexcept { return _value == rhs._value; } \
+        [[nodiscard]] constexpr bool operator!=(_type_ rhs) const noexcept { return _value != rhs._value; } \
+    };                                                                                                      \
     inline constexpr _type_ null_##_type_ = {null_handle_index}
 
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -400,7 +400,7 @@ void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::accel_struct>
 
 void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
 {
-    PHI_LOG << "Inspecting resource " << res.index;
+    PHI_LOG << "Inspecting resource " << res._value;
     if (!res.is_valid())
         PHI_LOG << "  invalid (== handle::null_resource)";
     else

--- a/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.cc
@@ -175,12 +175,12 @@ void phi::vk::AccelStructPool::free(phi::handle::accel_struct as)
     if (!as.is_valid())
         return;
 
-    accel_struct_node& freed_node = mPool.get(static_cast<unsigned>(as.index));
+    accel_struct_node& freed_node = mPool.get(as._value);
     internalFree(freed_node);
 
     {
         auto lg = std::lock_guard(mMutex);
-        mPool.release(static_cast<unsigned>(as.index));
+        mPool.release(as._value);
     }
 }
 
@@ -192,9 +192,9 @@ void phi::vk::AccelStructPool::free(cc::span<const phi::handle::accel_struct> as
     {
         if (as.is_valid())
         {
-            accel_struct_node& freed_node = mPool.get(static_cast<unsigned>(as.index));
+            accel_struct_node& freed_node = mPool.get(as._value);
             internalFree(freed_node);
-            mPool.release(static_cast<unsigned>(as.index));
+            mPool.release(as._value);
         }
     }
 }
@@ -212,7 +212,7 @@ void phi::vk::AccelStructPool::destroy()
     if (mDevice != nullptr)
     {
         auto num_leaks = 0;
-        mPool.iterate_allocated_nodes([&](accel_struct_node& leaked_node, unsigned) {
+        mPool.iterate_allocated_nodes([&](accel_struct_node& leaked_node) {
             ++num_leaks;
             internalFree(leaked_node);
         });
@@ -227,7 +227,7 @@ void phi::vk::AccelStructPool::destroy()
 phi::vk::AccelStructPool::accel_struct_node& phi::vk::AccelStructPool::getNode(phi::handle::accel_struct as)
 {
     CC_ASSERT(as.is_valid());
-    return mPool.get(static_cast<unsigned>(as.index));
+    return mPool.get(as._value);
 }
 
 phi::handle::accel_struct phi::vk::AccelStructPool::acquireAccelStruct(VkAccelerationStructureNV raw_as,
@@ -259,7 +259,7 @@ phi::handle::accel_struct phi::vk::AccelStructPool::acquireAccelStruct(VkAcceler
 void phi::vk::AccelStructPool::moveGeometriesToAS(phi::handle::accel_struct as, cc::vector<VkGeometryNV>&& geometries)
 {
     CC_ASSERT(as.is_valid());
-    mPool.get(static_cast<unsigned>(as.index)).geometries = cc::move(geometries);
+    mPool.get(as._value).geometries = cc::move(geometries);
 }
 
 void phi::vk::AccelStructPool::internalFree(phi::vk::AccelStructPool::accel_struct_node& node)

--- a/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.hh
@@ -60,7 +60,7 @@ private:
     VkDevice mDevice = nullptr;
     ResourcePool* mResourcePool = nullptr;
 
-    phi::detail::linked_pool<accel_struct_node, unsigned> mPool;
+    phi::detail::linked_pool<accel_struct_node> mPool;
 
     std::mutex mMutex;
 };

--- a/src/phantasm-hardware-interface/vulkan/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/cmd_list_pool.hh
@@ -246,7 +246,7 @@ public:
         VkCommandBuffer raw_buffer;
     };
 
-    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node, unsigned>;
+    using cmdlist_linked_pool_t = phi::detail::linked_pool<cmd_list_node>;
 
     static constexpr int mcIndexOffsetStep = 1'000'000;
 

--- a/src/phantasm-hardware-interface/vulkan/pools/fence_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/fence_pool.cc
@@ -43,12 +43,12 @@ void phi::vk::FencePool::free(phi::handle::fence fence)
     if (!fence.is_valid())
         return;
 
-    VkSemaphore freed_fence = mPool.get(static_cast<unsigned>(fence.index));
+    VkSemaphore freed_fence = mPool.get(fence._value);
     vkDestroySemaphore(mDevice, freed_fence, nullptr);
 
     {
         auto lg = std::lock_guard(mMutex);
-        mPool.release(static_cast<unsigned>(fence.index));
+        mPool.release(fence._value);
     }
 }
 
@@ -60,9 +60,9 @@ void phi::vk::FencePool::free(cc::span<const phi::handle::fence> fence_span)
     {
         if (as.is_valid())
         {
-            VkSemaphore freed_fence = mPool.get(static_cast<unsigned>(as.index));
+            VkSemaphore freed_fence = mPool.get(as._value);
             vkDestroySemaphore(mDevice, freed_fence, nullptr);
-            mPool.release(static_cast<unsigned>(as.index));
+            mPool.release(as._value);
         }
     }
 }
@@ -79,7 +79,7 @@ void phi::vk::FencePool::destroy()
     if (mDevice != nullptr)
     {
         auto num_leaks = 0;
-        mPool.iterate_allocated_nodes([&](VkSemaphore leaked_fence, unsigned) {
+        mPool.iterate_allocated_nodes([&](VkSemaphore leaked_fence) {
             ++num_leaks;
             vkDestroySemaphore(mDevice, leaked_fence, nullptr);
         });

--- a/src/phantasm-hardware-interface/vulkan/pools/fence_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/fence_pool.hh
@@ -24,7 +24,7 @@ public:
     VkSemaphore get(handle::fence fence) const
     {
         CC_ASSERT(fence.is_valid() && "invalid handle::fence");
-        return mPool.get(static_cast<unsigned>(fence.index));
+        return mPool.get(fence._value);
     }
 
     void signalCPU(handle::fence fence, uint64_t val) const;

--- a/src/phantasm-hardware-interface/vulkan/pools/fence_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/fence_pool.hh
@@ -44,7 +44,7 @@ public:
 private:
     VkDevice mDevice = nullptr;
 
-    phi::detail::linked_pool<VkSemaphore, unsigned> mPool;
+    phi::detail::linked_pool<VkSemaphore> mPool;
 
     std::mutex mMutex;
 };

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
@@ -129,13 +129,13 @@ void phi::vk::PipelinePool::free(phi::handle::pipeline_state ps)
     // TODO: dangle check
 
     // This requires no synchronization, as VMA internally syncs
-    pso_node& freed_node = mPool.get(static_cast<unsigned>(ps.index));
+    pso_node& freed_node = mPool.get(ps._value);
     vkDestroyPipeline(mDevice, freed_node.raw_pipeline, nullptr);
 
     {
         // This is a write access to the pool and must be synced
         auto lg = std::lock_guard(mMutex);
-        mPool.release(static_cast<unsigned>(ps.index));
+        mPool.release(ps._value);
     }
 }
 
@@ -156,7 +156,7 @@ void phi::vk::PipelinePool::destroy()
 {
     auto num_leaks = 0;
 
-    mPool.iterate_allocated_nodes([&](pso_node& leaked_node, unsigned) {
+    mPool.iterate_allocated_nodes([&](pso_node& leaked_node) {
         ++num_leaks;
         vkDestroyPipeline(mDevice, leaked_node.raw_pipeline, nullptr);
     });

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
@@ -51,7 +51,7 @@ public:
     void initialize(VkDevice device, unsigned max_num_psos);
     void destroy();
 
-    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(static_cast<unsigned>(ps.index)); }
+    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(unsigned(ps.index)); }
 
     [[nodiscard]] VkRenderPass getOrCreateRenderPass(cmd::begin_render_pass const& brp_cmd, int num_samples, cc::span<format const> rt_formats);
 
@@ -60,7 +60,7 @@ private:
     PipelineLayoutCache mLayoutCache;
     RenderPassCache mRenderPassCache;
     DescriptorAllocator mDescriptorAllocator;
-    phi::detail::linked_pool<pso_node, unsigned> mPool;
+    phi::detail::linked_pool<pso_node> mPool;
     std::mutex mMutex;
 };
 

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
@@ -51,7 +51,7 @@ public:
     void initialize(VkDevice device, unsigned max_num_psos);
     void destroy();
 
-    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(unsigned(ps.index)); }
+    [[nodiscard]] pso_node const& get(handle::pipeline_state ps) const { return mPool.get(ps._value); }
 
     [[nodiscard]] VkRenderPass getOrCreateRenderPass(cmd::begin_render_pass const& brp_cmd, int num_samples, cc::span<format const> rt_formats);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/query_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/query_pool.hh
@@ -77,9 +77,9 @@ public:
 
     static constexpr query_type HandleToQueryType(handle::query_range qr)
     {
-        if (qr.index >= mcIndexOffsetPipelineStats)
+        if (qr._value >= mcIndexOffsetPipelineStats)
             return query_type::pipeline_stats;
-        else if (qr.index >= mcIndexOffsetOcclusion)
+        else if (qr._value >= mcIndexOffsetOcclusion)
             return query_type::occlusion;
         else
             return query_type::timestamp;
@@ -91,13 +91,13 @@ public:
         static_assert(int(query_type::timestamp) == 0, "unexpected enum ordering");
         static_assert(int(query_type::occlusion) == 1, "unexpected enum ordering");
         static_assert(int(query_type::pipeline_stats) == 2, "unexpected enum ordering");
-        return {index + mcIndexOffsetStep * int(type)};
+        return {unsigned(index + mcIndexOffsetStep * int(type))};
     }
 
     static constexpr int HandleToIndex(handle::query_range qr, query_type type)
     {
         //
-        return qr.index - mcIndexOffsetStep * int(type);
+        return qr._value - mcIndexOffsetStep * int(type);
     }
 
     QueryPageAllocator& getHeap(query_type type)

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -166,7 +166,7 @@ private:
 
 private:
     /// The main pool data
-    phi::detail::linked_pool<resource_node, unsigned> mPool;
+    phi::detail::linked_pool<resource_node> mPool;
 
     /// The handle of the injected backbuffer resource
     handle::resource mInjectedBackbufferResource = handle::null_resource;

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -159,8 +159,8 @@ private:
     [[nodiscard]] handle::resource acquireImage(
         VmaAllocation alloc, VkImage buffer, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, int width, int height);
 
-    [[nodiscard]] resource_node const& internalGet(handle::resource res) const { return mPool.get(static_cast<unsigned>(res.index)); }
-    [[nodiscard]] resource_node& internalGet(handle::resource res) { return mPool.get(static_cast<unsigned>(res.index)); }
+    [[nodiscard]] resource_node const& internalGet(handle::resource res) const { return mPool.get(res._value); }
+    [[nodiscard]] resource_node& internalGet(handle::resource res) { return mPool.get(res._value); }
 
     void internalFree(resource_node& node);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
@@ -34,7 +34,7 @@ public:
     void initialize(VkDevice device, ResourcePool* res_pool, unsigned num_cbvs, unsigned num_srvs, unsigned num_uavs, unsigned num_samplers);
     void destroy();
 
-    [[nodiscard]] VkDescriptorSet get(handle::shader_view sv) const { return mPool.get(static_cast<unsigned>(sv.index)).raw_desc_set; }
+    [[nodiscard]] VkDescriptorSet get(handle::shader_view sv) const { return mPool.get(sv._value).raw_desc_set; }
 
     [[nodiscard]] VkImageView makeImageView(resource_view const& sve, bool is_uav = false) const;
 

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
@@ -67,7 +67,7 @@ private:
     ResourcePool* mResourcePool;
 
     /// The main pool data
-    phi::detail::linked_pool<shader_view_node, unsigned> mPool;
+    phi::detail::linked_pool<shader_view_node> mPool;
 
     /// "Backing" allocator
     DescriptorAllocator mAllocator;


### PR DESCRIPTION
- In debug modes, store generational counters in `handle::` types and assert on stale access or releases
- Rework D3D12/Vulkan pools with multiple internal cases for single handle types (cmdlist, PSO)
- API changes to linked_pool

### Minor
- Use tg::isize2 in various convenience initializers
- Speedup linked_pool iteration with a sort
- Increase default query amounts