### PR TITLE
cmd::copy_texture_to_buffer, fixes

### DIFF
--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -24,6 +24,7 @@ namespace detail
     PHI_X(copy_buffer)             \
     PHI_X(copy_texture)            \
     PHI_X(copy_buffer_to_texture)  \
+    PHI_X(copy_texture_to_buffer)  \
     PHI_X(resolve_texture)         \
     PHI_X(begin_render_pass)       \
     PHI_X(end_render_pass)         \
@@ -348,8 +349,8 @@ PHI_DEFINE_CMD(copy_buffer_to_texture)
     handle::resource source;
     handle::resource destination;
     size_t source_offset;
-    unsigned dest_width;       ///< width of the destination texture (in the specified MIP map and array element)
-    unsigned dest_height;      ///< height of the destination texture (in the specified MIP map and array element)
+    unsigned dest_width;       ///< width of the destination texture (in the specified MIP level and array element)
+    unsigned dest_height;      ///< height of the destination texture (in the specified MIP level and array element)
     unsigned dest_mip_index;   ///< index of the MIP level to copy
     unsigned dest_array_index; ///< index of the array element to copy (usually: 0)
 
@@ -363,6 +364,29 @@ public:
         dest_height = dest_h;
         dest_mip_index = dest_mip_i;
         dest_array_index = dest_arr_i;
+    }
+};
+
+PHI_DEFINE_CMD(copy_texture_to_buffer)
+{
+    handle::resource source;
+    handle::resource destination;
+    size_t dest_offset;
+    unsigned src_width;       ///< width of the source texture (in the specified MIP level and array element)
+    unsigned src_height;      ///< height of the destination texture (in the specified MIP level and array element)
+    unsigned src_mip_index;   ///< index of the MIP level to copy
+    unsigned src_array_index; ///< index of the array element to copy (usually: 0)
+
+public:
+    void init(handle::resource src, handle::resource dest, unsigned src_w, unsigned src_h, size_t dest_off = 0, unsigned src_mip_i = 0, unsigned src_arr_i = 0)
+    {
+        source = src;
+        destination = dest;
+        dest_offset = dest_off;
+        src_width = src_w;
+        src_height = src_h;
+        src_mip_index = src_mip_i;
+        src_array_index = src_arr_i;
     }
 };
 

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -178,7 +178,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::draw& draw)
                                                      draw.root_constants, 0);
         }
 
