### PR TITLE
Better debug names, fix synced present

### DIFF
--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -68,17 +68,27 @@ public:
     /// create a 1D, 2D or 3D texture, or a 1D/2D array
     /// if mips is 0, the maximum amount will be used
     /// if the texture will be used as a UAV, allow_uav must be true
-    [[nodiscard]] virtual handle::resource createTexture(
-        phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim = texture_dimension::t2d, unsigned depth_or_array_size = 1, bool allow_uav = false)
+    [[nodiscard]] virtual handle::resource createTexture(phi::format format,
+                                                         tg::isize2 size,
+                                                         unsigned mips,
+                                                         texture_dimension dim = texture_dimension::t2d,
+                                                         unsigned depth_or_array_size = 1,
+                                                         bool allow_uav = false,
+                                                         char const* debug_name = nullptr)
         = 0;
 
     /// create a [multisampled] 2D render- or depth-stencil target
-    [[nodiscard]] virtual handle::resource createRenderTarget(
-        phi::format format, tg::isize2 size, unsigned samples = 1, unsigned array_size = 1, rt_clear_value const* optimized_clear_val = nullptr)
+    [[nodiscard]] virtual handle::resource createRenderTarget(phi::format format,
+                                                              tg::isize2 size,
+                                                              unsigned samples = 1,
+                                                              unsigned array_size = 1,
+                                                              rt_clear_value const* optimized_clear_val = nullptr,
+                                                              char const* debug_name = nullptr)
         = 0;
 
     /// create a buffer with optional element stride, allocation on an upload/readback heap, or allowing UAV access
-    [[nodiscard]] virtual handle::resource createBuffer(unsigned size_bytes, unsigned stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false)
+    [[nodiscard]] virtual handle::resource createBuffer(
+        unsigned size_bytes, unsigned stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false, char const* debug_name = nullptr)
         = 0;
 
     /// create a buffer with optional element stride on resource_heap::upload (shorthand function)
@@ -247,31 +257,31 @@ public:
         (free(handles), ...);
     }
 
-    [[nodiscard]] handle::resource createBufferFromInfo(arg::create_buffer_info const& info)
+    [[nodiscard]] handle::resource createBufferFromInfo(arg::create_buffer_info const& info, char const* debug_name = nullptr)
     {
-        return createBuffer(info.size_bytes, info.stride_bytes, info.heap, info.allow_uav);
+        return createBuffer(info.size_bytes, info.stride_bytes, info.heap, info.allow_uav, debug_name);
     }
 
-    [[nodiscard]] handle::resource createRenderTargetFromInfo(arg::create_render_target_info const& info)
+    [[nodiscard]] handle::resource createRenderTargetFromInfo(arg::create_render_target_info const& info, char const* debug_name = nullptr)
     {
-        return createRenderTarget(info.format, {info.width, info.height}, info.num_samples, info.array_size, &info.clear_value);
+        return createRenderTarget(info.format, {info.width, info.height}, info.num_samples, info.array_size, &info.clear_value, debug_name);
     }
 
-    [[nodiscard]] handle::resource createTextureFromInfo(arg::create_texture_info const& info)
+    [[nodiscard]] handle::resource createTextureFromInfo(arg::create_texture_info const& info, char const* debug_name = nullptr)
     {
-        return createTexture(info.fmt, {info.width, info.height}, info.num_mips, info.dim, info.depth_or_array_size, info.allow_uav);
+        return createTexture(info.fmt, {info.width, info.height}, info.num_mips, info.dim, info.depth_or_array_size, info.allow_uav, debug_name);
     }
 
