### PR TITLE
D3D12 break-on-warn, Vulkan fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ if (NOT MSVC)
     set(THREADS_PREFER_PTHREAD_FLAG ON)
     find_package(Threads REQUIRED)
 
-    target_link_libraries(phantasm-hardware-interface PRIVATE -lX11 Threads::Threads)
+    target_link_libraries(phantasm-hardware-interface PRIVATE -lX11 Threads::Threads -ldl)
 endif()
 
 # =========================================
@@ -102,11 +102,6 @@ if (PHI_BACKEND_VULKAN)
     target_compile_definitions(phantasm-hardware-interface PUBLIC PHI_BACKEND_VULKAN)
     target_link_libraries(phantasm-hardware-interface PUBLIC ${Vulkan_LIBRARY})
     target_include_directories(phantasm-hardware-interface PUBLIC ${Vulkan_INCLUDE_DIRS})
-
-    if (NOT MSVC)
-        # Non-windows targets require libdl to load Vulkan
-        target_link_libraries(phantasm-hardware-interface PRIVATE -ldl)
-    endif()
 else()
     message(STATUS "[phantasm hardware interface] Vulkan backend disabled")
 endif()

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -254,7 +254,7 @@ public:
     }
 
     static create_resource_info render_target(
-        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0, 0, 0, 255})
+        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
     {
         return create(create_render_target_info::create(fmt, size, num_samples, array_size, clear_val));
     }

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -61,7 +61,8 @@ struct backend_config
     enum native_feature_flags : uint8_t
     {
         native_feature_none = 0,
-        native_feature_vk_api_dump = 1 << 0
+        native_feature_vk_api_dump = 1 << 0,
+        native_feature_d3d12_break_on_warn = 1 << 1,
     };
 
     /// native features to enable