-        for (uint8_t i = 0; i < draw.shader_arguments.size(); ++i)
+        for (uint8_t i = 0; i < root_sig.argument_maps.size(); ++i)
         {
             auto& bound_arg = _bound.shader_args[i];
             auto const& arg = draw.shader_arguments[i];

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -62,6 +62,8 @@ struct command_list_translator
 
     void execute(cmd::copy_buffer_to_texture const& copy_text);
 
+    void execute(cmd::copy_texture_to_buffer const& copy_text);
+
     void execute(cmd::resolve_texture const& resolve);
 
     void execute(cmd::write_timestamp const& timestamp);

--- a/src/phantasm-hardware-interface/detail/linked_pool.hh
+++ b/src/phantasm-hardware-interface/detail/linked_pool.hh
@@ -23,7 +23,6 @@ namespace phi::detail
 template <class T>
 struct linked_pool
 {
-    static_assert(sizeof(T) >= sizeof(T*), "linked_pool element type must be large enough to accomodate a pointer");
     using handle_t = uint32_t;
 
     static constexpr size_t sc_num_padding_bits = 3;
@@ -49,6 +48,8 @@ struct linked_pool
 
     void initialize(size_t size)
     {
+        static_assert(sizeof(T) >= sizeof(T*), "linked_pool element type must be large enough to accomodate a pointer");
+
         if (size == 0)
             return;
 

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -469,6 +469,16 @@ struct rt_clear_value
     {
     }
     rt_clear_value(float depth, uint8_t stencil) : red_or_depth(uint8_t(depth * 255)), green_or_stencil(stencil) {}
+
+    static rt_clear_value from_uint(uint32_t value)
+    {
+        rt_clear_value res;
+        res.red_or_depth = uint8_t(value >> 24);
+        res.green_or_stencil = uint8_t(value >> 16);
+        res.blue = uint8_t(value >> 8);
+        res.alpha = uint8_t(value);
+        return res;
+    };
 };
 
 /// blending logic operation a (graphics) handle::pipeline_state performs on its render targets

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -436,6 +436,6 @@ void phi::vk::BackendVulkan::createDebugMessenger()
     createInfo.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
                              | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
     createInfo.pfnUserCallback = detail::debug_callback;
-    createInfo.pUserData = nullptr;
+    createInfo.pUserData = this;
     PHI_VK_VERIFY_SUCCESS(vkCreateDebugUtilsMessengerEXT(mInstance, &createInfo, nullptr, &mDebugMessenger));
 }

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -454,6 +454,25 @@ void phi::vk::command_list_translator::execute(const phi::cmd::copy_buffer_to_te
     vkCmdCopyBufferToImage(_cmd_list, src_buffer, dest_image_info.raw_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 }
 
+void phi::vk::command_list_translator::execute(const phi::cmd::copy_texture_to_buffer& copy_text)
+{
+    auto const src_image = _globals.pool_resources->getRawImage(copy_text.source);
+    auto const& src_image_info = _globals.pool_resources->getImageInfo(copy_text.destination);
+    auto const dest_buffer = _globals.pool_resources->getRawBuffer(copy_text.destination);
+
+    VkBufferImageCopy region = {};
+    region.bufferOffset = uint32_t(copy_text.dest_offset);
+    region.imageSubresource.aspectMask = util::to_native_image_aspect(src_image_info.pixel_format);
+    region.imageSubresource.baseArrayLayer = copy_text.src_array_index;
+    region.imageSubresource.layerCount = 1;
+    region.imageSubresource.mipLevel = copy_text.src_mip_index;
+    region.imageExtent.width = copy_text.src_width;
+    region.imageExtent.height = copy_text.src_height;
+    region.imageExtent.depth = 1;
+
+    vkCmdCopyImageToBuffer(_cmd_list, src_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dest_buffer, 1, &region);
+}
+
 void phi::vk::command_list_translator::execute(const phi::cmd::resolve_texture& resolve)
 {
     constexpr auto src_layout = util::to_image_layout(resource_state::resolve_src);

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -70,6 +70,8 @@ struct command_list_translator
 
     void execute(cmd::copy_buffer_to_texture const& copy_text);
 
+    void execute(cmd::copy_texture_to_buffer const& copy_text);
+
     void execute(cmd::resolve_texture const& resolve);
 
     void execute(cmd::write_timestamp const& timestamp);

--- a/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
@@ -2,6 +2,8 @@
 
 #include <phantasm-hardware-interface/detail/log.hh>
 
+#include <clean-core/breakpoint.hh>
+
 namespace
 {
 constexpr char const* to_literal(VkDebugUtilsMessageSeverityFlagBitsEXT severity)
@@ -37,12 +39,13 @@ constexpr char const* to_literal(VkDebugUtilsMessageTypeFlagsEXT type)
 }
 
 VkBool32 phi::vk::detail::debug_callback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
-                                         VkDebugUtilsMessageTypeFlagsEXT type,
+                                         VkDebugUtilsMessageTypeFlagsEXT /*type*/,
                                          const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
                                          void* /*user_data*/)
 {
     if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
     {
+        // cc::breakpoint(); // NOTE: setting a breakpoint here sometimes doesn't suffice
         RICH_LOG_IMPL(phi::detail::vulkan_log)("{}", callback_data->pMessage);
     }
     return VK_FALSE;


### PR DESCRIPTION
- Add `cmd::copy_texture_to_buffer`
- Fix D3D12 behavior if more shader arguments are present than configured in the PSO
- Fix D3D12 input topology switching
- Make `linked_pool` compatible with forward declared Ts