### PR TITLE
Backwards compatibility, no hard discrete queue requirements

### DIFF
--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -156,7 +156,7 @@ public:
     //
 
     /// create a command list handle from a software command buffer
-    [[nodiscard]] virtual handle::command_list recordCommandList(std::byte* buffer, size_t size, queue_type queue = queue_type::direct) = 0;
+    [[nodiscard]] virtual handle::command_list recordCommandList(std::byte const* buffer, size_t size, queue_type queue = queue_type::direct) = 0;
 
     /// destroy the given command list handles
     virtual void discard(cc::span<handle::command_list const> cls) = 0;
@@ -271,7 +271,7 @@ public:
     template <class... Args>
     void freeVariadic(Args... handles)
     {
-        (free(handles), ...);
+        (this->free(handles), ...);
     }
 
     [[nodiscard]] handle::resource createBufferFromInfo(arg::create_buffer_info const& info, char const* debug_name = nullptr);

--- a/src/phantasm-hardware-interface/common/command_reading.hh
+++ b/src/phantasm-hardware-interface/common/command_reading.hh
@@ -82,8 +82,8 @@ public:
 
     struct iterator
     {
-        iterator(std::byte* pos, size_t size)
-          : _pos(reinterpret_cast<cmd::detail::cmd_base*>(pos)), _remaining_size(_pos == nullptr ? 0 : static_cast<int64_t>(size))
+        iterator(std::byte const* pos, size_t size)
+          : _pos(reinterpret_cast<cmd::detail::cmd_base const*>(pos)), _remaining_size(_pos == nullptr ? 0 : static_cast<int64_t>(size))
         {
         }
 
@@ -92,21 +92,21 @@ public:
         iterator& operator++()
         {
             auto const advance = cmd::detail::get_command_size(_pos->s_internal_type);
-            _pos = reinterpret_cast<cmd::detail::cmd_base*>(reinterpret_cast<std::byte*>(_pos) + advance);
+            _pos = reinterpret_cast<cmd::detail::cmd_base const*>(reinterpret_cast<std::byte const*>(_pos) + advance);
             _remaining_size -= advance;
             return *this;
         }
 
-        cmd::detail::cmd_base& operator*() const { return *(_pos); }
+        cmd::detail::cmd_base const& operator*() const { return *(_pos); }
 
     private:
-        cmd::detail::cmd_base* _pos = nullptr;
+        cmd::detail::cmd_base const* _pos = nullptr;
         int64_t _remaining_size = 0;
     };
 
 public:
     command_stream_parser() = default;
-    command_stream_parser(std::byte* buffer, size_t size) : _in_buffer(buffer), _size(buffer == nullptr ? 0 : size) {}
+    command_stream_parser(std::byte const* buffer, size_t size) : _in_buffer(buffer), _size(buffer == nullptr ? 0 : size) {}
 
     void set_buffer(std::byte* buffer, size_t size)
     {
@@ -118,7 +118,7 @@ public:
     iterator_end end() const { return iterator_end(); }
 
 private:
-    std::byte* _in_buffer = nullptr;
+    std::byte const* _in_buffer = nullptr;
     size_t _size = 0;
 };
 }

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -279,7 +279,7 @@ phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState
 
 void phi::d3d12::BackendD3D12::free(phi::handle::pipeline_state ps) { mPoolPSOs.free(ps); }
 