-    [[nodiscard]] handle::resource createResourceFromInfo(arg::create_resource_info const& info)
+    [[nodiscard]] handle::resource createResourceFromInfo(arg::create_resource_info const& info, char const* debug_name = nullptr)
     {
         switch (info.type)
         {
         case arg::create_resource_info::e_resource_render_target:
-            return createRenderTargetFromInfo(info.info_render_target);
+            return createRenderTargetFromInfo(info.info_render_target, debug_name);
         case arg::create_resource_info::e_resource_texture:
-            return createTextureFromInfo(info.info_texture);
+            return createTextureFromInfo(info.info_texture, debug_name);
         case arg::create_resource_info::e_resource_buffer:
-            return createBufferFromInfo(info.info_buffer);
+            return createBufferFromInfo(info.info_buffer, debug_name);
         default:
             CC_ASSERT(false && "invalid type");
             return handle::null_resource;

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -223,6 +223,10 @@ public:
     // Debug interface
     //
 
+    /// resets the debug name of a resource
+    /// this is the name visible to diagnostic tools and referred to by validation warnings
+    virtual void setDebugName(handle::resource res, char const* name) = 0;
+
     /// prints diagnostic information about the given resource
     virtual void printInformation(handle::resource res) const = 0;
 

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <clean-core/fwd.hh>
+
 #include <typed-geometry/types/size.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
@@ -225,7 +227,7 @@ public:
 
     /// resets the debug name of a resource
     /// this is the name visible to diagnostic tools and referred to by validation warnings
-    virtual void setDebugName(handle::resource res, char const* name) = 0;
+    virtual void setDebugName(handle::resource res, cc::string_view name) = 0;
 
     /// prints diagnostic information about the given resource
     virtual void printInformation(handle::resource res) const = 0;

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
 
 #include <typed-geometry/types/size.hh>
@@ -109,14 +108,14 @@ struct blas_element
 struct raytracing_shader_library
 {
     shader_binary binary;
-    cc::capped_vector<wchar_t const*, 16> symbols;
+    detail::trivial_capped_vector<wchar_t const*, 16> symbols;
 };
 
 /// associates symbols exported from libraries with their argument shapes
 struct raytracing_argument_association
 {
-    cc::capped_vector<wchar_t const*, 16> symbols;
-    cc::capped_vector<shader_arg_shape, limits::max_shader_arguments> argument_shapes;
+    detail::trivial_capped_vector<wchar_t const*, 16> symbols;
+    detail::trivial_capped_vector<shader_arg_shape, limits::max_shader_arguments> argument_shapes;
     bool has_root_constants = false;
 };
 
@@ -133,7 +132,7 @@ struct shader_table_record
     wchar_t const* symbol = nullptr;     ///< name of the shader or hit group
     void const* root_arg_data = nullptr; ///< optional, data of the root constant data
     uint32_t root_arg_size = 0;          ///< size of the root constant data
-    cc::capped_vector<shader_argument, limits::max_shader_arguments> shader_arguments;
+    detail::trivial_capped_vector<shader_argument, limits::max_shader_arguments> shader_arguments;
 };
 
 using raytracing_shader_libraries = cc::span<raytracing_shader_library const>;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -327,6 +327,8 @@ void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::accel_struc
     mPoolAccelStructs.free(as);
 }
 
+void phi::d3d12::BackendD3D12::setDebugName(phi::handle::resource res, const char* name) { mPoolResources.setDebugName(res, name); }
+
 void phi::d3d12::BackendD3D12::printInformation(phi::handle::resource res) const
 {
     (void)res;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -327,7 +327,10 @@ void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::accel_struc
     mPoolAccelStructs.free(as);
 }
 
-void phi::d3d12::BackendD3D12::setDebugName(phi::handle::resource res, const char* name) { mPoolResources.setDebugName(res, name); }
+void phi::d3d12::BackendD3D12::setDebugName(phi::handle::resource res, cc::string_view name)
+{
+    mPoolResources.setDebugName(res, name.data(), unsigned(name.length()));
+}
 
 void phi::d3d12::BackendD3D12::printInformation(phi::handle::resource res) const
 {

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -220,7 +220,7 @@ public:
     // Debug interface
     //
 
-    void setDebugName(handle::resource res, const char* name) override;
+    void setDebugName(handle::resource res, cc::string_view name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -72,19 +72,25 @@ public:
     // Resource interface
     //
 
-    [[nodiscard]] handle::resource createTexture(phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav) override
+    [[nodiscard]] handle::resource createTexture(
+        phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override
     {
-        return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav);
+        return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
     }
 
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val) override
+    [[nodiscard]] handle::resource createRenderTarget(phi::format format,
+                                                      tg::isize2 size,
+                                                      unsigned samples,
+                                                      unsigned array_size,
+                                                      rt_clear_value const* optimized_clear_val = nullptr,
+                                                      char const* debug_name = nullptr) override
     {
-        return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, optimized_clear_val);
+        return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, optimized_clear_val, debug_name);
     }
 