--- a/src/phantasm-hardware-interface/d3d12/Adapter.cc
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.cc
@@ -10,38 +10,38 @@
 
 void phi::d3d12::Adapter::initialize(const backend_config& config)
 {
-    if (config.validation != validation_level::off)
-    {
-        // Suppress GBV startup message
-        // shared_com_ptr<IDXGIInfoQueue> dxgi_info_queue;
+//    if (config.validation != validation_level::off)
+//    {
+//        // Suppress GBV startup message
+//        // shared_com_ptr<IDXGIInfoQueue> dxgi_info_queue;
 
-        bool const dxgi_queue_success = detail::hr_succeeded(::DXGIGetDebugInterface1(0, PHI_COM_WRITE(mInfoQueue)));
-        if (dxgi_queue_success && mInfoQueue.is_valid())
-        {
-            DXGI_INFO_QUEUE_FILTER filter = {};
+//        bool const dxgi_queue_success = detail::hr_succeeded(::DXGIGetDebugInterface1(0, PHI_COM_WRITE(mInfoQueue)));
+//        if (dxgi_queue_success && mInfoQueue.is_valid())
+//        {
+//            DXGI_INFO_QUEUE_FILTER filter = {};
 
-            DXGI_INFO_QUEUE_MESSAGE_SEVERITY denied_severities[] = {DXGI_INFO_QUEUE_MESSAGE_SEVERITY_MESSAGE};
-            filter.DenyList.NumSeverities = 1;
-            filter.DenyList.pSeverityList = denied_severities;
+//            DXGI_INFO_QUEUE_MESSAGE_SEVERITY denied_severities[] = {DXGI_INFO_QUEUE_MESSAGE_SEVERITY_MESSAGE};
+//            filter.DenyList.NumSeverities = 1;
+//            filter.DenyList.pSeverityList = denied_severities;
 
-            DXGI_INFO_QUEUE_MESSAGE_ID denied_message_ids[] = {1016};
-            filter.DenyList.NumIDs = 1;
-            filter.DenyList.pIDList = denied_message_ids;
+//            DXGI_INFO_QUEUE_MESSAGE_ID denied_message_ids[] = {1016};
+//            filter.DenyList.NumIDs = 1;
+//            filter.DenyList.pIDList = denied_message_ids;
 
-            // TODO: This has no effect due to a bug
-            // Jesse Natalie:
-            // "[...] Apparently, the "most up-to-date" filter among all the ones that could possibly match are chosen.
-            // The D3D12 device produces a filter during creation, which makes it more up-to-date than any that'd be
-            // created before device creation is begun. [...]"
-            // will revisit once that is fixed
-            PHI_D3D12_VERIFY(mInfoQueue->PushStorageFilter(DXGI_DEBUG_ALL, &filter));
+//            // TODO: This has no effect due to a bug
+//            // Jesse Natalie:
+//            // "[...] Apparently, the "most up-to-date" filter among all the ones that could possibly match are chosen.
+//            // The D3D12 device produces a filter during creation, which makes it more up-to-date than any that'd be
+//            // created before device creation is begun. [...]"
+//            // will revisit once that is fixed
+//            PHI_D3D12_VERIFY(mInfoQueue->PushStorageFilter(DXGI_DEBUG_ALL, &filter));
 
-            // (none of these have either)
-            //            PHI_D3D12_VERIFY(mInfoQueue->PushDenyAllStorageFilter(DXGI_DEBUG_D3D12));
-            //            PHI_D3D12_VERIFY(mInfoQueue->PushDenyAllRetrievalFilter(DXGI_DEBUG_D3D12));
-            //            mInfoQueue->SetMuteDebugOutput(DXGI_DEBUG_D3D12, TRUE);
-        }
-    }
+//            // (none of these have either)
+//            //            PHI_D3D12_VERIFY(mInfoQueue->PushDenyAllStorageFilter(DXGI_DEBUG_D3D12));
+//            //            PHI_D3D12_VERIFY(mInfoQueue->PushDenyAllRetrievalFilter(DXGI_DEBUG_D3D12));
+//            //            mInfoQueue->SetMuteDebugOutput(DXGI_DEBUG_D3D12, TRUE);
+//        }
+//    }
 
     // Factory init
     {

--- a/src/phantasm-hardware-interface/d3d12/Device.cc
+++ b/src/phantasm-hardware-interface/d3d12/Device.cc
@@ -50,4 +50,19 @@ void phi::d3d12::Device::initialize(IDXGIAdapter& adapter, const backend_config&
         // this is likely redundant, but just to make sure
         mDevice5 = nullptr;
     }
+
+    if ((config.native_features & backend_config::native_feature_d3d12_break_on_warn) != 0)
+    {
+        if (config.validation < validation_level::on)
+        {
+            PHI_LOG_ERROR("cannot enable d3d12_break_on_warn with disabled validation");
+        }
+        else
+        {
+            shared_com_ptr<ID3D12InfoQueue> info_queue;
+            PHI_D3D12_VERIFY(mDevice5.get_interface(info_queue));
+            PHI_D3D12_VERIFY(info_queue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, TRUE));
+            PHI_LOG("d3d12_break_on_warn enabled");
+        }
+    }
 }