-phi::handle::command_list phi::d3d12::BackendD3D12::recordCommandList(std::byte* buffer, size_t size, queue_type queue)
+phi::handle::command_list phi::d3d12::BackendD3D12::recordCommandList(std::byte const* buffer, size_t size, queue_type queue)
 {
     auto& thread_comp = getCurrentThreadComponent();
     ID3D12GraphicsCommandList5* raw_list5;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -124,7 +124,7 @@ public:
     // Command list interface
     //
 
-    [[nodiscard]] handle::command_list recordCommandList(std::byte* buffer, size_t size, queue_type queue = queue_type::direct) override;
+    [[nodiscard]] handle::command_list recordCommandList(std::byte const* buffer, size_t size, queue_type queue = queue_type::direct) override;
     void discard(cc::span<handle::command_list const> cls) override;
     void submit(cc::span<handle::command_list const> cls,
                 queue_type queue = queue_type::direct,

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -30,7 +30,7 @@ void phi::d3d12::command_list_translator::initialize(
 void phi::d3d12::command_list_translator::destroy() { _thread_local.destroy(); }
 
 void phi::d3d12::command_list_translator::translateCommandList(
-    ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size)
+    ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size)
 {
     _cmd_list = list;
     _current_queue_type = type;

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -44,7 +44,7 @@ struct command_list_translator
     void initialize(ID3D12Device* device, ShaderViewPool* sv_pool, ResourcePool* resource_pool, PipelineStateObjectPool* pso_pool, AccelStructPool* as_pool, QueryPool* query_pool);
     void destroy();
 
-    void translateCommandList(ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size);
+    void translateCommandList(ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size);
 
     void execute(cmd::begin_render_pass const& begin_rp);
 

--- a/src/phantasm-hardware-interface/d3d12/common/sdk_version.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/sdk_version.hh
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <sdkddkver.h>
+
+// Mesh and Amplification shaders were added in Win10 20H1, also known as Win10 2004, codename Vibranium (Vb) (Released May 2020)
+// NOTE: Explicitly do not use NTDDI_WIN10_VB on the right hand as it isn't defined on previous versions
+#if WDK_NTDDI_VERSION >= 0x0A000008
+#define PHI_D3D12_HAS_20H1_FEATURES 1
+#else
+#define PHI_D3D12_HAS_20H1_FEATURES 0
+#endif

--- a/src/phantasm-hardware-interface/d3d12/common/verify.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/verify.cc
@@ -8,6 +8,7 @@
 #include <phantasm-hardware-interface/common/log.hh>
 
 #include "d3d12_sanitized.hh"
+#include "sdk_version.hh"
 #include "shared_com_ptr.hh"
 
 namespace
@@ -62,7 +63,10 @@ char const* get_breadcrumb_op_literal(D3D12_AUTO_BREADCRUMB_OP op)
         PHI_D3D12_BC_SWITCH_RETURN(SETPIPELINESTATE1);
         PHI_D3D12_BC_SWITCH_RETURN(INITIALIZEEXTENSIONCOMMAND);
         PHI_D3D12_BC_SWITCH_RETURN(EXECUTEEXTENSIONCOMMAND);
+#if PHI_D3D12_HAS_20H1_FEATURES
         PHI_D3D12_BC_SWITCH_RETURN(DISPATCHMESH);
+#endif
+
     default:
         return "Unknown Operation";
     }

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -501,7 +501,7 @@ struct rt_clear_value
       : red_or_depth(uint8_t(r * 255)), green_or_stencil(uint8_t(g * 255)), blue(uint8_t(b * 255)), alpha(uint8_t(a * 255))
     {
     }
-    rt_clear_value(float depth, uint8_t stencil) : red_or_depth(uint8_t(depth * 255)), green_or_stencil(stencil) {}
+    rt_clear_value(float depth, uint8_t stencil) : red_or_depth(uint8_t(depth * 255)), green_or_stencil(stencil), blue(0), alpha(0) {}
 
     static rt_clear_value from_uint(uint32_t value)
     {
@@ -511,7 +511,7 @@ struct rt_clear_value
         res.blue = uint8_t(value >> 8);
         res.alpha = uint8_t(value);
         return res;
-    };
+    }
 };
 
 /// blending logic operation a (graphics) handle::pipeline_state performs on its render targets

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -318,7 +318,7 @@ phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(c
 
 void phi::vk::BackendVulkan::free(phi::handle::pipeline_state ps) { mPoolPipelines.free(ps); }
 
-phi::handle::command_list phi::vk::BackendVulkan::recordCommandList(std::byte* buffer, size_t size, queue_type queue)
+phi::handle::command_list phi::vk::BackendVulkan::recordCommandList(std::byte const* buffer, size_t size, queue_type queue)
 {
     // possibly fall back to a direct queue
     queue = mDevice.getQueueTypeOrFallback(queue);

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -121,8 +121,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
         volkLoadDevice(mDevice.getDevice());
 
         print_startup_message(gpu_infos, chosen_index, config, false);
-        PHI_LOG("   compiled with vulkan sdk v{}.{}.{}", VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE), VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
-                VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
+        PHI_LOG("   compiled with vulkan sdk v{}.{}.{}", vkver::major, vkver::minor, vkver::patch);
     }
 
     // Pool init

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -206,8 +206,6 @@ public:
 private:
     void createDebugMessenger();
 
-    VkQueue getQueueByType(queue_type type) const;
-
     struct per_thread_component;
     per_thread_component& getCurrentThreadComponent();
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -116,7 +116,7 @@ public:
     // Command list interface
     //
 
-    [[nodiscard]] handle::command_list recordCommandList(std::byte* buffer, size_t size, queue_type queue = queue_type::direct) override;
+    [[nodiscard]] handle::command_list recordCommandList(std::byte const* buffer, size_t size, queue_type queue = queue_type::direct) override;
     void discard(cc::span<handle::command_list const> cls) override;
 
     void submit(cc::span<handle::command_list const> cls,

--- a/src/phantasm-hardware-interface/vulkan/Device.hh
+++ b/src/phantasm-hardware-interface/vulkan/Device.hh
@@ -23,9 +23,11 @@ public:
     void initialize(vulkan_gpu_info const& device, backend_config const& config);
     void destroy();
 
-    VkQueue getQueueDirect() const { return mQueueDirect; }
-    VkQueue getQueueCompute() const { return mQueueCompute; }
-    VkQueue getQueueCopy() const { return mQueueCopy; }
+    // returns the requested type, or a fallback type if unavailable
+    queue_type getQueueTypeOrFallback(queue_type request) const { return mFallbackQueueTypes[static_cast<uint8_t>(request)]; }
+
+    // reqturns the vulkan queue of the specified type, or the corresponding fallback queue
+    VkQueue getRawQueue(queue_type type) const { return mQueues[static_cast<uint8_t>(type)]; }
 
     int getQueueFamilyDirect() const { return mQueueIndices.direct.family_index; }
     int getQueueFamilyCompute() const { return mQueueIndices.compute.family_index; }
@@ -51,9 +53,8 @@ private:
     VkPhysicalDevice mPhysicalDevice;
     VkDevice mDevice = nullptr;
 
-    VkQueue mQueueDirect = nullptr;
-    VkQueue mQueueCompute = nullptr;
-    VkQueue mQueueCopy = nullptr;
+    VkQueue mQueues[3];
+    phi::queue_type mFallbackQueueTypes[3];
 
     chosen_queues mQueueIndices;
 

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -19,7 +19,7 @@
 #include "resources/transition_barrier.hh"
 
 void phi::vk::command_list_translator::translateCommandList(
-    VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size)
+    VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size)
 {
     _cmd_list = list;
     _cmd_list_handle = list_handle;

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -48,7 +48,7 @@ struct command_list_translator
         _globals.initialize(device, sv_pool, resource_pool, pso_pool, cmd_pool, query_pool, as_pool);
     }
 
-    void translateCommandList(VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte* buffer, size_t buffer_size);
+    void translateCommandList(VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size);
 
     void execute(cmd::begin_render_pass const& begin_rp);
 

--- a/src/phantasm-hardware-interface/vulkan/loader/volk.hh
+++ b/src/phantasm-hardware-interface/vulkan/loader/volk.hh
@@ -6,3 +6,28 @@
 #ifndef VK_VERSION_1_2
 #error "Vulkan version lower than 1.2, update your SDK"
 #endif
+
+namespace phi::vk::vkver
+{
+enum vkver_e
+{
+#ifdef VK_HEADER_VERSION_COMPLETE
+    major = VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE),
+    minor = VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE),
+    patch = VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE),
+#else
+    // older SDKs do not have the full version macro
+    major = 1,
+    minor =
+#ifdef VK_API_VERSION_1_2
+        2,
+#elif defined(VK_API_VERSION_1_1)
+        1,
+#else
+        0,
+#endif
+    patch = VK_HEADER_VERSION
+#endif
+};
+
+}

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -207,7 +207,7 @@ void phi::vk::SwapchainPool::initialize(VkInstance instance, const phi::vk::Devi
     mInstance = instance;
     mDevice = device.getDevice();
     mPhysicalDevice = device.getPhysicalDevice();
-    mPresentQueue = config.present_from_compute_queue ? device.getQueueCompute() : device.getQueueDirect();
+    mPresentQueue = config.present_from_compute_queue ? device.getRawQueue(queue_type::compute) : device.getRawQueue(queue_type::direct);
     mPresentQueueFamilyIndex = config.present_from_compute_queue ? device.getQueueFamilyCompute() : device.getQueueFamilyDirect();
 
     mPool.initialize(config.max_num_swapchains, config.static_allocator);


### PR DESCRIPTION
- D3D12: Fix compilation with Windows SDKs pre-20H1
- Vulkan: Fix compilation with Vulkan SDKs pre-1.2.135
- Vulkan: Remove hard requirements on discrete copy/compute queues
    - now transparently falls back to the main queue, fixing use of ie. integrated GPUs
    - (might need options to query presence of dedicated queues eventually)
- Fix some warnings, make cmdlist buffer arg const