### PR TITLE
sRGB format

### DIFF
--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -50,6 +50,7 @@ namespace phi::util
     case format::rgba8i:
     case format::rgba8u:
     case format::rgba8un:
+    case format::rgba8un_srgb:
     case format::bgra8un:
         return 4;
 
@@ -97,6 +98,7 @@ namespace phi::util
     case format::rgba8i:
     case format::rgba8u:
     case format::rgba8un:
+    case format::rgba8un_srgb:
     case format::bgra8un:
         return 4;
 

--- a/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
@@ -82,6 +82,9 @@ namespace phi::d3d12::util
     case af::r8un:
         return DXGI_FORMAT_R8_UNORM;
 
+    case af::rgba8un_srgb:
+        return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+
     case af::bgra8un:
         return DXGI_FORMAT_B8G8R8A8_UNORM;
     case af::b10g11r11uf:

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -162,6 +162,9 @@ enum class format : uint8_t
     rg8un,
     r8un,
 
+    // sRGB formats
+    rgba8un_srgb,
+
     // swizzled and irregular formats
     bgra8un,
     b10g11r11uf,

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -77,7 +77,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::begin_render_pass
         }
         else
         {
-            fb_image_views.push_back(_globals.pool_shader_views->makeImageView(rt.rv));
+            fb_image_views.push_back(_globals.pool_shader_views->makeImageView(rt.rv, false, false));
             fb_image_views_to_clean_up.push_back(fb_image_views.back());
         }
 
@@ -89,7 +89,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::begin_render_pass
     if (begin_rp.depth_target.rv.resource.is_valid())
     {
         // image view
-        fb_image_views.push_back(_globals.pool_shader_views->makeImageView(begin_rp.depth_target.rv));
+        fb_image_views.push_back(_globals.pool_shader_views->makeImageView(begin_rp.depth_target.rv, false, false));
         fb_image_views_to_clean_up.push_back(fb_image_views.back());
 
         // clear val

--- a/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/debug_callback.cc
@@ -39,12 +39,14 @@ namespace
 }
 
 VkBool32 phi::vk::detail::debug_callback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
-                                         VkDebugUtilsMessageTypeFlagsEXT /*type*/,
+                                         VkDebugUtilsMessageTypeFlagsEXT type,
                                          const VkDebugUtilsMessengerCallbackDataEXT* callback_data,
                                          void* /*user_data*/)
 {
     if (severity >= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT)
     {
+        (void)type;
+        // RICH_LOG_IMPL(phi::detail::vulkan_log)("{} message - {}", to_literal(type), to_literal(severity));
         RICH_LOG_IMPL(phi::detail::vulkan_log)("{}", callback_data->pMessage);
         // cc::breakpoint(); // NOTE: setting a breakpoint here sometimes doesn't suffice, this does
     }

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -82,6 +82,9 @@ namespace phi::vk::util
     case bf::r8un:
         return VK_FORMAT_R8_UNORM;
 
+    case bf::rgba8un_srgb:
+        return VK_FORMAT_R8G8B8A8_SRGB;
+
     case bf::bgra8un:
         return VK_FORMAT_B8G8R8A8_UNORM;
     case bf::b10g11r11uf:
@@ -187,6 +190,9 @@ namespace phi::vk::util
         return bf::rg8un;
     case VK_FORMAT_R8_UNORM:
         return bf::r8un;
+
+    case VK_FORMAT_R8G8B8A8_SRGB:
+        return bf::rgba8un_srgb;
 
     case VK_FORMAT_B8G8R8A8_UNORM:
         return bf::bgra8un;

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -84,20 +84,23 @@ phi::handle::resource phi::vk::ResourcePool::createTexture(
     image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
+    // SAMPLED: can be read with a sampler; TRANSFER_DST/SRC: can be copied
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     if (allow_uav)
     {
-        // TODO: Image usage transfer src might deserve its own option, this is coarse
-        // in fact we might want to create a pr::texture_usage enum
-        image_info.usage |= VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        // STORAGE: can be used as a UAV in shaders
+        image_info.usage |= VK_IMAGE_USAGE_STORAGE_BIT;
     }
 
-    image_info.flags = 0;
     image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+
+    // MUTABLE_FORMAT: can be viewed with a different format
+    image_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
 
     if (dim == texture_dimension::t2d && depth_or_array_size == 6)
     {
+        // t2d[6] is likely used as a cubemap
         image_info.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
@@ -36,7 +36,7 @@ public:
 
     [[nodiscard]] VkDescriptorSet get(handle::shader_view sv) const { return mPool.get(sv._value).raw_desc_set; }
 
-    [[nodiscard]] VkImageView makeImageView(resource_view const& sve, bool is_uav = false) const;
+    [[nodiscard]] VkImageView makeImageView(resource_view const& sve, bool is_uav, bool restrict_usage_for_shader) const;
 
 
 private:


### PR DESCRIPTION
- Add `format::rgba8un_srgb` - sampling from textures viewed with this format automatically transforms them to linear colors
- Vulkan: restrict resource usage flags for SRVs/UAVs to prevent conflicts related to this format.