-    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav) override
+    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override
     {
-        return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav);
+        return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
     }
 
     [[nodiscard]] handle::resource createUploadBuffer(unsigned size_bytes, unsigned stride_bytes = 0) override

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -220,7 +220,7 @@ public:
     // Debug interface
     //
 
-    void setDebugName(handle::resource res, const char *name) override;
+    void setDebugName(handle::resource res, const char* name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -220,6 +220,7 @@ public:
     // Debug interface
     //
 
+    void setDebugName(handle::resource res, const char *name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
@@ -105,7 +105,8 @@ phi::handle::accel_struct phi::d3d12::AccelStructPool::createTopLevelAS(unsigned
         = mResourcePool->createBufferInternal(prebuild_info.ResultDataMaxSizeInBytes, 0, true, D3D12_RESOURCE_STATE_RAYTRACING_ACCELERATION_STRUCTURE);
     new_node.buffer_scratch = mResourcePool->createBufferInternal(
         cc::max<UINT64>(prebuild_info.ScratchDataSizeInBytes, prebuild_info.UpdateScratchDataSizeInBytes), 0, true, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
-    new_node.buffer_instances = mResourcePool->createBuffer(sizeof(accel_struct_geometry_instance) * num_instances, 0, resource_heap::upload, false);
+    new_node.buffer_instances
+        = mResourcePool->createBuffer(sizeof(accel_struct_geometry_instance) * num_instances, 0, resource_heap::upload, false, "phi-toplevel-as");
     new_node.buffer_instances_map = mResourcePool->mapBuffer(new_node.buffer_instances);
 
     // query GPU address (raw native handle)

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -295,6 +295,12 @@ void phi::d3d12::ResourcePool::free(cc::span<const phi::handle::resource> resour
     }
 }
 
+void phi::d3d12::ResourcePool::setDebugName(phi::handle::resource res, const char* name)
+{
+    CC_CONTRACT(name != nullptr);
+    util::set_object_name(internalGet(res).resource, "%s [respool named]", name);
+}
+
 phi::handle::resource phi::d3d12::ResourcePool::acquireBuffer(
     D3D12MA::Allocation* alloc, D3D12_RESOURCE_STATES initial_state, uint64_t buffer_width, unsigned buffer_stride, phi::resource_heap heap)
 {

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -300,10 +300,10 @@ void phi::d3d12::ResourcePool::free(cc::span<const phi::handle::resource> resour
     }
 }
 
-void phi::d3d12::ResourcePool::setDebugName(phi::handle::resource res, const char* name)
+void phi::d3d12::ResourcePool::setDebugName(phi::handle::resource res, const char* name, unsigned name_length)
 {
     CC_CONTRACT(name != nullptr);
-    util::set_object_name(internalGet(res).resource, "%s [respool named]", name);
+    util::set_object_name(internalGet(res).resource, "%*s [respool named]", name_length, name);
 }
 
 phi::handle::resource phi::d3d12::ResourcePool::acquireBuffer(

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -121,6 +121,8 @@ phi::handle::resource phi::d3d12::ResourcePool::createTexture(
 {
     constexpr D3D12_RESOURCE_STATES initial_state = util::to_native(resource_state::copy_dest);
 
+    CC_CONTRACT(w > 0 && h > 0);
+
     D3D12_RESOURCE_DESC desc = {};
     desc.Dimension = util::to_native(dim);
     desc.Format = util::to_dxgi_format(format);
@@ -147,6 +149,8 @@ phi::handle::resource phi::d3d12::ResourcePool::createTexture(
 phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(
     phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val, const char* dbg_name)
 {
+    CC_CONTRACT(w > 0 && h > 0);
+
     auto const format_dxgi = util::to_dxgi_format(format);
     if (is_depth_format(format))
     {
@@ -206,6 +210,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(
 
 phi::handle::resource phi::d3d12::ResourcePool::createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, const char* dbg_name)
 {
+    CC_CONTRACT(size_bytes > 0);
     D3D12_RESOURCE_STATES const initial_state = d3d12_get_initial_state_by_heap(heap);
 
     auto desc = CD3DX12_RESOURCE_DESC::Buffer(size_bytes);

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -19,14 +19,14 @@ public:
 
     /// create a 1D, 2D or 3D texture, or a 1D/2D array
     [[nodiscard]] handle::resource createTexture(
-        format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim = texture_dimension::t2d, unsigned depth_or_array_size = 1, bool allow_uav = false);
+        format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
 
     /// create a render- or depth-stencil target
     [[nodiscard]] handle::resource createRenderTarget(
-        phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val = nullptr);
+        phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val, char const* dbg_name);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
-    [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav);
+    [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name);
 
     [[nodiscard]] std::byte* mapBuffer(handle::resource res);
 

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -37,7 +37,7 @@ public:
     void free(handle::resource res);
     void free(cc::span<handle::resource const> resources);
 
-    void setDebugName(handle::resource res, char const* name);
+    void setDebugName(handle::resource res, char const* name, unsigned name_length);
 
 public:
     struct resource_node

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -37,6 +37,8 @@ public:
     void free(handle::resource res);
     void free(cc::span<handle::resource const> resources);
 
+    void setDebugName(handle::resource res, char const* name);
+
 public:
     struct resource_node
     {

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -62,6 +62,7 @@ void phi::d3d12::SwapchainPool::destroy()
 
 phi::handle::swapchain phi::d3d12::SwapchainPool::createSwapchain(HWND window_handle, int initial_w, int initial_h, unsigned num_backbuffers, phi::present_mode mode)
 {
+    CC_CONTRACT(initial_w > 0 && initial_h > 0);
     handle::index_t res;
     {
         auto lg = std::lock_guard(mMutex);
@@ -127,6 +128,7 @@ void phi::d3d12::SwapchainPool::free(phi::handle::swapchain handle)
 
 void phi::d3d12::SwapchainPool::onResize(phi::handle::swapchain handle, int w, int h)
 {
+    CC_CONTRACT(w > 0 && h > 0);
     swapchain& node = mPool.get(handle._value);
     node.backbuf_width = w;
     node.backbuf_height = h;

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -146,7 +146,9 @@ void phi::d3d12::SwapchainPool::setFullscreen(phi::handle::swapchain handle, boo
 void phi::d3d12::SwapchainPool::present(phi::handle::swapchain handle)
 {
     swapchain& node = mPool.get(handle._value);
-    PHI_D3D12_VERIFY_FULL(node.swapchain_com->Present(0, node.mode == present_mode::allow_tearing ? DXGI_PRESENT_ALLOW_TEARING : 0), mParentDevice);
+    PHI_D3D12_VERIFY_FULL(node.swapchain_com->Present(node.mode == present_mode::synced ? 1 : 0, //
+                                                      node.mode == present_mode::allow_tearing ? DXGI_PRESENT_ALLOW_TEARING : 0),
+                          mParentDevice);
 
     auto const backbuffer_i = node.swapchain_com->GetCurrentBackBufferIndex();
     node.backbuffers[backbuffer_i].fence.issueFence(*mParentQueue);

--- a/src/phantasm-hardware-interface/detail/trivial_capped_vector.hh
+++ b/src/phantasm-hardware-interface/detail/trivial_capped_vector.hh
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
 #include <type_traits>
 
 #include <clean-core/assert.hh>
@@ -92,6 +93,15 @@ public:
     }
 
     void clear() { _size = 0; }
+
+public:
+    trivial_capped_vector() = default;
+    trivial_capped_vector(std::initializer_list<T> data)
+    {
+        CC_ASSERT(data.size() <= N && "initializer list too large");
+        std::memcpy(_vals, data.begin(), sizeof(T) * data.size());
+        _size = uint8_t(data.size());
+    }
 
 private:
     T _vals[N];

--- a/src/phantasm-hardware-interface/handles.hh
+++ b/src/phantasm-hardware-interface/handles.hh
@@ -14,6 +14,7 @@ struct abstract_handle
     index_t _value;
     abstract_handle() = default;
     constexpr abstract_handle(index_t val) : _value(val) {}
+    void invalidate() & { _value = null_handle_value; }
     [[nodiscard]] constexpr bool is_valid() const noexcept { return _value != null_handle_value; }
     [[nodiscard]] constexpr bool operator==(abstract_handle rhs) const noexcept { return _value == rhs._value; }
     [[nodiscard]] constexpr bool operator!=(abstract_handle rhs) const noexcept { return _value != rhs._value; }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -393,7 +393,10 @@ void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::accel_struct>
     mPoolAccelStructs.free(as);
 }
 
-void phi::vk::BackendVulkan::setDebugName(phi::handle::resource res, const char* name) { mPoolResources.setDebugName(res, name); }
+void phi::vk::BackendVulkan::setDebugName(phi::handle::resource res, cc::string_view name)
+{
+    mPoolResources.setDebugName(res, name.data(), unsigned(name.length()));
+}
 
 void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
 {

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -393,6 +393,8 @@ void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::accel_struct>
     mPoolAccelStructs.free(as);
 }
 
+void phi::vk::BackendVulkan::setDebugName(phi::handle::resource res, const char* name) { mPoolResources.setDebugName(res, name); }
+
 void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
 {
     PHI_LOG << "Inspecting resource " << res._value;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -209,6 +209,7 @@ public:
     // Debug interface
     //
 
+    void setDebugName(handle::resource res, const char *name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -65,19 +65,21 @@ public:
     // Resource interface
     //
 
-    [[nodiscard]] handle::resource createTexture(phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav) override
+    [[nodiscard]] handle::resource createTexture(
+        phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override
     {
-        return mPoolResources.createTexture(format, static_cast<unsigned>(size.width), static_cast<unsigned>(size.height), mips, dim, depth_or_array_size, allow_uav);
+        return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
     }
 
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const*) override
+    [[nodiscard]] handle::resource createRenderTarget(
+        phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const* = nullptr, char const* debug_name = nullptr) override
     {
-        return mPoolResources.createRenderTarget(format, static_cast<unsigned>(size.width), static_cast<unsigned>(size.height), samples, array_size);
+        return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, debug_name);
     }
 
-    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav) override
+    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override
     {
-        return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav);
+        return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
     }
 
     [[nodiscard]] handle::resource createUploadBuffer(unsigned size_bytes, unsigned stride_bytes = 0) override

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -209,7 +209,7 @@ public:
     // Debug interface
     //
 
-    void setDebugName(handle::resource res, const char* name) override;
+    void setDebugName(handle::resource res, cc::string_view name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -209,7 +209,7 @@ public:
     // Debug interface
     //
 
-    void setDebugName(handle::resource res, const char *name) override;
+    void setDebugName(handle::resource res, const char* name) override;
     void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -140,7 +140,7 @@ VkPresentModeKHR phi::vk::choose_present_mode(cc::span<const VkPresentModeKHR> a
         preferred = VK_PRESENT_MODE_IMMEDIATE_KHR;
         break;
     case present_mode::synced:
-        preferred = VK_PRESENT_MODE_MAILBOX_KHR;
+        preferred = VK_PRESENT_MODE_FIFO_KHR;
         break;
     }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -292,17 +292,17 @@ void phi::vk::ResourcePool::free(cc::span<const phi::handle::resource> resources
     }
 }
 
-void phi::vk::ResourcePool::setDebugName(phi::handle::resource res, const char* name)
+void phi::vk::ResourcePool::setDebugName(phi::handle::resource res, const char* name, unsigned name_len)
 {
     CC_CONTRACT(name != nullptr);
     auto const& node = internalGet(res);
     if (node.type == resource_node::resource_type::image)
     {
-        util::set_object_name(mDevice, node.image.raw_image, "%s [respool named]", name);
+        util::set_object_name(mDevice, node.image.raw_image, "%*s [respool named]", name_len, name);
     }
     else
     {
-        util::set_object_name(mDevice, node.buffer.raw_buffer, "%s [respool named]", name);
+        util::set_object_name(mDevice, node.buffer.raw_buffer, "%*s [respool named]", name_len, name);
     }
 }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -63,7 +63,8 @@ constexpr char const* vk_get_heap_type_literal(phi::resource_heap heap)
 }
 }
 
-phi::handle::resource phi::vk::ResourcePool::createTexture(format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav)
+phi::handle::resource phi::vk::ResourcePool::createTexture(
+    format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, const char* dbg_name)
 {
     VkImageCreateInfo image_info = {};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -105,12 +106,12 @@ phi::handle::resource phi::vk::ResourcePool::createTexture(format format, unsign
     VmaAllocation res_alloc;
     VkImage res_image;
     PHI_VK_VERIFY_SUCCESS(vmaCreateImage(mAllocator, &image_info, &alloc_info, &res_image, &res_alloc, nullptr));
-    util::set_object_name(mDevice, res_image, "respool texture%s[%u] (%ux%u, %u mips)", vk_get_tex_dim_literal(dim), depth_or_array_size, w, h,
-                          image_info.mipLevels);
+    util::set_object_name(mDevice, res_image, "pool tex%s[%u] %s (%ux%u, %u mips)", vk_get_tex_dim_literal(dim), depth_or_array_size,
+                          dbg_name ? dbg_name : "", w, h, image_info.mipLevels);
     return acquireImage(res_alloc, res_image, format, image_info.mipLevels, image_info.arrayLayers, 1, w, h);
 }
 
-phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size)
+phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, char const* dbg_name)
 {
     VkImageCreateInfo image_info = {};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -146,15 +147,13 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
     VkImage res_image;
     PHI_VK_VERIFY_SUCCESS(vmaCreateImage(mAllocator, &image_info, &alloc_info, &res_image, &res_alloc, nullptr));
 
-    if (phi::is_depth_format(format))
-        util::set_object_name(mDevice, res_image, "respool depth stencil target");
-    else
-        util::set_object_name(mDevice, res_image, "respool render target");
+    util::set_object_name(mDevice, res_image, "pool %s tgt %s (%ux%u, fmt %u)", phi::is_depth_format(format) ? "depth" : "render",
+                          dbg_name ? dbg_name : "", w, h, unsigned(format));
 
     return acquireImage(res_alloc, res_image, format, image_info.mipLevels, image_info.arrayLayers, samples, w, h);
 }
 
-phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav)
+phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name)
 {
     VkBufferCreateInfo buffer_info = {};
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
@@ -178,7 +177,8 @@ phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, u
     VmaAllocation res_alloc;
     VkBuffer res_buffer;
     PHI_VK_VERIFY_SUCCESS(vmaCreateBuffer(mAllocator, &buffer_info, &alloc_info, &res_buffer, &res_alloc, nullptr));
-    util::set_object_name(mDevice, res_buffer, "respool buffer (%uB, %uB stride, %s heap)", unsigned(size_bytes), stride_bytes, vk_get_heap_type_literal(heap));
+    util::set_object_name(mDevice, res_buffer, "pool buf %s (%uB, %uB stride, %s heap)", dbg_name ? dbg_name : "", unsigned(size_bytes), stride_bytes,
+                          vk_get_heap_type_literal(heap));
     return acquireBuffer(res_alloc, res_buffer, buffer_info.usage, size_bytes, stride_bytes, heap);
 }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -66,6 +66,7 @@ constexpr char const* vk_get_heap_type_literal(phi::resource_heap heap)
 phi::handle::resource phi::vk::ResourcePool::createTexture(
     format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, const char* dbg_name)
 {
+    CC_CONTRACT(w > 0 && h > 0);
     VkImageCreateInfo image_info = {};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     image_info.pNext = nullptr;
@@ -113,6 +114,7 @@ phi::handle::resource phi::vk::ResourcePool::createTexture(
 
 phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, char const* dbg_name)
 {
+    CC_CONTRACT(w > 0 && h > 0);
     VkImageCreateInfo image_info = {};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
     image_info.pNext = nullptr;
@@ -155,6 +157,7 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
 
 phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name)
 {
+    CC_CONTRACT(size_bytes > 0);
     VkBufferCreateInfo buffer_info = {};
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
     buffer_info.size = size_bytes;

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -289,6 +289,20 @@ void phi::vk::ResourcePool::free(cc::span<const phi::handle::resource> resources
     }
 }
 
+void phi::vk::ResourcePool::setDebugName(phi::handle::resource res, const char* name)
+{
+    CC_CONTRACT(name != nullptr);
+    auto const& node = internalGet(res);
+    if (node.type == resource_node::resource_type::image)
+    {
+        util::set_object_name(mDevice, node.image.raw_image, "%s [respool named]", name);
+    }
+    else
+    {
+        util::set_object_name(mDevice, node.buffer.raw_buffer, "%s [respool named]", name);
+    }
+}
+
 void phi::vk::ResourcePool::initialize(VkPhysicalDevice physical, VkDevice device, unsigned max_num_resources, unsigned max_num_swapchains)
 {
     mDevice = device;

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -40,6 +40,8 @@ public:
     void free(handle::resource res);
     void free(cc::span<handle::resource const> resources);
 
+    void setDebugName(handle::resource res, char const* name);
+
 public:
     struct resource_node
     {

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -41,7 +41,7 @@ public:
     void free(handle::resource res);
     void free(cc::span<handle::resource const> resources);
 
-    void setDebugName(handle::resource res, char const* name);
+    void setDebugName(handle::resource res, char const* name, unsigned name_len);
 
 public:
     struct resource_node

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -23,13 +23,13 @@ public:
     // frontend-facing API
 
     /// create a 1D, 2D or 3D texture, or a 1D/2D array
-    [[nodiscard]] handle::resource createTexture(format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav);
+    [[nodiscard]] handle::resource createTexture(format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
 
     /// create a render- or depth-stencil target
-    [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples, unsigned array_size);
+    [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, char const* dbg_name);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
-    [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav);
+    [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name);
 
     std::byte* mapBuffer(handle::resource res);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -23,7 +23,8 @@ public:
     // frontend-facing API
 
     /// create a 1D, 2D or 3D texture, or a 1D/2D array
-    [[nodiscard]] handle::resource createTexture(format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
+    [[nodiscard]] handle::resource createTexture(
+        format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
 
     /// create a render- or depth-stencil target
     [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, char const* dbg_name);

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -18,6 +18,7 @@ constexpr VkFormat gc_assumed_backbuffer_format = VK_FORMAT_B8G8R8A8_UNORM;
 
 phi::handle::swapchain phi::vk::SwapchainPool::createSwapchain(const window_handle& window_handle, int initial_w, int initial_h, unsigned num_backbuffers, phi::present_mode mode)
 {
+    CC_CONTRACT(initial_w > 0 && initial_h > 0);
     handle::index_t res;
     {
         auto lg = std::lock_guard(mMutex);
@@ -111,6 +112,7 @@ void phi::vk::SwapchainPool::free(phi::handle::swapchain handle)
 
 void phi::vk::SwapchainPool::onResize(phi::handle::swapchain handle, int w, int h)
 {
+    CC_CONTRACT(w > 0 && h > 0);
     auto& node = mPool.get(handle._value);
     teardownSwapchain(node);
     setupSwapchain(handle, w, h);


### PR DESCRIPTION
- Improve debug object names for resources
    - Add `debug_name` as optional parameter to add custom information on resource creation
    - Add `Backend::setDebugName(handle::resource)` to change the debug name after the fact
- Fix swapchain synced present (use FIFO over Mailbox in Vk, Present(1, -) in d3d12)
- Add asserts about minimum texture, render target, buffer and swapchain sizes to improve error behavior
- Minor changes