--- a/src/phantasm-hardware-interface/d3d12/common/util.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/util.cc
@@ -29,21 +29,32 @@ cc::capped_vector<D3D12_INPUT_ELEMENT_DESC, 16> phi::d3d12::util::get_native_ver
 
 void phi::d3d12::util::set_object_name(ID3D12Object* object, const char* name, ...)
 {
-    if (name != nullptr)
-    {
-        char name_formatted[1024];
-        {
-            va_list args;
-            va_start(args, name);
-            ::vsprintf_s(name_formatted, 1024, name, args);
-            va_end(args);
-        }
+    CC_ASSERT(name != nullptr);
+    CC_ASSERT(object != nullptr);
 
-        // Since recently, d3d12 object names can be set using non-wide strings
-        // even though it doesn't look like it, this works perfectly with validation layers, PIX, Renderdoc, NSight and DRED
-        object->SetPrivateData(WKPDID_D3DDebugObjectName, static_cast<UINT>(strlen(name_formatted)), name_formatted);
+    char name_formatted[1024];
+    {
+        va_list args;
+        va_start(args, name);
+        ::vsprintf_s(name_formatted, 1024, name, args);
+        va_end(args);
     }
+
+    // Since recently, d3d12 object names can be set using non-wide strings
+    // even though it doesn't look like it, this works perfectly with validation layers, PIX, Renderdoc, NSight and DRED
+    object->SetPrivateData(WKPDID_D3DDebugObjectName, static_cast<UINT>(strlen(name_formatted)), name_formatted);
 }
+
+unsigned phi::d3d12::util::get_object_name(ID3D12Object* object, cc::span<char> out_name)
+{
+    CC_ASSERT(object != nullptr);
+    CC_ASSERT(out_name.data() != nullptr);
+
+    UINT size = UINT(out_name.size());
+    object->GetPrivateData(WKPDID_D3DDebugObjectName, &size, out_name.data());
+    return size;
+}
+
 
 D3D12_SHADER_RESOURCE_VIEW_DESC phi::d3d12::util::create_srv_desc(const phi::resource_view& sve, ID3D12Resource* raw_resource)
 {

--- a/src/phantasm-hardware-interface/d3d12/common/util.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/util.hh
@@ -21,6 +21,8 @@ namespace phi::d3d12::util
 
 void set_object_name(ID3D12Object* object, char const* name, ...) CC_PRINTF_FUNC(2, 3);
 
+unsigned get_object_name(ID3D12Object* object, cc::span<char> out_name);
+
 /// create a SRV description based on a shader_view_element
 /// the raw resource is only required in case a raytracing AS is described
 [[nodiscard]] D3D12_SHADER_RESOURCE_VIEW_DESC create_srv_desc(resource_view const& sve, ID3D12Resource* raw_resource);

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -37,15 +37,15 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
     // Populate new node
     pso_node& new_node = mPool.get(pool_index);
     new_node.associated_root_sig = root_sig;
+    new_node.primitive_topology = util::to_native_topology(primitive_config.topology);
 
     {
         // Create PSO
         auto const vert_format_native = util::get_native_vertex_format(vertex_format.attributes);
         new_node.raw_pso = create_pipeline_state(*mDevice, root_sig->raw_root_sig, vert_format_native, framebuffer_format, shader_stages, primitive_config);
-        util::set_object_name(new_node.raw_pso, "pool pso #%d", int(pool_index));
+        util::set_object_name(new_node.raw_pso, "pool graphics pso #%d", int(pool_index));
     }
 
-    new_node.primitive_topology = util::to_native_topology(primitive_config.topology);
 
     return {static_cast<handle::index_t>(pool_index)};
 }

--- a/src/phantasm-hardware-interface/detail/gpu_stats.cc
+++ b/src/phantasm-hardware-interface/detail/gpu_stats.cc
@@ -88,7 +88,7 @@ struct nvml_dll_state
         }
 #elif defined(CC_OS_LINUX)
         // Available globally
-        _dll = dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_GLOBAL);
+        _dll = ::dlopen("libnvidia-ml.so", RTLD_LAZY | RTLD_GLOBAL);
 #endif
 
         if (!_dll)

--- a/src/phantasm-hardware-interface/detail/unique_buffer.hh
+++ b/src/phantasm-hardware-interface/detail/unique_buffer.hh
@@ -42,19 +42,20 @@ struct unique_buffer
 
     ~unique_buffer() { std::free(_ptr); }
 
-    [[nodiscard]] std::byte* get() const { return _ptr; }
-    [[nodiscard]] char* get_as_char() const { return cc::bit_cast<char*>(_ptr); }
-    [[nodiscard]] size_t size() const { return _size; }
+    std::byte* data() const { return _ptr; }
+    std::byte* get() const { return _ptr; }
+    char* get_as_char() const { return cc::bit_cast<char*>(_ptr); }
+    size_t size() const { return _size; }
 
-    [[nodiscard]] bool is_valid() const { return _ptr != nullptr; }
+    bool is_valid() const { return _ptr != nullptr; }
 
     operator std::byte*() const& { return _ptr; }
     operator std::byte*() const&& = delete;
 
-    [[nodiscard]] bool operator==(unique_buffer const& rhs) const { return _ptr == rhs._ptr; }
-    [[nodiscard]] bool operator!=(unique_buffer const& rhs) const { return _ptr != rhs._ptr; }
-    [[nodiscard]] bool operator==(void const* rhs) const { return _ptr == rhs; }
-    [[nodiscard]] bool operator!=(void const* rhs) const { return _ptr != rhs; }
+    bool operator==(unique_buffer const& rhs) const { return _ptr == rhs._ptr; }
+    bool operator!=(unique_buffer const& rhs) const { return _ptr != rhs._ptr; }
+    bool operator==(void const* rhs) const { return _ptr == rhs; }
+    bool operator!=(void const* rhs) const { return _ptr != rhs; }
 
     [[nodiscard]] static unique_buffer create_from_binary_file(char const* filename);
 

--- a/src/phantasm-hardware-interface/handles.hh
+++ b/src/phantasm-hardware-interface/handles.hh
@@ -5,17 +5,26 @@
 namespace phi::handle
 {
 using index_t = uint32_t;
-inline constexpr index_t null_handle_index = index_t(-1);
+inline constexpr index_t null_handle_value = index_t(-1);
 
-#define PHI_DEFINE_HANDLE(_type_)                                                                           \
-    struct _type_                                                                                           \
-    {                                                                                                       \
-        index_t _value;                                                                                     \
-        [[nodiscard]] constexpr bool is_valid() const noexcept { return _value != null_handle_index; }      \
-        [[nodiscard]] constexpr bool operator==(_type_ rhs) const noexcept { return _value == rhs._value; } \
-        [[nodiscard]] constexpr bool operator!=(_type_ rhs) const noexcept { return _value != rhs._value; } \
-    };                                                                                                      \
-    inline constexpr _type_ null_##_type_ = {null_handle_index}
+namespace detail
+{
+struct abstract_handle
+{
+    index_t _value;
+    abstract_handle() = default;
+    constexpr abstract_handle(index_t val) : _value(val) {}
+    [[nodiscard]] constexpr bool is_valid() const noexcept { return _value != null_handle_value; }
+    [[nodiscard]] constexpr bool operator==(abstract_handle rhs) const noexcept { return _value == rhs._value; }
+    [[nodiscard]] constexpr bool operator!=(abstract_handle rhs) const noexcept { return _value != rhs._value; }
+};
+}
+
+#define PHI_DEFINE_HANDLE(_type_)                                 \
+    struct _type_ : public ::phi::handle::detail::abstract_handle \
+    {                                                             \
+    };                                                            \
+    inline constexpr _type_ null_##_type_ = {::phi::handle::null_handle_value}
 
 
 /// generic resource (buffer, texture, render target)
@@ -39,6 +48,4 @@ PHI_DEFINE_HANDLE(query_range);
 
 /// raytracing acceleration structure handle
 PHI_DEFINE_HANDLE(accel_struct);
-
-#undef PHI_DEFINE_HANDLE
 }

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -200,6 +200,10 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
         {
             PHI_LOG_ERROR << "missing API dump layer";
         }
+        else
+        {
+            PHI_LOG("vk_api_dump enabled");
+        }
     }
 
     // VK_EXT_debug_utils

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -323,6 +323,8 @@ void phi::vk::ResourcePool::initialize(VkPhysicalDevice physical, VkDevice devic
 
 void phi::vk::ResourcePool::destroy()
 {
+    mPool.release(mInjectedBackbufferResource._value);
+
     auto num_leaks = 0;
     mPool.iterate_allocated_nodes([&](resource_node& leaked_node) {
         if (leaked_node.allocation != nullptr)

--- a/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
+++ b/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
@@ -211,7 +211,7 @@ VkPipeline phi::vk::create_pipeline(VkDevice device,
 
     VkPipelineInputAssemblyStateCreateInfo input_assembly = {};
     input_assembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    input_assembly.topology = no_vertices ? VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST : util::to_native(config.topology);
+    input_assembly.topology = util::to_native(config.topology);
     input_assembly.primitiveRestartEnable = VK_FALSE;
 
     // we use dynamic viewports and scissors, these initial values are irrelevant


### PR DESCRIPTION
- Add `d3d12_break_on_warn` native feature flag (breaks on validation warnings, similar to a breakpoint in the vulkan callback)
- Output object names of leaked `handle::resource`s in d3d12 during shutdown
- Fix vulkan crash on shutdown
- Fix vulkan PSOs with empty vertices and non-triangle input topology
- Fix optimized clear value default values
- Minor changes