### PR TITLE
Instancing, enum from/to string utilities, DLL Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,17 @@ endif()
 option(PHI_BACKEND_VULKAN "enable Vulkan backend" ON)
 option(PHI_BACKEND_D3D12 "enable DirectX 12 backend" ON)
 
-# If disabled, cmd::debug_marker is ignored
-option(PHI_ENABLE_DEBUG_MARKERS "enable API debug markers" ON)
-
 # Enables PIX detection, marker support and capture forcing
 # requires WinPixEventRuntime.dll to be available to the executable (in the same folder)
 # this dll is included in extern/win32_pix_runtime/bin/ and is automatically copied if enabled
 option(PHI_ENABLE_D3D12_PIX "enable DirectX 12 PIX integration" ON)
+
+# Enables support for surface creation from SDL_Window*
 option(PHI_ENABLE_SDL2 "enable SDL2 integration" ON)
+
+# Enables Optick profiler GPU integration
+# Set GPU scopes via cmd::begin_profile_scope and cmd::end_profile_scope
+option(PHI_ENABLE_OPTICK "enable Optick profiler integration" OFF)
 
 # =========================================
 # post-process options
@@ -91,10 +94,6 @@ target_link_libraries(phantasm-hardware-interface PUBLIC
     rich-log
 )
 
-if (PHI_ENABLE_DEBUG_MARKERS)
-    target_compile_definitions(phantasm-hardware-interface PUBLIC PHI_ENABLE_DEBUG_MARKERS)
-endif()
-
 
 # =========================================
 # set up compile flags
@@ -152,10 +151,20 @@ endif()
 
 if (PHI_ENABLE_SDL2)
     if (NOT TARGET sdl2)
-        message(FATAL_ERROR "[phantasm hardware interface] no target sdl2 found (wrong add_subdirectory order?)")
+        message(FATAL_ERROR "[phantasm hardware interface] PHI_ENABLE_SDL2 is active, but target sdl2 can't be found (wrong add_subdirectory order?)")
     endif()
 
     message(STATUS "[phantasm hardware interface] SDL2 support enabled")
     target_link_libraries(phantasm-hardware-interface PUBLIC sdl2)
     target_compile_definitions(phantasm-hardware-interface PUBLIC PHI_HAS_SDL2)
+endif()
+
+if (PHI_ENABLE_OPTICK)
+    if (NOT TARGET OptickCore)
+        message(FATAL_ERROR "[phantasm hardware interface] PHI_ENABLE_OPTICK is active, but target OptickCore can't be found (wrong add_subdirectory order?)")
+    endif()
+    
+    message(STATUS "[phantasm hardware interface] Optick support enabled")
+    target_link_libraries(phantasm-hardware-interface PUBLIC OptickCore)
+    target_compile_definitions(phantasm-hardware-interface PUBLIC PHI_HAS_OPTICK)
 endif()

--- a/src/phantasm-hardware-interface/Backend.cc
+++ b/src/phantasm-hardware-interface/Backend.cc
@@ -44,9 +44,26 @@ phi::handle::resource phi::Backend::createRenderTarget(
     return createTexture(desc, debug_name);
 }
 
-phi::handle::resource phi::Backend::createBufferFromInfo(const phi::arg::buffer_description& info, const char* debug_name)
+phi::handle::resource phi::Backend::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name)
 {
-    return createBuffer(info.size_bytes, info.stride_bytes, info.heap, info.allow_uav, debug_name);
+    arg::buffer_description desc = {};
+    desc.size_bytes = size_bytes;
+    desc.stride_bytes = stride_bytes;
+    desc.heap = heap;
+    desc.allow_uav = allow_uav;
+
+    return createBuffer(desc, debug_name);
+}
+
+phi::handle::resource phi::Backend::createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes, char const* debug_name)
+{
+    arg::buffer_description desc = {};
+    desc.size_bytes = size_bytes;
+    desc.stride_bytes = stride_bytes;
+    desc.heap = resource_heap::upload;
+    desc.allow_uav = false;
+
+    return createBuffer(desc, debug_name);
 }
 
 phi::handle::resource phi::Backend::createResourceFromInfo(const phi::arg::resource_description& info, const char* debug_name)
@@ -56,7 +73,7 @@ phi::handle::resource phi::Backend::createResourceFromInfo(const phi::arg::resou
     case arg::resource_description::e_resource_texture:
         return createTexture(info.info_texture, debug_name);
     case arg::resource_description::e_resource_buffer:
-        return createBufferFromInfo(info.info_buffer, debug_name);
+        return createBuffer(info.info_buffer, debug_name);
     default:
         CC_ASSERT(false && "invalid type");
         return handle::null_resource;

--- a/src/phantasm-hardware-interface/Backend.cc
+++ b/src/phantasm-hardware-interface/Backend.cc
@@ -1,31 +1,61 @@
 #include "Backend.hh"
 
+#include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
+
 #include <phantasm-hardware-interface/arguments.hh>
 
-phi::handle::resource phi::Backend::createBufferFromInfo(const phi::arg::create_buffer_info& info, const char* debug_name)
+phi::handle::resource phi::Backend::createTexture(
+    phi::format format, tg::isize2 size, uint32_t mips, texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, char const* debug_name)
+{
+    arg::texture_description desc = {};
+    desc.fmt = format;
+    desc.dim = dim;
+    desc.usage = allow_uav ? resource_usage_flags::allow_uav : 0;
+    desc.width = size.width;
+    desc.height = size.height;
+    desc.depth_or_array_size = depth_or_array_size;
+    desc.num_mips = mips;
+    desc.num_samples = 1;
+
+    return createTexture(desc, debug_name);
+}
+
+phi::handle::resource phi::Backend::createRenderTarget(
+    phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, rt_clear_value const* optimized_clear_val, char const* debug_name)
+{
+    arg::texture_description desc = {};
+    desc.fmt = format;
+    desc.dim = texture_dimension::t2d;
+    desc.usage = util::is_depth_format(format) ? resource_usage_flags::allow_depth_stencil : resource_usage_flags::allow_render_target;
+    desc.width = size.width;
+    desc.height = size.height;
+    desc.depth_or_array_size = array_size;
+    desc.num_mips = 1;
+    desc.num_samples = samples;
+
+    if (optimized_clear_val)
+    {
+        desc.usage |= resource_usage_flags::use_optimized_clear_value;
+        desc.optimized_clear_value = util::pack_rgba8(optimized_clear_val->red_or_depth, optimized_clear_val->green_or_stencil,
+                                                      optimized_clear_val->blue, optimized_clear_val->alpha);
+    }
+
+    return createTexture(desc, debug_name);
+}
+
+phi::handle::resource phi::Backend::createBufferFromInfo(const phi::arg::buffer_description& info, const char* debug_name)
 {
     return createBuffer(info.size_bytes, info.stride_bytes, info.heap, info.allow_uav, debug_name);
 }
 
-phi::handle::resource phi::Backend::createRenderTargetFromInfo(const phi::arg::create_render_target_info& info, const char* debug_name)
-{
-    return createRenderTarget(info.format, {info.width, info.height}, info.num_samples, info.array_size, &info.clear_value, debug_name);
-}
-
-phi::handle::resource phi::Backend::createTextureFromInfo(const phi::arg::create_texture_info& info, const char* debug_name)
-{
-    return createTexture(info.fmt, {info.width, info.height}, info.num_mips, info.dim, info.depth_or_array_size, info.allow_uav, debug_name);
-}
-
-phi::handle::resource phi::Backend::createResourceFromInfo(const phi::arg::create_resource_info& info, const char* debug_name)
+phi::handle::resource phi::Backend::createResourceFromInfo(const phi::arg::resource_description& info, const char* debug_name)
 {
     switch (info.type)
     {
-    case arg::create_resource_info::e_resource_render_target:
-        return createRenderTargetFromInfo(info.info_render_target, debug_name);
-    case arg::create_resource_info::e_resource_texture:
-        return createTextureFromInfo(info.info_texture, debug_name);
-    case arg::create_resource_info::e_resource_buffer:
+    case arg::resource_description::e_resource_texture:
+        return createTexture(info.info_texture, debug_name);
+    case arg::resource_description::e_resource_buffer:
         return createBufferFromInfo(info.info_buffer, debug_name);
     default:
         CC_ASSERT(false && "invalid type");

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -124,6 +124,12 @@ public:
                                                                bool usage_compute = false)
         = 0;
 
+    //  [[nodiscard]] virtual handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute = false) = 0;
+
+    //    virtual void writeShaderViewResource(handle::shader_view sv, resource_view const& resview, uint32_t index) = 0;
+
+    //  virtual void writeShaderViewSampler(handle::shader_view sv, sampler_config const& sampler, uint32_t index) = 0;
+
     virtual void free(handle::shader_view sv) = 0;
 
     virtual void freeRange(cc::span<handle::shader_view const> svs) = 0;

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -39,16 +39,11 @@ public:
     virtual void free(handle::swapchain sc) = 0;
 
     /// acquire the next available backbuffer on the given swapchain
-    /// blocks on CPU until a backbuffer is available
     /// if the returned handle is handle::null_resource, the current frame must be discarded
     /// can cause an internal resize on the swapchain
-    [[nodiscard]] virtual handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) = 0;
+    [[nodiscard]] virtual handle::resource acquireBackbuffer(handle::swapchain sc) = 0;
 
-    /// wait on CPU until a previously acquired backbuffer is ready
-    /// use with acquireBackbuffer, waitOnCPU = false
-    virtual void waitOnBackbuffer(handle::swapchain sc) = 0;
-
-    /// attempts to present on the swapchain
+    /// attempts to present on the swapchain (blocking)
     /// can fail and cause an internal resize
     virtual void present(handle::swapchain sc) = 0;
 

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -74,12 +74,7 @@ public:
     [[nodiscard]] virtual handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) = 0;
 
     /// create a buffer with optional element stride, allocation on an upload/readback heap, or allowing UAV access
-    [[nodiscard]] virtual handle::resource createBuffer(
-        uint32_t size_bytes, uint32_t stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false, char const* debug_name = nullptr)
-        = 0;
-
-    /// create a buffer with optional element stride on resource_heap::upload (shorthand function)
-    [[nodiscard]] virtual handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) = 0;
+    [[nodiscard]] virtual handle::resource createBuffer(arg::buffer_description const& info, char const* debug_name = nullptr) = 0;
 
     /// maps a buffer created on resource_heap::upload or ::readback to CPU-accessible memory and returns a pointer
     /// multiple (nested) maps are allowed, leaving a resource_heap::upload buffer persistently mapped is valid
@@ -293,7 +288,14 @@ public:
                                                       rt_clear_value const* optimized_clear_val = nullptr,
                                                       char const* debug_name = nullptr);
 
-    [[nodiscard]] handle::resource createBufferFromInfo(arg::buffer_description const& info, char const* debug_name = nullptr);
+
+    /// create a buffer with optional element stride, allocation on an upload/readback heap, or allowing UAV access
+    [[nodiscard]] handle::resource createBuffer(
+        uint32_t size_bytes, uint32_t stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false, char const* debug_name = nullptr);
+
+    /// create a buffer with optional element stride on resource_heap::upload (shorthand function)
+    [[nodiscard]] handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr);
+
     [[nodiscard]] handle::resource createResourceFromInfo(arg::resource_description const& info, char const* debug_name = nullptr);
 
     Backend(Backend const&) = delete;

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -147,16 +147,21 @@ public:
                                                                      arg::shader_arg_shapes shader_arg_shapes,
                                                                      bool has_root_constants,
                                                                      arg::graphics_shaders shaders,
-                                                                     phi::pipeline_config const& primitive_config)
+                                                                     phi::pipeline_config const& primitive_config,
+                                                                     char const* debug_name = nullptr)
         = 0;
 
     /// create a graphics pipeline state from a compact description struct
-    [[nodiscard]] virtual handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description) = 0;
+    [[nodiscard]] virtual handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) = 0;
 
-    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes, arg::shader_binary shader, bool has_root_constants = false)
+    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
+                                                                            arg::shader_binary shader,
+                                                                            bool has_root_constants = false,
+                                                                            char const* debug_name = nullptr)
         = 0;
 
-    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description) = 0;
+    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr)
+        = 0;
 
     virtual void free(handle::pipeline_state ps) = 0;
 

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -67,26 +67,11 @@ public:
     // Resource interface
     //
 
-    /// create a 1D, 2D or 3D texture, or a 1D/2D array
+    /// create a 1D, 2D or 3D texture, or a 1D/2D texture array
+    /// for render- or depth targets, set the allow_render_target / allow_depth_stencil usage flags
+    /// for UAV usage, set the allow_uav usage flag
     /// if mips is 0, the maximum amount will be used
-    /// if the texture will be used as a UAV, allow_uav must be true
-    [[nodiscard]] virtual handle::resource createTexture(phi::format format,
-                                                         tg::isize2 size,
-                                                         uint32_t mips,
-                                                         texture_dimension dim = texture_dimension::t2d,
-                                                         uint32_t depth_or_array_size = 1,
-                                                         bool allow_uav = false,
-                                                         char const* debug_name = nullptr)
-        = 0;
-
-    /// create a [multisampled] 2D render- or depth-stencil target
-    [[nodiscard]] virtual handle::resource createRenderTarget(phi::format format,
-                                                              tg::isize2 size,
-                                                              uint32_t samples = 1,
-                                                              uint32_t array_size = 1,
-                                                              rt_clear_value const* optimized_clear_val = nullptr,
-                                                              char const* debug_name = nullptr)
-        = 0;
+    [[nodiscard]] virtual handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) = 0;
 
     /// create a buffer with optional element stride, allocation on an upload/readback heap, or allowing UAV access
     [[nodiscard]] virtual handle::resource createBuffer(
@@ -152,7 +137,8 @@ public:
         = 0;
 
     /// create a graphics pipeline state from a compact description struct
-    [[nodiscard]] virtual handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) = 0;
+    [[nodiscard]] virtual handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_description const& description, char const* debug_name = nullptr)
+        = 0;
 
     [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
                                                                             arg::shader_binary shader,
@@ -160,7 +146,7 @@ public:
                                                                             char const* debug_name = nullptr)
         = 0;
 
-    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr)
+    [[nodiscard]] virtual handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_description const& description, char const* debug_name = nullptr)
         = 0;
 
     virtual void free(handle::pipeline_state ps) = 0;
@@ -213,7 +199,7 @@ public:
     // Raytracing interface
     //
 
-    [[nodiscard]] virtual handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_desc const& description) = 0;
+    [[nodiscard]] virtual handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_description const& description) = 0;
 
     /// create a bottom level acceleration structure (BLAS) holding geometry elements
     /// out_native_handle receives the value to be written to accel_struct_instance::native_bottom_level_as_handle
@@ -286,10 +272,29 @@ public:
         (this->free(handles), ...);
     }
 
-    [[nodiscard]] handle::resource createBufferFromInfo(arg::create_buffer_info const& info, char const* debug_name = nullptr);
-    [[nodiscard]] handle::resource createRenderTargetFromInfo(arg::create_render_target_info const& info, char const* debug_name = nullptr);
-    [[nodiscard]] handle::resource createTextureFromInfo(arg::create_texture_info const& info, char const* debug_name = nullptr);
-    [[nodiscard]] handle::resource createResourceFromInfo(arg::create_resource_info const& info, char const* debug_name = nullptr);
+
+    /// create a 1D, 2D or 3D texture, or a 1D/2D array
+    /// if mips is 0, the maximum amount will be used
+    /// if the texture will be used as a UAV, allow_uav must be true
+    [[nodiscard]] handle::resource createTexture(phi::format format,
+                                                 tg::isize2 size,
+                                                 uint32_t mips,
+                                                 texture_dimension dim = texture_dimension::t2d,
+                                                 uint32_t depth_or_array_size = 1,
+                                                 bool allow_uav = false,
+                                                 char const* debug_name = nullptr);
+
+
+    /// create a [multisampled] 2D render- or depth-stencil target
+    [[nodiscard]] handle::resource createRenderTarget(phi::format format,
+                                                      tg::isize2 size,
+                                                      uint32_t samples = 1,
+                                                      uint32_t array_size = 1,
+                                                      rt_clear_value const* optimized_clear_val = nullptr,
+                                                      char const* debug_name = nullptr);
+
+    [[nodiscard]] handle::resource createBufferFromInfo(arg::buffer_description const& info, char const* debug_name = nullptr);
+    [[nodiscard]] handle::resource createResourceFromInfo(arg::resource_description const& info, char const* debug_name = nullptr);
 
     Backend(Backend const&) = delete;
     Backend(Backend&&) = delete;

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -4,6 +4,7 @@
 
 #include <typed-geometry/types/size.hh>
 
+#include <phantasm-hardware-interface/common/api.hh>
 #include <phantasm-hardware-interface/fwd.hh>
 #include <phantasm-hardware-interface/types.hh>
 
@@ -15,7 +16,7 @@ enum class backend_type : uint8_t
     vulkan
 };
 
-class Backend
+class PHI_API Backend
 {
 public:
     virtual void initialize(backend_config const& config) = 0;

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -42,7 +42,11 @@ public:
     /// blocks on CPU until a backbuffer is available
     /// if the returned handle is handle::null_resource, the current frame must be discarded
     /// can cause an internal resize on the swapchain
-    [[nodiscard]] virtual handle::resource acquireBackbuffer(handle::swapchain sc) = 0;
+    [[nodiscard]] virtual handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) = 0;
+
+    /// wait on GPU until a previously acquired backbuffer is ready
+    /// use with acquireBackbuffer, waitOnCPU = false
+    virtual void waitOnBackbufferFromGPU(handle::swapchain sc) = 0;
 
     /// attempts to present on the swapchain
     /// can fail and cause an internal resize

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -44,9 +44,9 @@ public:
     /// can cause an internal resize on the swapchain
     [[nodiscard]] virtual handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) = 0;
 
-    /// wait on GPU until a previously acquired backbuffer is ready
+    /// wait on CPU until a previously acquired backbuffer is ready
     /// use with acquireBackbuffer, waitOnCPU = false
-    virtual void waitOnBackbufferFromGPU(handle::swapchain sc) = 0;
+    virtual void waitOnBackbuffer(handle::swapchain sc) = 0;
 
     /// attempts to present on the swapchain
     /// can fail and cause an internal resize

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -258,6 +258,8 @@ public:
 
     virtual backend_type getBackendType() const = 0;
 
+    virtual gpu_info const& getGPUInfo() const = 0;
+
     //
     // Non-virtual utility
     //

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -124,11 +124,14 @@ public:
                                                                bool usage_compute = false)
         = 0;
 
-    //  [[nodiscard]] virtual handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute = false) = 0;
+    // WARNING: This API is subject to change (will have to get more verbose for Vulkan)
+    [[nodiscard]] virtual handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute = false) = 0;
 
-    //    virtual void writeShaderViewResource(handle::shader_view sv, resource_view const& resview, uint32_t index) = 0;
+    virtual void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) = 0;
 
-    //  virtual void writeShaderViewSampler(handle::shader_view sv, sampler_config const& sampler, uint32_t index) = 0;
+    virtual void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs) = 0;
+
+    virtual void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers) = 0;
 
     virtual void free(handle::shader_view sv) = 0;
 

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -32,7 +32,7 @@ public:
     [[nodiscard]] virtual handle::swapchain createSwapchain(window_handle const& window_handle,
                                                             tg::isize2 initial_size,
                                                             present_mode mode = present_mode::synced,
-                                                            unsigned num_backbuffers = 3)
+                                                            uint32_t num_backbuffers = 3)
         = 0;
 
     /// destroy a swapchain
@@ -57,7 +57,7 @@ public:
     virtual format getBackbufferFormat(handle::swapchain sc) const = 0;
 
     /// returns the amount of backbuffers
-    virtual unsigned getNumBackbuffers(handle::swapchain sc) const = 0;
+    virtual uint32_t getNumBackbuffers(handle::swapchain sc) const = 0;
 
     /// Clears pending internal resize events, returns true if the
     /// backbuffer has resized since the last call
@@ -72,9 +72,9 @@ public:
     /// if the texture will be used as a UAV, allow_uav must be true
     [[nodiscard]] virtual handle::resource createTexture(phi::format format,
                                                          tg::isize2 size,
-                                                         unsigned mips,
+                                                         uint32_t mips,
                                                          texture_dimension dim = texture_dimension::t2d,
-                                                         unsigned depth_or_array_size = 1,
+                                                         uint32_t depth_or_array_size = 1,
                                                          bool allow_uav = false,
                                                          char const* debug_name = nullptr)
         = 0;
@@ -82,19 +82,19 @@ public:
     /// create a [multisampled] 2D render- or depth-stencil target
     [[nodiscard]] virtual handle::resource createRenderTarget(phi::format format,
                                                               tg::isize2 size,
-                                                              unsigned samples = 1,
-                                                              unsigned array_size = 1,
+                                                              uint32_t samples = 1,
+                                                              uint32_t array_size = 1,
                                                               rt_clear_value const* optimized_clear_val = nullptr,
                                                               char const* debug_name = nullptr)
         = 0;
 
     /// create a buffer with optional element stride, allocation on an upload/readback heap, or allowing UAV access
     [[nodiscard]] virtual handle::resource createBuffer(
-        unsigned size_bytes, unsigned stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false, char const* debug_name = nullptr)
+        uint32_t size_bytes, uint32_t stride_bytes = 0, resource_heap heap = resource_heap::gpu, bool allow_uav = false, char const* debug_name = nullptr)
         = 0;
 
     /// create a buffer with optional element stride on resource_heap::upload (shorthand function)
-    [[nodiscard]] virtual handle::resource createUploadBuffer(unsigned size_bytes, unsigned stride_bytes = 0, char const* debug_name = nullptr) = 0;
+    [[nodiscard]] virtual handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) = 0;
 
     /// maps a buffer created on resource_heap::upload or ::readback to CPU-accessible memory and returns a pointer
     /// multiple (nested) maps are allowed, leaving a resource_heap::upload buffer persistently mapped is valid
@@ -200,7 +200,7 @@ public:
     // Query interface
     //
 
-    [[nodiscard]] virtual handle::query_range createQueryRange(query_type type, unsigned size) = 0;
+    [[nodiscard]] virtual handle::query_range createQueryRange(query_type type, uint32_t size) = 0;
 
     virtual void free(handle::query_range query_range) = 0;
 
@@ -218,7 +218,7 @@ public:
         = 0;
 
     /// create a top level acceleration structure (TLAS) holding BLAS instances
-    [[nodiscard]] virtual handle::accel_struct createTopLevelAccelStruct(unsigned num_instances, accel_struct_build_flags_t flags) = 0;
+    [[nodiscard]] virtual handle::accel_struct createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags) = 0;
 
     /// receive the native acceleration struct handle to be written to accel_struct_instance::native_bottom_level_as_handle
     [[nodiscard]] virtual uint64_t getAccelStructNativeHandle(handle::accel_struct as) = 0;
@@ -231,7 +231,7 @@ public:
         = 0;
 
     /// write shader table records to memory - usually a mapped buffer
-    virtual void writeShaderTable(std::byte* dest, handle::pipeline_state pso, unsigned stride, arg::shader_table_records records) = 0;
+    virtual void writeShaderTable(std::byte* dest, handle::pipeline_state pso, uint32_t stride, arg::shader_table_records records) = 0;
 
     virtual void free(handle::accel_struct as) = 0;
 

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -37,19 +37,19 @@ public:
 struct vertex_format
 {
     cc::span<vertex_attribute_info const> attributes;
-    unsigned vertex_size_bytes = 0;
+    uint32_t vertex_size_bytes = 0;
 };
 
 /// A shader argument consists of SRVs, UAVs, an optional CBV, and an offset into it
 struct shader_arg_shape
 {
-    unsigned num_srvs = 0;
-    unsigned num_uavs = 0;
-    unsigned num_samplers = 0;
+    uint32_t num_srvs = 0;
+    uint32_t num_uavs = 0;
+    uint32_t num_samplers = 0;
     bool has_cbv = false;
 
 public:
-    constexpr shader_arg_shape(unsigned srvs, unsigned uavs = 0, unsigned samplers = 0, bool cbv = false)
+    constexpr shader_arg_shape(uint32_t srvs, uint32_t uavs = 0, uint32_t samplers = 0, bool cbv = false)
       : num_srvs(srvs), num_uavs(uavs), num_samplers(samplers), has_cbv(cbv)
     {
     }
@@ -100,13 +100,24 @@ struct compute_pipeline_state_desc
 /// an element in a bottom-level acceleration strucutre
 struct blas_element
 {
-    handle::resource vertex_buffer = handle::null_resource;
-    handle::resource index_buffer = handle::null_resource; ///< optional
-    unsigned num_vertices = 0;
-    unsigned num_indices = 0;
-    handle::resource transform_buffer = handle::null_resource; ///< optional
-    unsigned transform_buffer_offset_bytes = 0;
+    /// the vertex buffer containing positions
+    buffer_address vertex_addr;
+    /// amount of vertices to use
+    uint32_t num_vertices = 0;
+    /// the vertex position format
+    /// positions must come first in the vertex struct
     format vertex_pos_format = format::rgb32f;
+
+    /// the index buffer to use, optional
+    buffer_address index_addr;
+    /// amount of indices to read
+    uint32_t num_indices;
+
+    /// location in a buffer containing a 3x4 affine transform matrix (row major), optional
+    buffer_address transform_addr;
+
+    /// if true, the geometry acts as if no any-hit shader is present when hit
+    /// enable wherever possible (can be overriden using flags in TraceRay)
     bool is_opaque = true;
 };
 
@@ -136,7 +147,7 @@ struct raytracing_argument_association
     e_arg_association_target target_type = e_target_identifiable_shader;
     /// order corresponds to the order of exports/hitgroups at PSO creation
     /// NOTE: identifiable shaders are indexed contiguously across libraries, and non-identifiable shaders are skipped
-    flat_vector<unsigned, 16> target_indices;
+    flat_vector<uint32_t, 16> target_indices;
 
     flat_vector<shader_arg_shape, limits::max_shader_arguments> argument_shapes;
     bool has_root_constants = false;
@@ -145,7 +156,7 @@ public:
     void set_target_identifiable() { target_type = e_target_identifiable_shader; }
     void set_target_hitgroup() { target_type = e_target_hitgroup; }
 
-    void add_shader_arg(unsigned num_srvs, unsigned num_uavs, unsigned num_samplers, bool has_cbv)
+    void add_shader_arg(uint32_t num_srvs, uint32_t num_uavs, uint32_t num_samplers, bool has_cbv)
     {
         argument_shapes.push_back(shader_arg_shape{num_srvs, num_uavs, num_samplers, has_cbv});
     }
@@ -168,9 +179,9 @@ struct raytracing_pipeline_state_desc
     cc::span<raytracing_argument_association const> argument_associations;
     cc::span<raytracing_hit_group const> hit_groups;
 
-    unsigned max_recursion = 0;
-    unsigned max_payload_size_bytes = 0;
-    unsigned max_attribute_size_bytes = 0;
+    uint32_t max_recursion = 0;
+    uint32_t max_payload_size_bytes = 0;
+    uint32_t max_attribute_size_bytes = 0;
 };
 
 struct shader_table_record
@@ -185,25 +196,25 @@ struct shader_table_record
     e_table_record_target target_type = e_target_identifiable_shader;
     /// order corresponds to the order of exports/hitgroups at PSO creation
     /// NOTE: identifiable shaders are indexed contiguously across libraries, and non-identifiable shaders are skipped
-    unsigned target_index = 0;
+    uint32_t target_index = 0;
 
     void const* root_arg_data = nullptr; ///< optional, data of the root constant data
-    unsigned root_arg_size_bytes = 0;    ///< size of the root constant data
+    uint32_t root_arg_size_bytes = 0;    ///< size of the root constant data
     flat_vector<shader_argument, limits::max_shader_arguments> shader_arguments;
 
-    void set_shader(unsigned index)
+    void set_shader(uint32_t index)
     {
         target_type = e_target_identifiable_shader;
         target_index = index;
     }
 
-    void set_hitgroup(unsigned index)
+    void set_hitgroup(uint32_t index)
     {
         target_type = e_target_hitgroup;
         target_index = index;
     }
 
-    void add_shader_arg(handle::resource cbv, unsigned cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
+    void add_shader_arg(handle::resource cbv, uint32_t cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
     {
         shader_arguments.push_back(shader_argument{cbv, sv, cbv_off});
     }
@@ -216,13 +227,13 @@ struct create_render_target_info
     phi::format format;
     int width;
     int height;
-    unsigned num_samples;
-    unsigned array_size;
+    uint32_t num_samples;
+    uint32_t array_size;
     rt_clear_value clear_value;
 
 public:
     static create_render_target_info create(
-        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
+        phi::format fmt, tg::isize2 size, uint32_t num_samples = 1, uint32_t array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
     {
         return create_render_target_info{fmt, size.width, size.height, num_samples, array_size, clear_val};
     }
@@ -239,15 +250,15 @@ struct create_texture_info
     bool allow_uav;
     int width;
     int height;
-    unsigned depth_or_array_size;
-    unsigned num_mips;
+    uint32_t depth_or_array_size;
+    uint32_t num_mips;
 
 public:
     static create_texture_info create(phi::format fmt,
                                       tg::isize2 size,
-                                      unsigned num_mips = 1,
+                                      uint32_t num_mips = 1,
                                       phi::texture_dimension dim = phi::texture_dimension::t2d,
-                                      unsigned depth_or_array_size = 1,
+                                      uint32_t depth_or_array_size = 1,
                                       bool allow_uav = false)
     {
         return create_texture_info{fmt, dim, allow_uav, size.width, size.height, depth_or_array_size, num_mips};
@@ -262,13 +273,13 @@ public:
 
 struct create_buffer_info
 {
-    unsigned size_bytes;
-    unsigned stride_bytes;
+    uint32_t size_bytes;
+    uint32_t stride_bytes;
     bool allow_uav;
     phi::resource_heap heap;
 
 public:
-    static create_buffer_info create(unsigned size_bytes, unsigned stride_bytes, phi::resource_heap heap = phi::resource_heap::gpu, bool allow_uav = false)
+    static create_buffer_info create(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap = phi::resource_heap::gpu, bool allow_uav = false)
     {
         return create_buffer_info{size_bytes, stride_bytes, allow_uav, heap};
     }
@@ -322,22 +333,22 @@ public:
     }
 
     static create_resource_info render_target(
-        phi::format fmt, tg::isize2 size, unsigned num_samples = 1, unsigned array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
+        phi::format fmt, tg::isize2 size, uint32_t num_samples = 1, uint32_t array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
     {
         return create(create_render_target_info::create(fmt, size, num_samples, array_size, clear_val));
     }
 
     static create_resource_info texture(phi::format fmt,
                                         tg::isize2 size,
-                                        unsigned num_mips = 1,
+                                        uint32_t num_mips = 1,
                                         phi::texture_dimension dim = phi::texture_dimension::t2d,
-                                        unsigned depth_or_array_size = 1,
+                                        uint32_t depth_or_array_size = 1,
                                         bool allow_uav = false)
     {
         return create(create_texture_info::create(fmt, size, num_mips, dim, depth_or_array_size, allow_uav));
     }
 
-    static create_resource_info buffer(unsigned size_bytes, unsigned stride_bytes, phi::resource_heap heap = phi::resource_heap::gpu, bool allow_uav = false)
+    static create_resource_info buffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap = phi::resource_heap::gpu, bool allow_uav = false)
     {
         return create(create_buffer_info::create(size_bytes, stride_bytes, heap, allow_uav));
     }

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -111,7 +111,7 @@ struct blas_element
     /// the index buffer to use, optional
     buffer_address index_addr;
     /// amount of indices to read
-    uint32_t num_indices;
+    uint32_t num_indices = 0;
 
     /// location in a buffer containing a 3x4 affine transform matrix (row major), optional
     buffer_address transform_addr;

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -290,8 +290,7 @@ struct create_resource_info
 
     e_resource_type type = e_resource_undefined;
 
-    union
-    {
+    union {
         create_render_target_info info_render_target;
         create_texture_info info_texture;
         create_buffer_info info_buffer;

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -239,18 +239,19 @@ struct texture_description
     uint32_t optimized_clear_value;
 
 public:
-    static texture_description create_tex(phi::format fmt,
-                                          tg::isize2 size,
-                                          uint32_t num_mips = 1,
-                                          phi::texture_dimension dim = phi::texture_dimension::t2d,
-                                          uint32_t depth_or_array_size = 1,
-                                          bool allow_uav = false)
+    [[nodiscard]] static texture_description create_tex(phi::format fmt,
+                                                        tg::isize2 size,
+                                                        uint32_t num_mips = 1,
+                                                        phi::texture_dimension dim = phi::texture_dimension::t2d,
+                                                        uint32_t depth_or_array_size = 1,
+                                                        bool allow_uav = false)
     {
         return texture_description{fmt, dim, allow_uav ? resource_usage_flags::allow_uav : 0, size.width, size.height, depth_or_array_size, num_mips,
                                    1u,  0u};
     }
 
-    static texture_description create_rt(phi::format fmt, tg::isize2 size, uint32_t num_samples = 1, uint32_t array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
+    [[nodiscard]] static texture_description create_rt(
+        phi::format fmt, tg::isize2 size, uint32_t num_samples = 1, uint32_t array_size = 1, rt_clear_value clear_val = {0.f, 0.f, 0.f, 1.f})
     {
         arg::texture_description res = {};
         res.fmt = fmt;

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -49,7 +49,7 @@ struct shader_arg_shape
     bool has_cbv = false;
 
 public:
-    shader_arg_shape(unsigned srvs, unsigned uavs = 0, unsigned samplers = 0, bool cbv = false)
+    constexpr shader_arg_shape(unsigned srvs, unsigned uavs = 0, unsigned samplers = 0, bool cbv = false)
       : num_srvs(srvs), num_uavs(uavs), num_samplers(samplers), has_cbv(cbv)
     {
     }
@@ -290,7 +290,8 @@ struct create_resource_info
 
     e_resource_type type = e_resource_undefined;
 
-    union {
+    union
+    {
         create_render_target_info info_render_target;
         create_texture_info info_texture;
         create_buffer_info info_buffer;

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -38,8 +38,10 @@ public:
 
 struct vertex_format
 {
+    // vertex attribute descriptions
     cc::span<vertex_attribute_info const> attributes;
-    uint32_t vertex_size_bytes = 0;
+    // vertex data size in bytes, per vertex buffer (leave at 0 if none)
+    uint32_t vertex_sizes_bytes[limits::max_vertex_buffers] = {};
 };
 
 /// A shader argument consists of SRVs, UAVs, an optional CBV, and an offset into it

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -142,7 +142,7 @@ PHI_DEFINE_CMD(draw)
     handle::pipeline_state pipeline_state = handle::null_pipeline_state;
     handle::resource vertex_buffer = handle::null_resource; // optional
     handle::resource index_buffer = handle::null_resource;  // optional
-    
+
     /// amount of indices drawn (or amount of vertices if no index buffer specified)
     unsigned num_indices = 0;
     /// location of the first index (or first vertex if no index buffer specified)

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -218,9 +218,9 @@ PHI_DEFINE_CMD(draw_indirect)
     handle::pipeline_state pipeline_state = handle::null_pipeline_state;
 
     /// the buffer from which to read arguments, must be in resource_state::indirect_argument
-    handle::resource indirect_argument_buffer = handle::null_resource; 
-    uint32_t argument_buffer_offset_bytes = 0;                         ///< offset in bytes into the argument buffer
-    uint32_t num_arguments = 0;                                        ///< amount of arguments to read from the buffer
+    handle::resource indirect_argument_buffer = handle::null_resource;
+    uint32_t argument_buffer_offset_bytes = 0; ///< offset in bytes into the argument buffer
+    uint32_t num_arguments = 0;                ///< amount of arguments to read from the buffer
 
     handle::resource vertex_buffer = handle::null_resource; ///< optional
     handle::resource index_buffer = handle::null_resource;  ///< optional

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -141,9 +141,11 @@ public:
 
 PHI_DEFINE_CMD(barrier_uav)
 {
-    // Explicitly record UAV barriers on the spot (currently D3D12 only)
+    // Explicitly record UAV barriers on the spot, no tracking
 
-    flat_vector<handle::resource, limits::max_uav_barriers> resources;
+    // If no resources are given, a full UAV barrier is issued
+
+    flat_vector<handle::resource, limits::max_uav_barriers> resources; // optional
 };
 
 

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -554,6 +554,21 @@ PHI_DEFINE_CMD(clear_textures)
     flat_vector<clear_info, 4> clear_ops;
 };
 
+PHI_DEFINE_CMD(code_location_marker)
+{
+    // Mark the code location that currently writes commands, can be viewed in command list translators
+    // no GPU / API effects whatsoever
+
+    char const* function = "NO_DEBUG_LOCATION";
+    char const* file = "NO_DEBUG_LOCATION";
+    int line = 0;
+
+    code_location_marker(char const* func, char const* file, int line) : function(func), file(file), line(line) {}
+};
+
+#define PHI_CMD_CODE_LOCATION() \
+    ::phi::cmd::code_location_marker { __FUNCTION__, __FILE__, __LINE__ }
+
 #undef PHI_DEFINE_CMD
 }
 

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -142,9 +142,13 @@ PHI_DEFINE_CMD(draw)
     handle::pipeline_state pipeline_state = handle::null_pipeline_state;
     handle::resource vertex_buffer = handle::null_resource; // optional
     handle::resource index_buffer = handle::null_resource;  // optional
+    
+    /// amount of indices drawn (or amount of vertices if no index buffer specified)
     unsigned num_indices = 0;
+    /// location of the first index (or first vertex if no index buffer specified)
     unsigned index_offset = 0;
-    unsigned vertex_offset = 0;
+    /// added to the vertex index before indexing into the vertex buffer
+    int vertex_offset = 0;
 
     /// the scissor rectangle to set, none if -1
     /// left, top, right, bottom of the rectangle in absolute pixel values
@@ -152,7 +156,7 @@ PHI_DEFINE_CMD(draw)
 
 public:
     void init(handle::pipeline_state pso, unsigned num_ind, handle::resource vb = handle::null_resource, handle::resource ib = handle::null_resource,
-              unsigned ind_offset = 0, unsigned vert_offset = 0)
+              unsigned ind_offset = 0, int vert_offset = 0)
     {
         pipeline_state = pso;
         num_indices = num_ind;

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -10,6 +10,22 @@
 #include <phantasm-hardware-interface/limits.hh>
 #include <phantasm-hardware-interface/types.hh>
 
+#ifdef PHI_HAS_OPTICK
+namespace Optick
+{
+struct EventDescription;
+}
+
+// create an Optick event name for use with cmd::begin_debug_label
+#define PHI_CREATE_OPTICK_EVENT(VariableName, NameString)                                  \
+    static ::Optick::EventDescription* VariableName = nullptr;                             \
+    if (VariableName == nullptr)                                                           \
+    {                                                                                      \
+        VariableName = ::Optick::EventDescription::Create(NameString, __FILE__, __LINE__); \
+    }                                                                                      \
+    CC_FORCE_SEMICOLON
+#endif
+
 namespace phi
 {
 namespace cmd
@@ -434,9 +450,8 @@ public:
 PHI_DEFINE_CMD(begin_debug_label)
 {
     // Begin a debug label on the cmdlist
-
-    // for diagnostic tools like renderdoc, nsight, gpa, pix
     // close it using cmd::end_debug_label
+    // for diagnostic tools like renderdoc, nsight, gpa, pix
 
     char const* string = "UNLABELED_DEBUG_MARKER";
 
@@ -449,6 +464,22 @@ PHI_DEFINE_CMD(end_debug_label){
     // Close a debug label started with cmd::begin_debug_label
 };
 
+PHI_DEFINE_CMD(begin_profile_scope)
+{
+    // Creates a GPU profile scope on the cmdlist
+    // close it using cmd::end_profile_scope
+    // usage depends on enabled profilers, see CMake options
+
+#ifdef PHI_HAS_OPTICK
+    // point to a manually allocated Optick EventDescription
+    // create one using PHI_CREATE_OPTICK_EVENT(VariableName, NameString)
+    Optick::EventDescription* optick_event = nullptr;
+#endif
+};
+
+PHI_DEFINE_CMD(end_profile_scope){
+    // Close a profile scope started with cmd::begin_profile_scope
+};
 
 PHI_DEFINE_CMD(update_bottom_level)
 {

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -162,11 +162,11 @@ PHI_DEFINE_CMD(draw)
     handle::resource index_buffer = handle::null_resource;  // optional
 
     /// amount of instances to draw
-    unsigned num_instances = 1;
+    uint32_t num_instances = 1;
     /// amount of indices drawn (or amount of vertices if no index buffer specified)
-    unsigned num_indices = 0;
+    uint32_t num_indices = 0;
     /// location of the first index (or first vertex if no index buffer specified)
-    unsigned index_offset = 0;
+    uint32_t index_offset = 0;
     /// added to the vertex index before indexing into the vertex buffer
     int vertex_offset = 0;
 
@@ -175,8 +175,8 @@ PHI_DEFINE_CMD(draw)
     tg::iaabb2 scissor = tg::iaabb2(-1, -1);
 
 public:
-    void init(handle::pipeline_state pso, unsigned num_ind, handle::resource vb = handle::null_resource, handle::resource ib = handle::null_resource,
-              unsigned ind_offset = 0, int vert_offset = 0)
+    void init(handle::pipeline_state pso, uint32_t num_ind, handle::resource vb = handle::null_resource, handle::resource ib = handle::null_resource,
+              uint32_t ind_offset = 0, int vert_offset = 0)
     {
         pipeline_state = pso;
         num_indices = num_ind;
@@ -186,7 +186,7 @@ public:
         vertex_offset = vert_offset;
     }
 
-    void add_shader_arg(handle::resource cbv, unsigned cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
+    void add_shader_arg(handle::resource cbv, uint32_t cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
     {
         shader_arguments.push_back(shader_argument{cbv, sv, cbv_off});
     }
@@ -218,14 +218,14 @@ PHI_DEFINE_CMD(draw_indirect)
     handle::pipeline_state pipeline_state = handle::null_pipeline_state;
 
     handle::resource indirect_argument_buffer = handle::null_resource; ///< the buffer from which to read arguments
-    unsigned argument_buffer_offset_bytes = 0;                         ///< offset in bytes into the argument buffer
-    unsigned num_arguments = 0;                                        ///< amount of arguments to read from the buffer
+    uint32_t argument_buffer_offset_bytes = 0;                         ///< offset in bytes into the argument buffer
+    uint32_t num_arguments = 0;                                        ///< amount of arguments to read from the buffer
 
     handle::resource vertex_buffer = handle::null_resource; ///< optional
     handle::resource index_buffer = handle::null_resource;  ///< optional
 
 public:
-    void add_shader_arg(handle::resource cbv, unsigned cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
+    void add_shader_arg(handle::resource cbv, uint32_t cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
     {
         shader_arguments.push_back(shader_argument{cbv, sv, cbv_off});
     }
@@ -248,12 +248,12 @@ PHI_DEFINE_CMD(dispatch)
     flat_vector<shader_argument, limits::max_shader_arguments> shader_arguments;
     handle::pipeline_state pipeline_state = handle::null_pipeline_state;
 
-    unsigned dispatch_x = 0;
-    unsigned dispatch_y = 0;
-    unsigned dispatch_z = 0;
+    uint32_t dispatch_x = 0;
+    uint32_t dispatch_y = 0;
+    uint32_t dispatch_z = 0;
 
 public:
-    void init(handle::pipeline_state pso, unsigned x, unsigned y = 1, unsigned z = 1)
+    void init(handle::pipeline_state pso, uint32_t x, uint32_t y = 1, uint32_t z = 1)
     {
         pipeline_state = pso;
         dispatch_x = x;
@@ -261,7 +261,7 @@ public:
         dispatch_z = z;
     }
 
-    void add_shader_arg(handle::resource cbv, unsigned cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
+    void add_shader_arg(handle::resource cbv, uint32_t cbv_off = 0, handle::shader_view sv = handle::null_shader_view)
     {
         shader_arguments.push_back(shader_argument{cbv, sv, cbv_off});
     }
@@ -309,17 +309,17 @@ PHI_DEFINE_CMD(copy_texture)
 
     handle::resource source = handle::null_resource;
     handle::resource destination = handle::null_resource;
-    unsigned src_mip_index = 0;    ///< index of the MIP level to read from
-    unsigned src_array_index = 0;  ///< index of the first array element to read from (usually: 0)
-    unsigned dest_mip_index = 0;   ///< index of the MIP level to write to
-    unsigned dest_array_index = 0; ///< index of the first array element to write to (usually: 0)
-    unsigned width = 0;            ///< width of the destination texture (in the specified MIP map and array element(s))
-    unsigned height = 0;           ///< height of the destination texture (in the specified MIP map and array element(s))
-    unsigned num_array_slices = 0; ///< amount of array slices to copy, all other parameters staying equal (usually: 1)
+    uint32_t src_mip_index = 0;    ///< index of the MIP level to read from
+    uint32_t src_array_index = 0;  ///< index of the first array element to read from (usually: 0)
+    uint32_t dest_mip_index = 0;   ///< index of the MIP level to write to
+    uint32_t dest_array_index = 0; ///< index of the first array element to write to (usually: 0)
+    uint32_t width = 0;            ///< width of the destination texture (in the specified MIP map and array element(s))
+    uint32_t height = 0;           ///< height of the destination texture (in the specified MIP map and array element(s))
+    uint32_t num_array_slices = 0; ///< amount of array slices to copy, all other parameters staying equal (usually: 1)
 
 public:
-    void init_symmetric(handle::resource src, handle::resource dest, unsigned width, unsigned height, unsigned mip_index,
-                        unsigned first_array_index = 0, unsigned num_array_slices = 1)
+    void init_symmetric(handle::resource src, handle::resource dest, uint32_t width, uint32_t height, uint32_t mip_index,
+                        uint32_t first_array_index = 0, uint32_t num_array_slices = 1)
     {
         source = src;
         destination = dest;
@@ -340,13 +340,13 @@ PHI_DEFINE_CMD(copy_buffer_to_texture)
     handle::resource source = handle::null_resource;
     handle::resource destination = handle::null_resource;
     size_t source_offset_bytes = 0;
-    unsigned dest_width = 0;       ///< width of the destination texture (in the specified MIP level and array element)
-    unsigned dest_height = 0;      ///< height of the destination texture (in the specified MIP level and array element)
-    unsigned dest_mip_index = 0;   ///< index of the MIP level to copy
-    unsigned dest_array_index = 0; ///< index of the array element to copy (usually: 0)
+    uint32_t dest_width = 0;       ///< width of the destination texture (in the specified MIP level and array element)
+    uint32_t dest_height = 0;      ///< height of the destination texture (in the specified MIP level and array element)
+    uint32_t dest_mip_index = 0;   ///< index of the MIP level to copy
+    uint32_t dest_array_index = 0; ///< index of the array element to copy (usually: 0)
 
 public:
-    void init(handle::resource src, handle::resource dest, unsigned dest_w, unsigned dest_h, size_t src_offset = 0, unsigned dest_mip_i = 0, unsigned dest_arr_i = 0)
+    void init(handle::resource src, handle::resource dest, uint32_t dest_w, uint32_t dest_h, size_t src_offset = 0, uint32_t dest_mip_i = 0, uint32_t dest_arr_i = 0)
     {
         source = src;
         destination = dest;
@@ -365,13 +365,13 @@ PHI_DEFINE_CMD(copy_texture_to_buffer)
     handle::resource source = handle::null_resource;
     handle::resource destination = handle::null_resource;
     size_t dest_offset = 0;
-    unsigned src_width = 0;       ///< width of the source texture (in the specified MIP level and array element)
-    unsigned src_height = 0;      ///< height of the destination texture (in the specified MIP level and array element)
-    unsigned src_mip_index = 0;   ///< index of the MIP level to copy
-    unsigned src_array_index = 0; ///< index of the array element to copy (usually: 0)
+    uint32_t src_width = 0;       ///< width of the source texture (in the specified MIP level and array element)
+    uint32_t src_height = 0;      ///< height of the destination texture (in the specified MIP level and array element)
+    uint32_t src_mip_index = 0;   ///< index of the MIP level to copy
+    uint32_t src_array_index = 0; ///< index of the array element to copy (usually: 0)
 
 public:
-    void init(handle::resource src, handle::resource dest, unsigned src_w, unsigned src_h, size_t dest_off = 0, unsigned src_mip_i = 0, unsigned src_arr_i = 0)
+    void init(handle::resource src, handle::resource dest, uint32_t src_w, uint32_t src_h, size_t dest_off = 0, uint32_t src_mip_i = 0, uint32_t src_arr_i = 0)
     {
         source = src;
         destination = dest;
@@ -389,15 +389,15 @@ PHI_DEFINE_CMD(resolve_texture)
 
     handle::resource source = handle::null_resource;      ///< the multisampled source texture
     handle::resource destination = handle::null_resource; ///< the non-multisampled destination texture
-    unsigned src_mip_index = 0;                           ///< index of the MIP level to read from (usually: 0)
-    unsigned src_array_index = 0;                         ///< index of the array element to read from (usually: 0)
-    unsigned dest_mip_index = 0;                          ///< index of the MIP level to write to (usually: 0)
-    unsigned dest_array_index = 0;                        ///< index of the array element to write to (usually: 0)
-    unsigned width = 0;  ///< width of the destination texture (in the specified MIP map and array element) (ignored on d3d12)
-    unsigned height = 0; ///< height of the destination texture (in the specified MIP map and array element) (ignored on d3d12)
+    uint32_t src_mip_index = 0;                           ///< index of the MIP level to read from (usually: 0)
+    uint32_t src_array_index = 0;                         ///< index of the array element to read from (usually: 0)
+    uint32_t dest_mip_index = 0;                          ///< index of the MIP level to write to (usually: 0)
+    uint32_t dest_array_index = 0;                        ///< index of the array element to write to (usually: 0)
+    uint32_t width = 0;  ///< width of the destination texture (in the specified MIP map and array element) (ignored on d3d12)
+    uint32_t height = 0; ///< height of the destination texture (in the specified MIP map and array element) (ignored on d3d12)
 
 public:
-    void init_symmetric(handle::resource src, handle::resource dest, unsigned width, unsigned height, unsigned mip_index = 0, unsigned array_index = 0)
+    void init_symmetric(handle::resource src, handle::resource dest, uint32_t width, uint32_t height, uint32_t mip_index = 0, uint32_t array_index = 0)
     {
         source = src;
         destination = dest;
@@ -417,11 +417,11 @@ PHI_DEFINE_CMD(write_timestamp)
     // see cmd::resolve_queries to receive the data afterwards
 
     handle::query_range query_range = handle::null_query_range; ///< the query_range in which to write a timestamp query
-    unsigned index = 0;                                         ///< relative index into the query_range, element to write to
+    uint32_t index = 0;                                         ///< relative index into the query_range, element to write to
 
 public:
     write_timestamp() = default;
-    write_timestamp(handle::query_range qr, unsigned index = 0) : query_range(qr), index(index) {}
+    write_timestamp(handle::query_range qr, uint32_t index = 0) : query_range(qr), index(index) {}
 };
 
 PHI_DEFINE_CMD(resolve_queries)
@@ -434,12 +434,12 @@ PHI_DEFINE_CMD(resolve_queries)
 
     handle::resource dest_buffer = handle::null_resource;           ///< the buffer in which to write the resolve data
     handle::query_range src_query_range = handle::null_query_range; ///< the query_range from which to read
-    unsigned query_start = 0;                                       ///< relative index into the query_range, element to start the resolve from
-    unsigned num_queries = 1;                                       ///< amount of elements to resolve
-    unsigned dest_offset_bytes = 0;                                 ///< offset into the destination buffer
+    uint32_t query_start = 0;                                       ///< relative index into the query_range, element to start the resolve from
+    uint32_t num_queries = 1;                                       ///< amount of elements to resolve
+    uint32_t dest_offset_bytes = 0;                                 ///< offset into the destination buffer
 
 public:
-    void init(handle::resource dest, handle::query_range qr, unsigned start = 0, unsigned num = 1, unsigned dest_offset = 0)
+    void init(handle::resource dest, handle::query_range qr, uint32_t start = 0, uint32_t num = 1, uint32_t dest_offset = 0)
     {
         dest_buffer = dest;
         src_query_range = qr;
@@ -502,11 +502,10 @@ PHI_DEFINE_CMD(update_top_level)
     // filling it with instances of bottom level accel structs (BLAS)
 
     /// amount of instances to write
-    unsigned num_instances = 0;
+    uint32_t num_instances = 0;
 
     /// a buffer holding an array of accel_struct_instance structs (at least num_instances)
-    handle::resource source_buffer_instances = handle::null_resource;
-    unsigned source_buffer_offset_bytes = 0;
+    buffer_address source_instances_addr;
 
     /// the top level accel struct to update
     handle::accel_struct dest_accel_struct = handle::null_accel_struct;
@@ -524,9 +523,9 @@ PHI_DEFINE_CMD(dispatch_rays)
     buffer_range_and_stride table_hit_groups;
     buffer_range_and_stride table_callable; ///< optional
 
-    unsigned width = 1;
-    unsigned height = 1;
-    unsigned depth = 1;
+    uint32_t dispatch_x = 1;
+    uint32_t dispatch_y = 1;
+    uint32_t dispatch_z = 1;
 
 public:
     void set_strides(shader_table_strides const& strides)

--- a/src/phantasm-hardware-interface/commands.hh
+++ b/src/phantasm-hardware-interface/commands.hh
@@ -143,6 +143,8 @@ PHI_DEFINE_CMD(draw)
     handle::resource vertex_buffer = handle::null_resource; // optional
     handle::resource index_buffer = handle::null_resource;  // optional
     
+    /// amount of instances to draw
+    unsigned num_instances = 1;
     /// amount of indices drawn (or amount of vertices if no index buffer specified)
     unsigned num_indices = 0;
     /// location of the first index (or first vertex if no index buffer specified)

--- a/src/phantasm-hardware-interface/common/api.hh
+++ b/src/phantasm-hardware-interface/common/api.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <clean-core/macros.hh>
+
+#ifdef CC_OS_WINDOWS
+
+#ifdef PHI_BUILD_DLL
+
+#ifdef PHI_DLL
+#define PHI_API __declspec(dllexport)
+#else
+#define PHI_API __declspec(dllimport)
+#endif
+
+#else
+#define PHI_API
+#endif
+
+#else
+#define PHI_API
+#endif

--- a/src/phantasm-hardware-interface/common/byte_reader.hh
+++ b/src/phantasm-hardware-interface/common/byte_reader.hh
@@ -33,13 +33,24 @@ struct byte_reader
         return res;
     }
 
-    // in memory: [num] [T] [T] .. x num .. [T]
+    // in memory: [size_t: num] [T] [T] .. x num .. [T]
     template <class T>
     cc::span<T const> read_sized_array()
     {
-        size_t array_size;
-        void const* const res = read_size_and_skip(array_size, sizeof(T));
-        return cc::span{static_cast<T const*>(res), array_size};
+        static_assert(sizeof(T) > 0, "requires complete T");
+        size_t num_elems;
+        void const* const res = read_size_and_skip(num_elems, sizeof(T));
+        return cc::span{static_cast<T const*>(res), num_elems};
+    }
+
+    // in memory: [T] [T] .. x num .. [T]
+    template <class T>
+    cc::span<T const> read_unsized_array(size_t num_elems)
+    {
+        static_assert(sizeof(T) > 0, "requires complete T");
+        auto* const res = head();
+        skip(num_elems * sizeof(T));
+        return cc::span{reinterpret_cast<T const*>(res), num_elems};
     }
 
     void skip(size_t size)

--- a/src/phantasm-hardware-interface/common/byte_util.hh
+++ b/src/phantasm-hardware-interface/common/byte_util.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 namespace phi::util
 {
@@ -46,5 +47,33 @@ template <class T>
 [[nodiscard]] constexpr T align_offset(T offset, size_t alignment)
 {
     return ((offset + (alignment - 1)) & ~(alignment - 1));
+}
+
+inline uint32_t pack_rgba8(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+    uint32_t res = 0;
+    res |= uint32_t(a) << 0;
+    res |= uint32_t(b) << 8;
+    res |= uint32_t(g) << 16;
+    res |= uint32_t(r) << 24;
+    return res;
+}
+
+struct unpacked_rgba_t
+{
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t a;
+};
+
+inline unpacked_rgba_t unpack_rgba8(uint32_t value)
+{
+    unpacked_rgba_t res;
+    res.a = uint8_t((value >> 0) & 0xFF);
+    res.b = uint8_t((value >> 8) & 0xFF);
+    res.g = uint8_t((value >> 16) & 0xFF);
+    res.r = uint8_t((value >> 24) & 0xFF);
+    return res;
 }
 }

--- a/src/phantasm-hardware-interface/common/command_base.hh
+++ b/src/phantasm-hardware-interface/common/command_base.hh
@@ -25,7 +25,8 @@ namespace phi::cmd::detail
     PHI_X(update_bottom_level)     \
     PHI_X(update_top_level)        \
     PHI_X(dispatch_rays)           \
-    PHI_X(clear_textures)
+    PHI_X(clear_textures)          \
+    PHI_X(code_location_marker)
 
 enum class cmd_type : uint8_t
 {

--- a/src/phantasm-hardware-interface/common/command_base.hh
+++ b/src/phantasm-hardware-interface/common/command_base.hh
@@ -8,6 +8,7 @@ namespace phi::cmd::detail
     PHI_X(draw)                    \
     PHI_X(draw_indirect)           \
     PHI_X(dispatch)                \
+    PHI_X(dispatch_indirect)       \
     PHI_X(transition_resources)    \
     PHI_X(barrier_uav)             \
     PHI_X(transition_image_slices) \

--- a/src/phantasm-hardware-interface/common/command_base.hh
+++ b/src/phantasm-hardware-interface/common/command_base.hh
@@ -26,7 +26,9 @@ namespace phi::cmd::detail
     PHI_X(update_top_level)        \
     PHI_X(dispatch_rays)           \
     PHI_X(clear_textures)          \
-    PHI_X(code_location_marker)
+    PHI_X(code_location_marker)    \
+    PHI_X(begin_profile_scope)     \
+    PHI_X(end_profile_scope)
 
 enum class cmd_type : uint8_t
 {

--- a/src/phantasm-hardware-interface/common/container/unique_buffer.hh
+++ b/src/phantasm-hardware-interface/common/container/unique_buffer.hh
@@ -5,9 +5,11 @@
 
 #include <clean-core/bit_cast.hh>
 
+#include <phantasm-hardware-interface/common/api.hh>
+
 namespace phi
 {
-struct unique_buffer
+struct PHI_API unique_buffer
 {
     explicit unique_buffer() = default;
     explicit unique_buffer(size_t size) : _ptr(size > 0 ? static_cast<std::byte*>(std::malloc(size)) : nullptr), _size(size) {}

--- a/src/phantasm-hardware-interface/common/enums_from_string.hh
+++ b/src/phantasm-hardware-interface/common/enums_from_string.hh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstring>
+
+#include <phantasm-hardware-interface/types.hh>
+
+namespace phi
+{
+#define PHI_LIST_PRIMITIVE_TOPOLOGY(X) X(triangles) X(lines) X(points) X(patches)
+#define PHI_LIST_DEPTH_FUNCTION(X) X(none) X(less) X(less_equal) X(greater) X(greater_equal) X(equal) X(not_equal) X(always) X(never)
+#define PHI_LIST_CULL_MODE(X) X(none) X(back) X(front)
+
+
+#define PHI_X_TOSTRING_CASE(Val, ...) \
+    case rf_xlist_enum::Val:          \
+        return #Val;
+
+#define PHI_X_FROMSTRING_IF(Val, ...)   \
+    if (std::strcmp(str, #Val) == 0)    \
+    {                                   \
+        out_value = rf_xlist_enum::Val; \
+        return true;                    \
+    }
+
+// clang-format off
+#define PHI_DECLARE_TOSTRING(FuncName, Type, List)              \
+    [[maybe_unused]] constexpr char const* FuncName(Type value) \
+    {                                                           \
+        using rf_xlist_enum = Type;                             \
+        switch (value)                                          \
+        {                                                       \
+            List(PHI_X_TOSTRING_CASE)                           \
+        default:                                                \
+            return "unknown " #Type;                            \
+        }                                                       \
+    }
+// clang-format on
+
+// clang-format off
+#define PHI_DECLARE_FROMSTRING(FuncName, Type, List)                        \
+    [[maybe_unused]] inline bool FuncName(char const* str, Type& out_value) \
+    {                                                                       \
+        using rf_xlist_enum = Type;                                         \
+        List(PHI_X_FROMSTRING_IF)                                           \
+        return false;                                                       \
+    }
+// clang-format on
+
+PHI_DECLARE_TOSTRING(enum_to_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
+PHI_DECLARE_FROMSTRING(enum_from_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
+
+PHI_DECLARE_TOSTRING(enum_to_string, depth_function, PHI_LIST_DEPTH_FUNCTION);
+PHI_DECLARE_FROMSTRING(enum_from_string, depth_function, PHI_LIST_DEPTH_FUNCTION);
+
+PHI_DECLARE_TOSTRING(enum_to_string, cull_mode, PHI_LIST_CULL_MODE);
+PHI_DECLARE_FROMSTRING(enum_from_string, cull_mode, PHI_LIST_CULL_MODE);
+}

--- a/src/phantasm-hardware-interface/common/enums_from_string.hh
+++ b/src/phantasm-hardware-interface/common/enums_from_string.hh
@@ -2,10 +2,16 @@
 
 #include <cstring>
 
+#include <phantasm-hardware-interface/config.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 namespace phi
 {
+// config enums
+#define PHI_LIST_ADAPTER_PREF(X) X(highest_vram) X(first) X(integrated) X(highest_feature_level) X(explicit_index)
+#define PHI_LIST_VALIDATION_LVL(X) X(off) X(on) X(on_extended) X(on_extended_dred)
+
+// normal enums
 #define PHI_LIST_PRIMITIVE_TOPOLOGY(X) X(triangles) X(lines) X(points) X(patches)
 #define PHI_LIST_DEPTH_FUNCTION(X) X(none) X(less) X(less_equal) X(greater) X(greater_equal) X(equal) X(not_equal) X(always) X(never)
 #define PHI_LIST_CULL_MODE(X) X(none) X(back) X(front)
@@ -46,8 +52,11 @@ namespace phi
     }
 // clang-format on
 
-PHI_DECLARE_TOSTRING(enum_to_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
-PHI_DECLARE_FROMSTRING(enum_from_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
+PHI_DECLARE_TOSTRING(enum_to_string, adapter_preference, PHI_LIST_ADAPTER_PREF);
+PHI_DECLARE_FROMSTRING(enum_from_string, adapter_preference, PHI_LIST_ADAPTER_PREF);
+
+PHI_DECLARE_TOSTRING(enum_to_string, validation_level, PHI_LIST_VALIDATION_LVL);
+PHI_DECLARE_FROMSTRING(enum_from_string, validation_level, PHI_LIST_VALIDATION_LVL);
 
 PHI_DECLARE_TOSTRING(enum_to_string, depth_function, PHI_LIST_DEPTH_FUNCTION);
 PHI_DECLARE_FROMSTRING(enum_from_string, depth_function, PHI_LIST_DEPTH_FUNCTION);

--- a/src/phantasm-hardware-interface/common/enums_from_string.hh
+++ b/src/phantasm-hardware-interface/common/enums_from_string.hh
@@ -58,6 +58,9 @@ PHI_DECLARE_FROMSTRING(enum_from_string, adapter_preference, PHI_LIST_ADAPTER_PR
 PHI_DECLARE_TOSTRING(enum_to_string, validation_level, PHI_LIST_VALIDATION_LVL);
 PHI_DECLARE_FROMSTRING(enum_from_string, validation_level, PHI_LIST_VALIDATION_LVL);
 
+PHI_DECLARE_TOSTRING(enum_to_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
+PHI_DECLARE_FROMSTRING(enum_from_string, primitive_topology, PHI_LIST_PRIMITIVE_TOPOLOGY);
+
 PHI_DECLARE_TOSTRING(enum_to_string, depth_function, PHI_LIST_DEPTH_FUNCTION);
 PHI_DECLARE_FROMSTRING(enum_from_string, depth_function, PHI_LIST_DEPTH_FUNCTION);
 

--- a/src/phantasm-hardware-interface/common/enums_from_string.hh
+++ b/src/phantasm-hardware-interface/common/enums_from_string.hh
@@ -15,6 +15,7 @@ namespace phi
 #define PHI_LIST_PRIMITIVE_TOPOLOGY(X) X(triangles) X(lines) X(points) X(patches)
 #define PHI_LIST_DEPTH_FUNCTION(X) X(none) X(less) X(less_equal) X(greater) X(greater_equal) X(equal) X(not_equal) X(always) X(never)
 #define PHI_LIST_CULL_MODE(X) X(none) X(back) X(front)
+#define PHI_LIST_PRESENT_MODE(X) X(synced) X(synced_2nd_vblank) X(unsynced) X(unsynced_allow_tearing)
 
 
 #define PHI_X_TOSTRING_CASE(Val, ...) \
@@ -66,4 +67,12 @@ PHI_DECLARE_FROMSTRING(enum_from_string, depth_function, PHI_LIST_DEPTH_FUNCTION
 
 PHI_DECLARE_TOSTRING(enum_to_string, cull_mode, PHI_LIST_CULL_MODE);
 PHI_DECLARE_FROMSTRING(enum_from_string, cull_mode, PHI_LIST_CULL_MODE);
+
+PHI_DECLARE_TOSTRING(enum_to_string, present_mode, PHI_LIST_PRESENT_MODE);
+PHI_DECLARE_FROMSTRING(enum_from_string, present_mode, PHI_LIST_PRESENT_MODE);
+
+#undef PHI_X_TOSTRING_CASE
+#undef PHI_X_FROMSTRING_IF
+#undef PHI_DECLARE_TOSTRING
+#undef PHI_DECLARE_FROMSTRING
 }

--- a/src/phantasm-hardware-interface/common/format_info_list.hh
+++ b/src/phantasm-hardware-interface/common/format_info_list.hh
@@ -38,6 +38,9 @@ enum format_property_flags_e
     X(rgba16f, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_FLOAT, VK_FORMAT_R16G16B16A16_SFLOAT, 0x00)                          \
     X(rg16f, 2, 4, efp_none, DXGI_FORMAT_R16G16_FLOAT, VK_FORMAT_R16G16_SFLOAT, 0x00)                                        \
     X(r16f, 1, 2, efp_none, DXGI_FORMAT_R16_FLOAT, VK_FORMAT_R16_SFLOAT, 0x00)                                               \
+    X(rgba16un, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_UNORM, VK_FORMAT_R16G16B16A16_UNORM, 0x00)                          \
+    X(rg16un, 2, 4, efp_none, DXGI_FORMAT_R16G16_UNORM, VK_FORMAT_R16G16_UNORM, 0x00)                                        \
+    X(r16un, 1, 2, efp_none, DXGI_FORMAT_R16_UNORM, VK_FORMAT_R16_UNORM, 0x00)                                               \
     X(rgba8i, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_SINT, VK_FORMAT_R8G8B8A8_SINT, 0x00)                                      \
     X(rg8i, 2, 2, efp_none, DXGI_FORMAT_R8G8_SINT, VK_FORMAT_R8G8_SINT, 0x00)                                                \
     X(r8i, 1, 1, efp_none, DXGI_FORMAT_R8_SINT, VK_FORMAT_R8_SINT, 0x00)                                                     \

--- a/src/phantasm-hardware-interface/common/format_info_list.hh
+++ b/src/phantasm-hardware-interface/common/format_info_list.hh
@@ -93,19 +93,19 @@ enum format_property_flags_e
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                     \
-        return ((Props) & efp_has_depth) != 0;
+        return ((Props)&efp_has_depth) != 0;
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH_STENCIL(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                             \
-        return ((Props) & efp_has_depth_stencil) == efp_has_depth_stencil;
+        return ((Props)&efp_has_depth_stencil) == efp_has_depth_stencil;
 
 #define PHI_FORMAT_INFO_X_IS_BLOCK_COMPRESSED(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                               \
-        return ((Props) & efp_is_bc) != 0;
+        return ((Props)&efp_is_bc) != 0;
 
 #define PHI_FORMAT_INFO_X_IS_SRGB(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                   \
-        return ((Props) & efp_is_srgb) != 0;
+        return ((Props)&efp_is_srgb) != 0;
 
 #define PHI_FORMAT_INFO_X_TO_DXGI(PhiName, NumComps, SizeBytes, Props, DxgiName, ...) \
     case format::PhiName:                                                             \

--- a/src/phantasm-hardware-interface/common/format_info_list.hh
+++ b/src/phantasm-hardware-interface/common/format_info_list.hh
@@ -1,0 +1,102 @@
+#pragma once
+
+namespace phi
+{
+enum format_property_flags
+{
+    efp_none = 0,
+    efp_has_depth = 1 << 0,
+    efp_has_stencil = 1 << 1,
+    efp_is_srgb = 1 << 2,
+    efp_is_bc = 1 << 3, // block compressed
+};
+}
+
+// X(PhiName, NumComps, SizeBytes, Props, DxgiName, VkName, ...)
+#define PHI_FORMAT_INFO_LIST(X)                                                                                                        \
+    X(rgba32f, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_FLOAT, VK_FORMAT_R32G32B32A32_SFLOAT, 0x00)                                   \
+    X(rgb32f, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_FLOAT, VK_FORMAT_R32G32B32_SFLOAT, 0x00)                                          \
+    X(rg32f, 2, 8, efp_none, DXGI_FORMAT_R32G32_FLOAT, VK_FORMAT_R32G32_SFLOAT, 0x00)                                                  \
+    X(r32f, 1, 4, efp_none, DXGI_FORMAT_R32_FLOAT, VK_FORMAT_R32_SFLOAT, 0x00)                                                         \
+    X(rgba32i, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_SINT, VK_FORMAT_R32G32B32A32_SINT, 0x00)                                      \
+    X(rgb32i, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_SINT, VK_FORMAT_R32G32B32_SINT, 0x00)                                             \
+    X(rg32i, 2, 8, efp_none, DXGI_FORMAT_R32G32_SINT, VK_FORMAT_R32G32_SINT, 0x00)                                                     \
+    X(r32i, 1, 4, efp_none, DXGI_FORMAT_R32_SINT, VK_FORMAT_R32_SINT, 0x00)                                                            \
+    X(rgba32u, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_UINT, VK_FORMAT_R32G32B32A32_UINT, 0x00)                                      \
+    X(rgb32u, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_UINT, VK_FORMAT_R32G32B32_UINT, 0x00)                                             \
+    X(rg32u, 2, 8, efp_none, DXGI_FORMAT_R32G32_UINT, VK_FORMAT_R32G32_UINT, 0x00)                                                     \
+    X(r32u, 1, 4, efp_none, DXGI_FORMAT_R32_UINT, VK_FORMAT_R32_UINT, 0x00)                                                            \
+    X(rgba16i, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_SINT, VK_FORMAT_R16G16B16A16_SINT, 0x00)                                       \
+    X(rg16i, 2, 4, efp_none, DXGI_FORMAT_R16G16_SINT, VK_FORMAT_R16G16_SINT, 0x00)                                                     \
+    X(r16i, 1, 2, efp_none, DXGI_FORMAT_R16_SINT, VK_FORMAT_R16_SINT, 0x00)                                                            \
+    X(rgba16u, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_UINT, VK_FORMAT_R16G16B16A16_UINT, 0x00)                                       \
+    X(rg16u, 2, 4, efp_none, DXGI_FORMAT_R16G16_UINT, VK_FORMAT_R16G16_UINT, 0x00)                                                     \
+    X(r16u, 1, 2, efp_none, DXGI_FORMAT_R16_UINT, VK_FORMAT_R16_UINT, 0x00)                                                            \
+    X(rgba16f, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_FLOAT, VK_FORMAT_R16G16B16A16_SFLOAT, 0x00)                                    \
+    X(rg16f, 2, 4, efp_none, DXGI_FORMAT_R16G16_FLOAT, VK_FORMAT_R16G16_SFLOAT, 0x00)                                                  \
+    X(r16f, 1, 2, efp_none, DXGI_FORMAT_R16_FLOAT, VK_FORMAT_R16_SFLOAT, 0x00)                                                         \
+    X(rgba8i, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_SINT, VK_FORMAT_R8G8B8A8_SINT, 0x00)                                                \
+    X(rg8i, 2, 2, efp_none, DXGI_FORMAT_R8G8_SINT, VK_FORMAT_R8G8_SINT, 0x00)                                                          \
+    X(r8i, 1, 1, efp_none, DXGI_FORMAT_R8_SINT, VK_FORMAT_R8_SINT, 0x00)                                                               \
+    X(rgba8u, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UINT, VK_FORMAT_R8G8B8A8_UINT, 0x00)                                                \
+    X(rg8u, 2, 2, efp_none, DXGI_FORMAT_R8G8_UINT, VK_FORMAT_R8G8_UINT, 0x00)                                                          \
+    X(r8u, 1, 1, efp_none, DXGI_FORMAT_R8_UINT, VK_FORMAT_R8_UINT, 0x00)                                                               \
+    X(rgba8un, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, 0x00)                                             \
+    X(rg8un, 2, 2, efp_none, DXGI_FORMAT_R8G8_UNORM, VK_FORMAT_R8G8_UNORM, 0x00)                                                       \
+    X(r8un, 1, 1, efp_none, DXGI_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, 0x00)                                                            \
+    X(rgba8un_srgb, 4, 4, efp_is_srgb, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, VK_FORMAT_R8G8B8A8_SRGB, 0x00)                                 \
+    X(bgra8un, 4, 4, efp_none, DXGI_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_UNORM, 0x00)                                             \
+    X(b10g11r11uf, 3, 4, efp_none, DXGI_FORMAT_R11G11B10_FLOAT, VK_FORMAT_B10G11R11_UFLOAT_PACK32, 0x00)                               \
+    X(r10g10b10a2u, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UINT, VK_FORMAT_A2R10G10B10_UINT_PACK32, 0x00)                             \
+    X(r10g10b10a2un, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UNORM, VK_FORMAT_A2R10G10B10_UNORM_PACK32, 0x00)                          \
+    X(bc1_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC1_UNORM, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, 0x00)                                           \
+    X(bc1_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC1_UNORM_SRGB, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, 0x00)                    \
+    X(bc2_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC2_UNORM, VK_FORMAT_BC2_UNORM_BLOCK, 0x00)                                                \
+    X(bc2_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC2_UNORM_SRGB, VK_FORMAT_BC2_SRGB_BLOCK, 0x00)                         \
+    X(bc3_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC3_UNORM, VK_FORMAT_BC3_UNORM_BLOCK, 0x00)                                                \
+    X(bc3_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC3_UNORM_SRGB, VK_FORMAT_BC3_SRGB_BLOCK, 0x00)                         \
+    X(bc6h_16f, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_SF16, VK_FORMAT_BC6H_SFLOAT_BLOCK, 0x00)                                             \
+    X(bc6h_16uf, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_UF16, VK_FORMAT_BC6H_UFLOAT_BLOCK, 0x00)                                            \
+    X(depth32f, 1, 4, efp_has_depth, DXGI_FORMAT_D32_FLOAT, VK_FORMAT_D32_SFLOAT, 0x00)                                                \
+    X(depth16un, 1, 2, efp_has_depth, DXGI_FORMAT_D16_UNORM, VK_FORMAT_D16_UNORM, 0x00)                                                \
+    X(depth32f_stencil8u, 2, 8, efp_has_depth | efp_has_stencil, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, VK_FORMAT_D32_SFLOAT_S8_UINT, 0x00) \
+    X(depth24un_stencil8u, 2, 4, efp_has_depth | efp_has_stencil, DXGI_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, 0x00)
+
+// view-only formats have a separate xmacro list, because they map to identical formats in vulkan
+// (otherwise the Vulkan -> phi switch would have conflicting labels)
+#define PHI_FORMAT_INFO_LIST_VIEWONLY(X)                                                               \
+    X(r24un_g8t, 1, 0, efp_none, DXGI_FORMAT_R24_UNORM_X8_TYPELESS, VK_FORMAT_D24_UNORM_S8_UINT, 0x00) \
+    X(r24t_g8u, 1, 0, efp_none, DXGI_FORMAT_X24_TYPELESS_G8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, 0x00)
+
+#define PHI_FORMAT_INFO_X_PIXELSIZE(PhiName, NumComps, SizeBytes, ...) \
+    case format::PhiName:                                              \
+        res = SizeBytes;                                               \
+        break;
+
+#define PHI_FORMAT_INFO_X_NUM_COMPS(PhiName, NumComps, ...) \
+    case format::PhiName:                                   \
+        return NumComps;
+
+#define PHI_FORMAT_INFO_X_HAS_DEPTH(PhiName, NumComps, SizeBytes, Props, ...) \
+    case format::PhiName:                                                     \
+        return bool((Props & efp_has_depth) != 0);
+
+#define PHI_FORMAT_INFO_X_HAS_DEPTH_STENCIL(PhiName, NumComps, SizeBytes, Props, ...) \
+    case format::PhiName:                                                             \
+        return bool((Props & efp_has_depth) != 0) && bool((Props & efp_has_stencil) != 0);
+
+#define PHI_FORMAT_INFO_X_TO_DXGI(PhiName, NumComps, SizeBytes, Props, DxgiName, ...) \
+    case format::PhiName:                                                             \
+        return DxgiName;
+
+#define PHI_FORMAT_INFO_X_FROM_DXGI(PhiName, NumComps, SizeBytes, Props, DxgiName, ...) \
+    case DxgiName:                                                                      \
+        return format::PhiName;
+
+#define PHI_FORMAT_INFO_X_TO_VK(PhiName, NumComps, SizeBytes, Props, DxgiName, VkName, ...) \
+    case format::PhiName:                                                                   \
+        return VkName;
+
+#define PHI_FORMAT_INFO_X_FROM_VK(PhiName, NumComps, SizeBytes, Props, DxgiName, VkName, ...) \
+    case VkName:                                                                              \
+        return format::PhiName;

--- a/src/phantasm-hardware-interface/common/format_info_list.hh
+++ b/src/phantasm-hardware-interface/common/format_info_list.hh
@@ -1,72 +1,86 @@
 #pragma once
 
-namespace phi
+namespace phi::format_property_flags
 {
-enum format_property_flags
+enum format_property_flags_e
 {
     efp_none = 0,
     efp_has_depth = 1 << 0,
     efp_has_stencil = 1 << 1,
     efp_is_srgb = 1 << 2,
     efp_is_bc = 1 << 3, // block compressed
+
+    // test masks
+    efp_has_depth_stencil = efp_has_depth | efp_has_stencil
 };
 }
 
 // X(PhiName, NumComps, SizeBytes, Props, DxgiName, VkName, ...)
-#define PHI_FORMAT_INFO_LIST(X)                                                                                                        \
-    X(rgba32f, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_FLOAT, VK_FORMAT_R32G32B32A32_SFLOAT, 0x00)                                   \
-    X(rgb32f, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_FLOAT, VK_FORMAT_R32G32B32_SFLOAT, 0x00)                                          \
-    X(rg32f, 2, 8, efp_none, DXGI_FORMAT_R32G32_FLOAT, VK_FORMAT_R32G32_SFLOAT, 0x00)                                                  \
-    X(r32f, 1, 4, efp_none, DXGI_FORMAT_R32_FLOAT, VK_FORMAT_R32_SFLOAT, 0x00)                                                         \
-    X(rgba32i, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_SINT, VK_FORMAT_R32G32B32A32_SINT, 0x00)                                      \
-    X(rgb32i, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_SINT, VK_FORMAT_R32G32B32_SINT, 0x00)                                             \
-    X(rg32i, 2, 8, efp_none, DXGI_FORMAT_R32G32_SINT, VK_FORMAT_R32G32_SINT, 0x00)                                                     \
-    X(r32i, 1, 4, efp_none, DXGI_FORMAT_R32_SINT, VK_FORMAT_R32_SINT, 0x00)                                                            \
-    X(rgba32u, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_UINT, VK_FORMAT_R32G32B32A32_UINT, 0x00)                                      \
-    X(rgb32u, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_UINT, VK_FORMAT_R32G32B32_UINT, 0x00)                                             \
-    X(rg32u, 2, 8, efp_none, DXGI_FORMAT_R32G32_UINT, VK_FORMAT_R32G32_UINT, 0x00)                                                     \
-    X(r32u, 1, 4, efp_none, DXGI_FORMAT_R32_UINT, VK_FORMAT_R32_UINT, 0x00)                                                            \
-    X(rgba16i, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_SINT, VK_FORMAT_R16G16B16A16_SINT, 0x00)                                       \
-    X(rg16i, 2, 4, efp_none, DXGI_FORMAT_R16G16_SINT, VK_FORMAT_R16G16_SINT, 0x00)                                                     \
-    X(r16i, 1, 2, efp_none, DXGI_FORMAT_R16_SINT, VK_FORMAT_R16_SINT, 0x00)                                                            \
-    X(rgba16u, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_UINT, VK_FORMAT_R16G16B16A16_UINT, 0x00)                                       \
-    X(rg16u, 2, 4, efp_none, DXGI_FORMAT_R16G16_UINT, VK_FORMAT_R16G16_UINT, 0x00)                                                     \
-    X(r16u, 1, 2, efp_none, DXGI_FORMAT_R16_UINT, VK_FORMAT_R16_UINT, 0x00)                                                            \
-    X(rgba16f, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_FLOAT, VK_FORMAT_R16G16B16A16_SFLOAT, 0x00)                                    \
-    X(rg16f, 2, 4, efp_none, DXGI_FORMAT_R16G16_FLOAT, VK_FORMAT_R16G16_SFLOAT, 0x00)                                                  \
-    X(r16f, 1, 2, efp_none, DXGI_FORMAT_R16_FLOAT, VK_FORMAT_R16_SFLOAT, 0x00)                                                         \
-    X(rgba8i, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_SINT, VK_FORMAT_R8G8B8A8_SINT, 0x00)                                                \
-    X(rg8i, 2, 2, efp_none, DXGI_FORMAT_R8G8_SINT, VK_FORMAT_R8G8_SINT, 0x00)                                                          \
-    X(r8i, 1, 1, efp_none, DXGI_FORMAT_R8_SINT, VK_FORMAT_R8_SINT, 0x00)                                                               \
-    X(rgba8u, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UINT, VK_FORMAT_R8G8B8A8_UINT, 0x00)                                                \
-    X(rg8u, 2, 2, efp_none, DXGI_FORMAT_R8G8_UINT, VK_FORMAT_R8G8_UINT, 0x00)                                                          \
-    X(r8u, 1, 1, efp_none, DXGI_FORMAT_R8_UINT, VK_FORMAT_R8_UINT, 0x00)                                                               \
-    X(rgba8un, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, 0x00)                                             \
-    X(rg8un, 2, 2, efp_none, DXGI_FORMAT_R8G8_UNORM, VK_FORMAT_R8G8_UNORM, 0x00)                                                       \
-    X(r8un, 1, 1, efp_none, DXGI_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, 0x00)                                                            \
-    X(rgba8un_srgb, 4, 4, efp_is_srgb, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, VK_FORMAT_R8G8B8A8_SRGB, 0x00)                                 \
-    X(bgra8un, 4, 4, efp_none, DXGI_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_UNORM, 0x00)                                             \
-    X(b10g11r11uf, 3, 4, efp_none, DXGI_FORMAT_R11G11B10_FLOAT, VK_FORMAT_B10G11R11_UFLOAT_PACK32, 0x00)                               \
-    X(r10g10b10a2u, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UINT, VK_FORMAT_A2R10G10B10_UINT_PACK32, 0x00)                             \
-    X(r10g10b10a2un, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UNORM, VK_FORMAT_A2R10G10B10_UNORM_PACK32, 0x00)                          \
-    X(bc1_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC1_UNORM, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, 0x00)                                           \
-    X(bc1_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC1_UNORM_SRGB, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, 0x00)                    \
-    X(bc2_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC2_UNORM, VK_FORMAT_BC2_UNORM_BLOCK, 0x00)                                                \
-    X(bc2_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC2_UNORM_SRGB, VK_FORMAT_BC2_SRGB_BLOCK, 0x00)                         \
-    X(bc3_8un, 4, 0, efp_is_bc, DXGI_FORMAT_BC3_UNORM, VK_FORMAT_BC3_UNORM_BLOCK, 0x00)                                                \
-    X(bc3_8un_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC3_UNORM_SRGB, VK_FORMAT_BC3_SRGB_BLOCK, 0x00)                         \
-    X(bc6h_16f, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_SF16, VK_FORMAT_BC6H_SFLOAT_BLOCK, 0x00)                                             \
-    X(bc6h_16uf, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_UF16, VK_FORMAT_BC6H_UFLOAT_BLOCK, 0x00)                                            \
-    X(depth32f, 1, 4, efp_has_depth, DXGI_FORMAT_D32_FLOAT, VK_FORMAT_D32_SFLOAT, 0x00)                                                \
-    X(depth16un, 1, 2, efp_has_depth, DXGI_FORMAT_D16_UNORM, VK_FORMAT_D16_UNORM, 0x00)                                                \
-    X(depth32f_stencil8u, 2, 8, efp_has_depth | efp_has_stencil, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, VK_FORMAT_D32_SFLOAT_S8_UINT, 0x00) \
-    X(depth24un_stencil8u, 2, 4, efp_has_depth | efp_has_stencil, DXGI_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, 0x00)
+#define PHI_FORMAT_INFO_LIST_REGULAR(X)                                                                                      \
+    X(rgba32f, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_FLOAT, VK_FORMAT_R32G32B32A32_SFLOAT, 0x00)                         \
+    X(rgb32f, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_FLOAT, VK_FORMAT_R32G32B32_SFLOAT, 0x00)                                \
+    X(rg32f, 2, 8, efp_none, DXGI_FORMAT_R32G32_FLOAT, VK_FORMAT_R32G32_SFLOAT, 0x00)                                        \
+    X(r32f, 1, 4, efp_none, DXGI_FORMAT_R32_FLOAT, VK_FORMAT_R32_SFLOAT, 0x00)                                               \
+    X(rgba32i, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_SINT, VK_FORMAT_R32G32B32A32_SINT, 0x00)                            \
+    X(rgb32i, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_SINT, VK_FORMAT_R32G32B32_SINT, 0x00)                                   \
+    X(rg32i, 2, 8, efp_none, DXGI_FORMAT_R32G32_SINT, VK_FORMAT_R32G32_SINT, 0x00)                                           \
+    X(r32i, 1, 4, efp_none, DXGI_FORMAT_R32_SINT, VK_FORMAT_R32_SINT, 0x00)                                                  \
+    X(rgba32u, 4, 16, efp_none, DXGI_FORMAT_R32G32B32A32_UINT, VK_FORMAT_R32G32B32A32_UINT, 0x00)                            \
+    X(rgb32u, 3, 12, efp_none, DXGI_FORMAT_R32G32B32_UINT, VK_FORMAT_R32G32B32_UINT, 0x00)                                   \
+    X(rg32u, 2, 8, efp_none, DXGI_FORMAT_R32G32_UINT, VK_FORMAT_R32G32_UINT, 0x00)                                           \
+    X(r32u, 1, 4, efp_none, DXGI_FORMAT_R32_UINT, VK_FORMAT_R32_UINT, 0x00)                                                  \
+    X(rgba16i, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_SINT, VK_FORMAT_R16G16B16A16_SINT, 0x00)                             \
+    X(rg16i, 2, 4, efp_none, DXGI_FORMAT_R16G16_SINT, VK_FORMAT_R16G16_SINT, 0x00)                                           \
+    X(r16i, 1, 2, efp_none, DXGI_FORMAT_R16_SINT, VK_FORMAT_R16_SINT, 0x00)                                                  \
+    X(rgba16u, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_UINT, VK_FORMAT_R16G16B16A16_UINT, 0x00)                             \
+    X(rg16u, 2, 4, efp_none, DXGI_FORMAT_R16G16_UINT, VK_FORMAT_R16G16_UINT, 0x00)                                           \
+    X(r16u, 1, 2, efp_none, DXGI_FORMAT_R16_UINT, VK_FORMAT_R16_UINT, 0x00)                                                  \
+    X(rgba16f, 4, 8, efp_none, DXGI_FORMAT_R16G16B16A16_FLOAT, VK_FORMAT_R16G16B16A16_SFLOAT, 0x00)                          \
+    X(rg16f, 2, 4, efp_none, DXGI_FORMAT_R16G16_FLOAT, VK_FORMAT_R16G16_SFLOAT, 0x00)                                        \
+    X(r16f, 1, 2, efp_none, DXGI_FORMAT_R16_FLOAT, VK_FORMAT_R16_SFLOAT, 0x00)                                               \
+    X(rgba8i, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_SINT, VK_FORMAT_R8G8B8A8_SINT, 0x00)                                      \
+    X(rg8i, 2, 2, efp_none, DXGI_FORMAT_R8G8_SINT, VK_FORMAT_R8G8_SINT, 0x00)                                                \
+    X(r8i, 1, 1, efp_none, DXGI_FORMAT_R8_SINT, VK_FORMAT_R8_SINT, 0x00)                                                     \
+    X(rgba8u, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UINT, VK_FORMAT_R8G8B8A8_UINT, 0x00)                                      \
+    X(rg8u, 2, 2, efp_none, DXGI_FORMAT_R8G8_UINT, VK_FORMAT_R8G8_UINT, 0x00)                                                \
+    X(r8u, 1, 1, efp_none, DXGI_FORMAT_R8_UINT, VK_FORMAT_R8_UINT, 0x00)                                                     \
+    X(rgba8un, 4, 4, efp_none, DXGI_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_R8G8B8A8_UNORM, 0x00)                                   \
+    X(rg8un, 2, 2, efp_none, DXGI_FORMAT_R8G8_UNORM, VK_FORMAT_R8G8_UNORM, 0x00)                                             \
+    X(r8un, 1, 1, efp_none, DXGI_FORMAT_R8_UNORM, VK_FORMAT_R8_UNORM, 0x00)                                                  \
+    X(rgba8un_srgb, 4, 4, efp_is_srgb, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, VK_FORMAT_R8G8B8A8_SRGB, 0x00)                       \
+    X(bgra8un, 4, 4, efp_none, DXGI_FORMAT_B8G8R8A8_UNORM, VK_FORMAT_B8G8R8A8_UNORM, 0x00)                                   \
+    X(bgra4un, 4, 2, efp_none, DXGI_FORMAT_B4G4R4A4_UNORM, VK_FORMAT_B4G4R4A4_UNORM_PACK16, 0x00)                            \
+    X(b10g11r11uf, 3, 4, efp_none, DXGI_FORMAT_R11G11B10_FLOAT, VK_FORMAT_B10G11R11_UFLOAT_PACK32, 0x00)                     \
+    X(r10g10b10a2u, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UINT, VK_FORMAT_A2R10G10B10_UINT_PACK32, 0x00)                   \
+    X(r10g10b10a2un, 4, 4, efp_none, DXGI_FORMAT_R10G10B10A2_UNORM, VK_FORMAT_A2R10G10B10_UNORM_PACK32, 0x00)                \
+    X(b5g6r5un, 3, 2, efp_none, DXGI_FORMAT_B5G6R5_UNORM, VK_FORMAT_B5G6R5_UNORM_PACK16, 0x00)                               \
+    X(b5g5r5a1un, 4, 2, efp_none, DXGI_FORMAT_B5G5R5A1_UNORM, VK_FORMAT_B5G5R5A1_UNORM_PACK16, 0x00)                         \
+    X(r9g9b9e5_sharedexp_uf, 3, 4, efp_none, DXGI_FORMAT_R9G9B9E5_SHAREDEXP, VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, 0x00)         \
+    X(bc1, 4, 0, efp_is_bc, DXGI_FORMAT_BC1_UNORM, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, 0x00)                                     \
+    X(bc1_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC1_UNORM_SRGB, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, 0x00)              \
+    X(bc2, 4, 0, efp_is_bc, DXGI_FORMAT_BC2_UNORM, VK_FORMAT_BC2_UNORM_BLOCK, 0x00)                                          \
+    X(bc2_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC2_UNORM_SRGB, VK_FORMAT_BC2_SRGB_BLOCK, 0x00)                   \
+    X(bc3, 4, 0, efp_is_bc, DXGI_FORMAT_BC3_UNORM, VK_FORMAT_BC3_UNORM_BLOCK, 0x00)                                          \
+    X(bc3_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC3_UNORM_SRGB, VK_FORMAT_BC3_SRGB_BLOCK, 0x00)                   \
+    X(bc6h_16f, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_SF16, VK_FORMAT_BC6H_SFLOAT_BLOCK, 0x00)                                   \
+    X(bc6h_16uf, 3, 0, efp_is_bc, DXGI_FORMAT_BC6H_UF16, VK_FORMAT_BC6H_UFLOAT_BLOCK, 0x00)                                  \
+    X(bc7, 4, 0, efp_is_bc, DXGI_FORMAT_BC7_UNORM, VK_FORMAT_BC7_UNORM_BLOCK, 0x00)                                          \
+    X(bc7_srgb, 4, 0, efp_is_bc | efp_is_srgb, DXGI_FORMAT_BC7_UNORM_SRGB, VK_FORMAT_BC7_SRGB_BLOCK, 0x00)                   \
+    X(depth32f, 1, 4, efp_has_depth, DXGI_FORMAT_D32_FLOAT, VK_FORMAT_D32_SFLOAT, 0x00)                                      \
+    X(depth16un, 1, 2, efp_has_depth, DXGI_FORMAT_D16_UNORM, VK_FORMAT_D16_UNORM, 0x00)                                      \
+    X(depth32f_stencil8u, 2, 8, efp_has_depth_stencil, DXGI_FORMAT_D32_FLOAT_S8X24_UINT, VK_FORMAT_D32_SFLOAT_S8_UINT, 0x00) \
+    X(depth24un_stencil8u, 2, 4, efp_has_depth_stencil, DXGI_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, 0x00)
 
 // view-only formats have a separate xmacro list, because they map to identical formats in vulkan
 // (otherwise the Vulkan -> phi switch would have conflicting labels)
 #define PHI_FORMAT_INFO_LIST_VIEWONLY(X)                                                               \
     X(r24un_g8t, 1, 0, efp_none, DXGI_FORMAT_R24_UNORM_X8_TYPELESS, VK_FORMAT_D24_UNORM_S8_UINT, 0x00) \
     X(r24t_g8u, 1, 0, efp_none, DXGI_FORMAT_X24_TYPELESS_G8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, 0x00)
+
+#define PHI_FORMAT_INFO_LIST_ALL(X) PHI_FORMAT_INFO_LIST_REGULAR(X) PHI_FORMAT_INFO_LIST_VIEWONLY(X)
+
+//
+// below: X functors to insert into the format lists
 
 #define PHI_FORMAT_INFO_X_PIXELSIZE(PhiName, NumComps, SizeBytes, ...) \
     case format::PhiName:                                              \
@@ -79,11 +93,19 @@ enum format_property_flags
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                     \
-        return bool((Props & efp_has_depth) != 0);
+        return (Props & efp_has_depth) != 0;
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH_STENCIL(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                             \
-        return bool((Props & efp_has_depth) != 0) && bool((Props & efp_has_stencil) != 0);
+        return (Props & efp_has_depth_stencil) == efp_has_depth_stencil;
+
+#define PHI_FORMAT_INFO_X_IS_BLOCK_COMPRESSED(PhiName, NumComps, SizeBytes, Props, ...) \
+    case format::PhiName:                                                               \
+        return (Props & efp_is_bc) != 0;
+
+#define PHI_FORMAT_INFO_X_IS_SRGB(PhiName, NumComps, SizeBytes, Props, ...) \
+    case format::PhiName:                                                   \
+        return (Props & efp_is_srgb) != 0;
 
 #define PHI_FORMAT_INFO_X_TO_DXGI(PhiName, NumComps, SizeBytes, Props, DxgiName, ...) \
     case format::PhiName:                                                             \
@@ -100,3 +122,7 @@ enum format_property_flags
 #define PHI_FORMAT_INFO_X_FROM_VK(PhiName, NumComps, SizeBytes, Props, DxgiName, VkName, ...) \
     case VkName:                                                                              \
         return format::PhiName;
+
+#define PHI_FORMAT_INFO_X_RET_TRUE(PhiName, ...) \
+    case format::PhiName:                        \
+        return true;

--- a/src/phantasm-hardware-interface/common/format_info_list.hh
+++ b/src/phantasm-hardware-interface/common/format_info_list.hh
@@ -93,19 +93,19 @@ enum format_property_flags_e
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                     \
-        return (Props & efp_has_depth) != 0;
+        return ((Props) & efp_has_depth) != 0;
 
 #define PHI_FORMAT_INFO_X_HAS_DEPTH_STENCIL(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                             \
-        return (Props & efp_has_depth_stencil) == efp_has_depth_stencil;
+        return ((Props) & efp_has_depth_stencil) == efp_has_depth_stencil;
 
 #define PHI_FORMAT_INFO_X_IS_BLOCK_COMPRESSED(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                               \
-        return (Props & efp_is_bc) != 0;
+        return ((Props) & efp_is_bc) != 0;
 
 #define PHI_FORMAT_INFO_X_IS_SRGB(PhiName, NumComps, SizeBytes, Props, ...) \
     case format::PhiName:                                                   \
-        return (Props & efp_is_srgb) != 0;
+        return ((Props) & efp_is_srgb) != 0;
 
 #define PHI_FORMAT_INFO_X_TO_DXGI(PhiName, NumComps, SizeBytes, Props, DxgiName, ...) \
     case format::PhiName:                                                             \

--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -179,4 +179,20 @@ namespace phi::util
     return 0;
 }
 
+[[nodiscard]] inline format get_format_srgb_variant(format fmt)
+{
+    switch (fmt)
+    {
+    case format::rgba8un:
+        return format::rgba8un_srgb;
+    case format::bc1_8un:
+        return format::bc1_8un_srgb;
+    case format::bc2_8un:
+        return format::bc2_8un_srgb;
+    case format::bc3_8un:
+        return format::bc3_8un_srgb;
+    default:
+        return fmt;
+    }
+}
 }

--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -8,6 +8,8 @@
 
 namespace phi::util
 {
+/// returns the byte size of a single pixel of a texture in the given format
+/// NOTE: block-compressed formats do not have a per-pixel size, use get_block_format_4x4_size for them instead
 inline unsigned get_format_size_bytes(format fmt)
 {
     unsigned res = 0;
@@ -22,6 +24,7 @@ inline unsigned get_format_size_bytes(format fmt)
     return res;
 }
 
+/// returns the amount of components of a format (ie. RGBA = 4, Depth-Stencil = 2)
 inline unsigned get_format_num_components(format fmt)
 {
     switch (fmt)
@@ -33,6 +36,7 @@ inline unsigned get_format_num_components(format fmt)
     }
 }
 
+/// returns the byte size of a 4x4 pixel square of a texture in the given block-compressed format
 inline unsigned get_block_format_4x4_size(format fmt)
 {
     switch (fmt)
@@ -58,6 +62,7 @@ inline unsigned get_block_format_4x4_size(format fmt)
     }
 }
 
+/// returns the format's sRGB variant if existing, or the format itself otherwise
 inline format get_format_srgb_variant(format fmt)
 {
     switch (fmt)
@@ -73,6 +78,7 @@ inline format get_format_srgb_variant(format fmt)
     case format::bc7:
         return format::bc7_srgb;
     default:
+        // either fmt is already sRGB or no variant exsits
         return fmt;
     }
 }

--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -13,8 +13,7 @@ inline unsigned get_format_size_bytes(format fmt)
     unsigned res = 0;
     switch (fmt)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_PIXELSIZE)
-        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_PIXELSIZE)
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_PIXELSIZE)
     default:
         CC_UNREACHABLE("unknown format");
         break;
@@ -27,8 +26,7 @@ inline unsigned get_format_num_components(format fmt)
 {
     switch (fmt)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_NUM_COMPS)
-        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_NUM_COMPS)
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_NUM_COMPS)
     default:
         CC_UNREACHABLE("unknown format");
         return 0;
@@ -39,16 +37,18 @@ inline unsigned get_block_format_4x4_size(format fmt)
 {
     switch (fmt)
     {
-    case format::bc1_8un:
-    case format::bc1_8un_srgb:
+    case format::bc1:
+    case format::bc1_srgb:
         // BC1 and BC4 cost 8 B per 4x4 pixels
         return 8;
-    case format::bc2_8un:
-    case format::bc2_8un_srgb:
-    case format::bc3_8un:
-    case format::bc3_8un_srgb:
+    case format::bc2:
+    case format::bc2_srgb:
+    case format::bc3:
+    case format::bc3_srgb:
     case format::bc6h_16f:
     case format::bc6h_16uf:
+    case format::bc7:
+    case format::bc7_srgb:
         // BC2, 3, 5, 6H and 7 cost 16 B per 4x4 pixels
         return 16;
 
@@ -58,21 +58,85 @@ inline unsigned get_block_format_4x4_size(format fmt)
     }
 }
 
-
 inline format get_format_srgb_variant(format fmt)
 {
     switch (fmt)
     {
     case format::rgba8un:
         return format::rgba8un_srgb;
-    case format::bc1_8un:
-        return format::bc1_8un_srgb;
-    case format::bc2_8un:
-        return format::bc2_8un_srgb;
-    case format::bc3_8un:
-        return format::bc3_8un_srgb;
+    case format::bc1:
+        return format::bc1_srgb;
+    case format::bc2:
+        return format::bc2_srgb;
+    case format::bc3:
+        return format::bc3_srgb;
+    case format::bc7:
+        return format::bc7_srgb;
     default:
         return fmt;
+    }
+}
+
+/// returns true if the format is a view-only format
+constexpr bool is_view_format(format fmt)
+{
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_RET_TRUE)
+
+    default:
+        return false;
+    }
+}
+
+/// returns true if the format is a block-compressed format
+inline bool is_block_compressed_format(format fmt)
+{
+    using namespace phi::format_property_flags;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_IS_BLOCK_COMPRESSED)
+
+    default:
+        return false;
+    }
+}
+
+/// returns true if the format is a depth OR depth stencil format
+inline bool is_depth_format(format fmt)
+{
+    using namespace phi::format_property_flags;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_HAS_DEPTH)
+
+    default:
+        return false;
+    }
+}
+
+/// returns true if the format is a depth stencil format
+inline bool is_depth_stencil_format(format fmt)
+{
+    using namespace phi::format_property_flags;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_HAS_DEPTH_STENCIL)
+
+    default:
+        return false;
+    }
+}
+
+inline bool is_srgb_format(format fmt)
+{
+    using namespace phi::format_property_flags;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_IS_SRGB)
+
+    default:
+        return false;
     }
 }
 }

--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -72,6 +72,8 @@ namespace phi::util
         return 4;
 
     case format::b10g11r11uf:
+    case format::r10g10b10a2u:
+    case format::r10g10b10a2un:
         return 4;
 
         // NOTE: block-compressed formats do not have per-pixel byte sizes
@@ -134,6 +136,8 @@ namespace phi::util
     case format::rgba8un:
     case format::rgba8un_srgb:
     case format::bgra8un:
+    case format::r10g10b10a2u:
+    case format::r10g10b10a2un:
         return 4;
 
     case format::rgb32f:

--- a/src/phantasm-hardware-interface/common/format_size.hh
+++ b/src/phantasm-hardware-interface/common/format_size.hh
@@ -4,101 +4,38 @@
 
 #include <phantasm-hardware-interface/types.hh>
 
+#include <phantasm-hardware-interface/common/format_info_list.hh>
+
 namespace phi::util
 {
-[[nodiscard]] inline unsigned get_format_size_bytes(format fmt)
+inline unsigned get_format_size_bytes(format fmt)
+{
+    unsigned res = 0;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_PIXELSIZE)
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_PIXELSIZE)
+    default:
+        CC_UNREACHABLE("unknown format");
+        break;
+    }
+    CC_ASSERT(res > 0 && "compressed block formats have no per-pixel byte size, use get_block_format_4x4_size");
+    return res;
+}
+
+inline unsigned get_format_num_components(format fmt)
 {
     switch (fmt)
     {
-    case format::rgba32f:
-    case format::rgba32i:
-    case format::rgba32u:
-        return 16;
-
-    case format::rgb32f:
-    case format::rgb32i:
-    case format::rgb32u:
-        return 12;
-
-    case format::rg32f:
-    case format::rg32i:
-    case format::rg32u:
-        return 8;
-
-    case format::r32f:
-    case format::r32i:
-    case format::r32u:
-    case format::depth32f:
-        return 4;
-
-    case format::rgba16f:
-    case format::rgba16i:
-    case format::rgba16u:
-        return 8;
-
-    case format::rg16f:
-    case format::rg16i:
-    case format::rg16u:
-        return 4;
-
-    case format::r16f:
-    case format::r16i:
-    case format::r16u:
-    case format::depth16un:
-        return 2;
-
-    case format::rgba8i:
-    case format::rgba8u:
-    case format::rgba8un:
-    case format::rgba8un_srgb:
-    case format::bgra8un:
-        return 4;
-
-    case format::rg8i:
-    case format::rg8u:
-    case format::rg8un:
-        return 2;
-
-    case format::r8i:
-    case format::r8u:
-    case format::r8un:
-        return 1;
-
-    case format::depth32f_stencil8u:
-        return 8;
-    case format::depth24un_stencil8u:
-    case format::r24t_g8u:
-    case format::r24un_g8t:
-        return 4;
-
-    case format::b10g11r11uf:
-    case format::r10g10b10a2u:
-    case format::r10g10b10a2un:
-        return 4;
-
-        // NOTE: block-compressed formats do not have per-pixel byte sizes
-        // they cost bytes per NxN square block
-    case format::bc1_8un:
-    case format::bc1_8un_srgb:
-        // BC1 and BC4 cost 8 B per 4x4 pixels
-    case format::bc2_8un:
-    case format::bc2_8un_srgb:
-    case format::bc3_8un:
-    case format::bc3_8un_srgb:
-    case format::bc6h_16f:
-    case format::bc6h_16uf:
-        // BC2, 3, 5, 6H and 7 cost 16 B per 4x4 pixels
-        CC_UNREACHABLE("compressed block format has no per-pixel byte size");
-        return 0;
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_NUM_COMPS)
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_NUM_COMPS)
     default:
         CC_UNREACHABLE("unknown format");
         return 0;
     }
-    CC_UNREACHABLE("unknown format");
-    return 0;
 }
 
-[[nodiscard]] inline unsigned get_block_format_4x4_size(format fmt)
+inline unsigned get_block_format_4x4_size(format fmt)
 {
     switch (fmt)
     {
@@ -121,69 +58,8 @@ namespace phi::util
     }
 }
 
-[[nodiscard]] inline unsigned get_format_num_components(format fmt)
-{
-    switch (fmt)
-    {
-    case format::rgba32f:
-    case format::rgba32i:
-    case format::rgba32u:
-    case format::rgba16f:
-    case format::rgba16i:
-    case format::rgba16u:
-    case format::rgba8i:
-    case format::rgba8u:
-    case format::rgba8un:
-    case format::rgba8un_srgb:
-    case format::bgra8un:
-    case format::r10g10b10a2u:
-    case format::r10g10b10a2un:
-        return 4;
 
-    case format::rgb32f:
-    case format::rgb32i:
-    case format::rgb32u:
-    case format::b10g11r11uf:
-    case format::bc6h_16f:
-    case format::bc6h_16uf:
-        return 3;
-
-    case format::rg32f:
-    case format::rg32i:
-    case format::rg32u:
-    case format::rg16f:
-    case format::rg16i:
-    case format::rg16u:
-    case format::rg8i:
-    case format::rg8u:
-    case format::rg8un:
-    case format::depth32f_stencil8u:
-    case format::depth24un_stencil8u:
-        return 2;
-
-    case format::r32f:
-    case format::r32i:
-    case format::r32u:
-    case format::depth32f:
-    case format::r16f:
-    case format::r16i:
-    case format::r16u:
-    case format::depth16un:
-    case format::r8i:
-    case format::r8u:
-    case format::r8un:
-    case format::r24t_g8u:
-    case format::r24un_g8t:
-        return 1;
-    default:
-        CC_UNREACHABLE("unknown format");
-        return 0;
-    }
-    CC_UNREACHABLE("unknown format");
-    return 0;
-}
-
-[[nodiscard]] inline format get_format_srgb_variant(format fmt)
+inline format get_format_srgb_variant(format fmt)
 {
     switch (fmt)
     {

--- a/src/phantasm-hardware-interface/common/log.hh
+++ b/src/phantasm-hardware-interface/common/log.hh
@@ -17,6 +17,11 @@ inline void warn_log(rlog::MessageBuilder& builder)
     builder.set_severity(rlog::severity::warning());
     builder.set_use_error_stream(true);
 }
+inline void trace_log(rlog::MessageBuilder& builder)
+{
+    builder.set_domain(domain);
+    builder.set_severity(rlog::severity::trace());
+}
 inline void err_log(rlog::MessageBuilder& builder)
 {
     builder.set_domain(domain);
@@ -39,5 +44,6 @@ inline void vulkan_log(rlog::MessageBuilder& builder)
 
 #define PHI_LOG RICH_LOG_IMPL(phi::detail::info_log)
 #define PHI_LOG_WARN RICH_LOG_IMPL(phi::detail::warn_log)
+#define PHI_LOG_TRACE RICH_LOG_IMPL(phi::detail::trace_log)
 #define PHI_LOG_ERROR RICH_LOG_IMPL(phi::detail::err_log)
 #define PHI_LOG_ASSERT RICH_LOG_IMPL(phi::detail::assert_log)

--- a/src/phantasm-hardware-interface/common/page_allocator.hh
+++ b/src/phantasm-hardware-interface/common/page_allocator.hh
@@ -57,10 +57,17 @@ struct page_allocator
     void free_all() { std::memset(_pages.data(), 0, _pages.size_bytes()); }
 
 public:
-    [[nodiscard]] int get_page_size() const { return _page_size; }
-    [[nodiscard]] int get_num_pages() const { return int(_pages.size()); }
+    /// returns amount of elements per page
+    int get_page_size() const { return _page_size; }
+
+    /// returns amount of pages
+    int get_num_pages() const { return int(_pages.size()); }
+
+    /// returns amount of elements in total
+    int get_num_elements() const { return get_page_size() * get_num_pages(); }
+
     /// NOTE: this is the size given to ::allocate, ceiled to _page_size
-    [[nodiscard]] int get_allocation_size_in_elements(int page) const { return _pages[unsigned(page)] * _page_size; }
+    int get_allocation_size_in_elements(int page) const { return _pages[unsigned(page)] * _page_size; }
 
 private:
     // pages, each element is a natural number n

--- a/src/phantasm-hardware-interface/common/sse_hash.hh
+++ b/src/phantasm-hardware-interface/common/sse_hash.hh
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstdint>
+
+#include <clean-core/macros.hh>
+
+// disable SSE usage by defining PHI_USE_SSE_HASH to 0
+// requires SSE4.2 - Intel Nehalem (Nov 2008) and AMD Bulldozer (Oct 2011)
+#ifndef PHI_USE_SSE_HASH
+#define PHI_USE_SSE_HASH 1
+#endif
+
+#if PHI_USE_SSE_HASH
+#include <clean-core/utility.hh>
+
+#ifdef CC_COMPILER_MSVC
+#include <intrin.h>
+#pragma intrinsic(_mm_crc32_u32)
+#pragma intrinsic(_mm_crc32_u64)
+#else
+#include <smmintrin.h>
+#endif
+#endif
+
+namespace phi::util
+{
+inline uint64_t sse_hash(const uint32_t* begin, const uint32_t* end, uint64_t initial_hash = 2166136261U)
+{
+    // Modified from D3D12 MiniEngine, Hash.h
+    // Original license:
+    //
+    // Copyright (c) Microsoft. All rights reserved.
+    // This code is licensed under the MIT License (MIT).
+    // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+    // ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+    // IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+    // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+    //
+    // Developed by Minigraph
+    //
+    // Author:  James Stanard
+
+#if PHI_USE_SSE_HASH
+    const uint64_t* iter64 = (const uint64_t*)cc::align_up(begin, 8);
+    const uint64_t* const end64 = (const uint64_t* const)cc::align_down(end, 8);
+
+    // If not 64-bit aligned, start with a single u32
+    if ((uint32_t*)iter64 > begin)
+        initial_hash = _mm_crc32_u32((uint32_t)initial_hash, *begin);
+
+    // Iterate over consecutive u64 values
+    while (iter64 < end64)
+        initial_hash = _mm_crc32_u64((uint64_t)initial_hash, *iter64++);
+
+    // If there is a 32-bit remainder, accumulate that
+    if ((uint32_t*)iter64 < end)
+        initial_hash = _mm_crc32_u32((uint32_t)initial_hash, *(uint32_t*)iter64);
+#else
+    // An inexpensive hash for CPUs lacking SSE4.2
+    for (const uint32_t* iter = begin; iter < end; ++iter)
+        initial_hash = 16777619U * initial_hash ^ *iter;
+#endif
+
+    return initial_hash;
+}
+
+template <class T>
+uint64_t sse_hash_type(T const* value, uint32_t num_values = 1, uint64_t initial_hash = 2166136261U)
+{
+    static_assert((sizeof(T) & 3) == 0 && alignof(T) >= 4, "type is not word-aligned");
+    return sse_hash((uint32_t*)value, (uint32_t*)(value + num_values), initial_hash);
+}
+}

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -96,7 +96,7 @@ struct backend_config
     /// allocator for runtime allocations, must be thread-safe
     cc::allocator* dynamic_allocator = cc::system_allocator;
 
-    /// resource limits
+    // resource limits
     unsigned max_num_swapchains = 32;
     unsigned max_num_resources = 2048;
     unsigned max_num_pipeline_states = 1024;
@@ -108,7 +108,7 @@ struct backend_config
     unsigned max_num_accel_structs = 2048;
     unsigned max_num_raytrace_pipeline_states = 256;
 
-    /// command list allocator sizes (total = #threads * #allocs/thread * #lists/alloc)
+    // command list allocator sizes (total = #threads * #allocs/thread * #lists/alloc)
     unsigned num_direct_cmdlist_allocators_per_thread = 5;
     unsigned num_direct_cmdlists_per_allocator = 5;
     unsigned num_compute_cmdlist_allocators_per_thread = 5;
@@ -116,7 +116,10 @@ struct backend_config
     unsigned num_copy_cmdlist_allocators_per_thread = 3;
     unsigned num_copy_cmdlists_per_allocator = 3;
 
-    /// query heap sizes
+    // command list limits
+    unsigned max_num_unique_transitions_per_cmdlist = 64;
+
+    // query heap sizes
     unsigned num_timestamp_queries = 1024;
     unsigned num_occlusion_queries = 1024;
     unsigned num_pipeline_stat_queries = 256;

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -8,10 +8,19 @@ namespace phi
 {
 enum class adapter_preference : uint8_t
 {
+    // use the GPU with the highest VRAM
     highest_vram,
+
+    // use the first GPU found by the API
     first,
+
+    // prefer integrated GPUs (like Intel Graphics)
     integrated,
+
+    // use the GPU with the highest feature level
     highest_feature_level,
+
+    // use the n-th GPU, n given by the explicit_adapter_index field
     explicit_index
 };
 
@@ -26,19 +35,18 @@ enum class validation_level : uint8_t
 
     // D3D12: Whether to additionally enable GPU based validation (slow)
     //
-    // Vulkan: Whether to additionally enable LunarG GPU-assisted validation
-    //          Slow, and requires a reserved descriptor set. If your device
-    //          only has 8 (max shader args * 2), like an IGP, this could fail
+    // Vulkan: Whether to additionally enable LunarG GPU-assisted validation (slow)
+    //          Requires a reserved descriptor set, can fail if the device only supports 8, like some iGPUs.
     //
-    // Extended validation for both APIs can prevent diagnostic tools like
-    // Renderdoc and NSight from working properly (PIX will work though)
+    // Can prevent diagnostic tools like Renderdoc and NSight from working properly,
+    // but the backend will attempt to auto-disable if those are detected
     on_extended,
 
     // D3D12: Whether to additionally enable DRED (Device Removed Extended Data)
     //          with automatic breadcrumbs and pagefault recovery (very slow)
     //          see: https://docs.microsoft.com/en-us/windows/win32/direct3d12/use-dred
     //
-    // Vulkan: No additional effect
+    // Vulkan: same as on_extended
     on_extended_dred
 };
 
@@ -54,8 +62,16 @@ struct backend_config
     enum native_feature_flags : uint8_t
     {
         native_feature_none = 0,
+
+        // Vulkan: Dump all Vulkan API calls in text form
         native_feature_vk_api_dump = 1 << 0,
+
+        // D3D12: Cause a breakpoint on any warning, useful to find it's source
+        // for an equivalent Vulkan feature, set a breakpoint in <phi>/vulkan/common/debug_callback.cc
         native_feature_d3d12_break_on_warn = 1 << 1,
+
+        // D3D12: skip destroying ID3D12Device on shutdown to avoid a known crash in Windows pre-21H1 with enabled GPU based validation
+        // this causes a lot of spam on shutdown because of live COM objects, but will avoid the crash
         native_feature_d3d12_workaround_device_release_crash = 1 << 2
     };
 

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -57,7 +57,7 @@ struct backend_config
 
     /// the strategy for choosing a physical GPU
     adapter_preference adapter = adapter_preference::highest_vram;
-    unsigned explicit_adapter_index = unsigned(-1);
+    uint32_t explicit_adapter_index = uint32_t(-1);
 
     enum native_feature_flags : uint8_t
     {
@@ -72,7 +72,10 @@ struct backend_config
 
         // D3D12: skip destroying ID3D12Device on shutdown to avoid a known crash in Windows pre-21H1 with enabled GPU based validation
         // this causes a lot of spam on shutdown because of live COM objects, but will avoid the crash
-        native_feature_d3d12_workaround_device_release_crash = 1 << 2
+        native_feature_d3d12_workaround_device_release_crash = 1 << 2,
+
+        // Vulkan: present from the discrete compute queue (instead of the default direct queue)
+        native_feature_vk_present_from_compute = 1 << 3,
     };
 
     /// native features to enable
@@ -84,12 +87,9 @@ struct backend_config
     /// whether to print basic information on init
     bool print_startup_message = true;
 
-    /// whether to present from the discrete compute queue (instead of the default direct queue)
-    bool present_from_compute_queue = false;
-
     /// amount of threads to accomodate
     /// backend calls must only be made from <= [num_threads] unique OS threads
-    unsigned num_threads = 1;
+    uint32_t num_threads = 1;
 
     /// allocator for init-time allocations, only hit during init and shutdown
     cc::allocator* static_allocator = cc::system_allocator;
@@ -97,31 +97,31 @@ struct backend_config
     cc::allocator* dynamic_allocator = cc::system_allocator;
 
     // resource limits
-    unsigned max_num_swapchains = 32;
-    unsigned max_num_resources = 2048;
-    unsigned max_num_pipeline_states = 1024;
-    unsigned max_num_cbvs = 2048;
-    unsigned max_num_srvs = 2048;
-    unsigned max_num_uavs = 2048;
-    unsigned max_num_samplers = 1024;
-    unsigned max_num_fences = 4096;
-    unsigned max_num_accel_structs = 2048;
-    unsigned max_num_raytrace_pipeline_states = 256;
+    uint32_t max_num_swapchains = 32;
+    uint32_t max_num_resources = 2048;
+    uint32_t max_num_pipeline_states = 1024;
+    uint32_t max_num_cbvs = 2048;
+    uint32_t max_num_srvs = 2048;
+    uint32_t max_num_uavs = 2048;
+    uint32_t max_num_samplers = 1024;
+    uint32_t max_num_fences = 4096;
+    uint32_t max_num_accel_structs = 2048;
+    uint32_t max_num_raytrace_pipeline_states = 256;
 
     // command list allocator sizes (total = #threads * #allocs/thread * #lists/alloc)
-    unsigned num_direct_cmdlist_allocators_per_thread = 5;
-    unsigned num_direct_cmdlists_per_allocator = 5;
-    unsigned num_compute_cmdlist_allocators_per_thread = 5;
-    unsigned num_compute_cmdlists_per_allocator = 5;
-    unsigned num_copy_cmdlist_allocators_per_thread = 3;
-    unsigned num_copy_cmdlists_per_allocator = 3;
+    uint32_t num_direct_cmdlist_allocators_per_thread = 5;
+    uint32_t num_direct_cmdlists_per_allocator = 5;
+    uint32_t num_compute_cmdlist_allocators_per_thread = 5;
+    uint32_t num_compute_cmdlists_per_allocator = 5;
+    uint32_t num_copy_cmdlist_allocators_per_thread = 3;
+    uint32_t num_copy_cmdlists_per_allocator = 3;
 
     // command list limits
-    unsigned max_num_unique_transitions_per_cmdlist = 64;
+    uint32_t max_num_unique_transitions_per_cmdlist = 64;
 
     // query heap sizes
-    unsigned num_timestamp_queries = 1024;
-    unsigned num_occlusion_queries = 1024;
-    unsigned num_pipeline_stat_queries = 256;
+    uint32_t num_timestamp_queries = 1024;
+    uint32_t num_occlusion_queries = 1024;
+    uint32_t num_pipeline_stat_queries = 256;
 };
 }

--- a/src/phantasm-hardware-interface/d3d12/Adapter.cc
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.cc
@@ -9,6 +9,7 @@
 #include "adapter_choice_util.hh"
 #include "common/d3d12_sanitized.hh"
 #include "common/verify.hh"
+#include "common/shared_com_ptr.hh"
 
 void phi::d3d12::Adapter::initialize(const backend_config& config)
 {

--- a/src/phantasm-hardware-interface/d3d12/Adapter.cc
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.cc
@@ -138,11 +138,13 @@ void phi::d3d12::Adapter::initialize(const backend_config& config)
         }
         else
         {
+            // (prevent clangf from breaking the URL in code)
+            // clang-format off
             PHI_LOG_ERROR << "failed to enable validation\n"
                              "  verify that the D3D12 SDK is installed on this machine\n"
                              "  refer to "
-                             "https://docs.microsoft.com/en-us/windows/uwp/gaming/"
-                             "use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features";
+                             "https://docs.microsoft.com/en-us/windows/uwp/gaming/use-the-directx-runtime-and-visual-studio-graphics-diagnostic-features";
+            // clang-format on
         }
     }
 }

--- a/src/phantasm-hardware-interface/d3d12/Adapter.cc
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.cc
@@ -8,8 +8,8 @@
 
 #include "adapter_choice_util.hh"
 #include "common/d3d12_sanitized.hh"
-#include "common/verify.hh"
 #include "common/shared_com_ptr.hh"
+#include "common/verify.hh"
 
 void phi::d3d12::Adapter::initialize(const backend_config& config)
 {

--- a/src/phantasm-hardware-interface/d3d12/Adapter.cc
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.cc
@@ -95,6 +95,7 @@ void phi::d3d12::Adapter::initialize(const backend_config& config)
         PHI_D3D12_VERIFY(temp_adapter->QueryInterface(IID_PPV_ARGS(&mAdapter)));
 
         print_startup_message(candidates, chosen_adapter_index, config, true);
+        mGPUInfo = candidates[chosen_adapter_index];
     }
 
     // Debug layer init

--- a/src/phantasm-hardware-interface/d3d12/Adapter.hh
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.hh
@@ -4,8 +4,6 @@
 
 #include "common/d3d12_fwd.hh"
 
-#include "common/shared_com_ptr.hh"
-
 namespace phi::d3d12
 {
 /// Represents a IDXGIAdapter, the uppermost object in the D3D12 hierarchy

--- a/src/phantasm-hardware-interface/d3d12/Adapter.hh
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <phantasm-hardware-interface/features/gpu_info.hh>
 #include <phantasm-hardware-interface/fwd.hh>
 
 #include "common/d3d12_fwd.hh"
@@ -15,10 +16,13 @@ public:
 
     bool isValid() const { return mAdapter != nullptr; }
 
-    [[nodiscard]] IDXGIAdapter& getAdapter() const { return *mAdapter; }
-    [[nodiscard]] IDXGIFactory4& getFactory() const { return *mFactory; }
+    IDXGIAdapter& getAdapter() const { return *mAdapter; }
+    IDXGIFactory4& getFactory() const { return *mFactory; }
+
+    gpu_info const& getGPUInfo() const { return mGPUInfo; }
 
 private:
+    gpu_info mGPUInfo;
     IDXGIAdapter* mAdapter = nullptr;
     IDXGIFactory4* mFactory = nullptr;
     IDXGIInfoQueue* mInfoQueue = nullptr;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -294,27 +294,29 @@ phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(phi::a
                                                                           phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                           bool has_root_constants,
                                                                           phi::arg::graphics_shaders shaders,
-                                                                          const phi::pipeline_config& primitive_config)
+                                                                          const phi::pipeline_config& primitive_config,
+                                                                          char const* debug_name)
 {
-    return mPoolPSOs.createPipelineState(vertex_format, framebuffer_conf, shader_arg_shapes, has_root_constants, shaders, primitive_config);
+    return mPoolPSOs.createPipelineState(vertex_format, framebuffer_conf, shader_arg_shapes, has_root_constants, shaders, primitive_config, debug_name);
 }
 
-phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description, char const* debug_name)
 {
     return mPoolPSOs.createPipelineState(description.vertices, description.framebuffer, description.shader_arg_shapes, description.has_root_constants,
-                                         description.shader_binaries, description.config);
+                                         description.shader_binaries, description.config, debug_name);
 }
 
 phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState(phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                                  phi::arg::shader_binary shader,
-                                                                                 bool has_root_constants)
+                                                                                 bool has_root_constants,
+                                                                                 char const* debug_name)
 {
-    return mPoolPSOs.createComputePipelineState(shader_arg_shapes, shader, has_root_constants);
+    return mPoolPSOs.createComputePipelineState(shader_arg_shapes, shader, has_root_constants, debug_name);
 }
 
-phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description, char const* debug_name)
 {
-    return mPoolPSOs.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants);
+    return mPoolPSOs.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants, debug_name);
 }
 
 void phi::d3d12::BackendD3D12::free(phi::handle::pipeline_state ps) { mPoolPSOs.free(ps); }
@@ -440,8 +442,9 @@ void phi::d3d12::BackendD3D12::free(phi::handle::query_range query_range) { mPoo
 phi::handle::pipeline_state phi::d3d12::BackendD3D12::createRaytracingPipelineState(const arg::raytracing_pipeline_state_desc& description)
 {
     CC_ASSERT(isRaytracingEnabled() && "raytracing is not enabled");
+    // TODO: debug name
     return mPoolPSOs.createRaytracingPipelineState(description.libraries, description.argument_associations, description.hit_groups, description.max_recursion,
-                                                   description.max_payload_size_bytes, description.max_attribute_size_bytes, cc::system_allocator);
+                                                   description.max_payload_size_bytes, description.max_attribute_size_bytes, mDynamicAllocator, nullptr);
 }
 
 phi::handle::accel_struct phi::d3d12::BackendD3D12::createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags)

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -172,7 +172,7 @@ void phi::d3d12::BackendD3D12::flushGPU()
     ::WaitForSingleObject(mFlushEvent, INFINITE);
 }
 
-phi::handle::swapchain phi::d3d12::BackendD3D12::createSwapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, phi::present_mode mode, unsigned num_backbuffers)
+phi::handle::swapchain phi::d3d12::BackendD3D12::createSwapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, phi::present_mode mode, uint32_t num_backbuffers)
 {
     ::HWND native_hwnd = nullptr;
     {
@@ -224,23 +224,23 @@ phi::format phi::d3d12::BackendD3D12::getBackbufferFormat(handle::swapchain /*sc
 }
 
 phi::handle::resource phi::d3d12::BackendD3D12::createTexture(
-    phi::format format, tg::isize2 size, unsigned mips, phi::texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, const char* debug_name)
+    phi::format format, tg::isize2 size, uint32_t mips, phi::texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, const char* debug_name)
 {
-    return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
+    return mPoolResources.createTexture(format, uint32_t(size.width), uint32_t(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
 }
 
 phi::handle::resource phi::d3d12::BackendD3D12::createRenderTarget(
-    phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, const phi::rt_clear_value* optimized_clear_val, const char* debug_name)
+    phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, const phi::rt_clear_value* optimized_clear_val, const char* debug_name)
 {
-    return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, optimized_clear_val, debug_name);
+    return mPoolResources.createRenderTarget(format, uint32_t(size.width), uint32_t(size.height), samples, array_size, optimized_clear_val, debug_name);
 }
 
-phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(unsigned int size_bytes, unsigned int stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
 {
     return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
 }
 
-phi::handle::resource phi::d3d12::BackendD3D12::createUploadBuffer(unsigned size_bytes, unsigned stride_bytes, const char* debug_name)
+phi::handle::resource phi::d3d12::BackendD3D12::createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes, const char* debug_name)
 {
     return createBuffer(size_bytes, stride_bytes, resource_heap::upload, false, debug_name);
 }
@@ -331,7 +331,7 @@ void phi::d3d12::BackendD3D12::submit(cc::span<const phi::handle::command_list> 
                                       cc::span<const fence_operation> fence_waits_before,
                                       cc::span<const fence_operation> fence_signals_after)
 {
-    constexpr unsigned c_max_num_command_lists = 32u;
+    constexpr uint32_t c_max_num_command_lists = 32u;
     cc::capped_vector<ID3D12CommandList*, c_max_num_command_lists * 2> cmd_bufs_to_submit;
     cc::capped_vector<handle::command_list, c_max_num_command_lists> barrier_lists;
     CC_ASSERT(cls.size() <= c_max_num_command_lists && "too many commandlists submitted at once");
@@ -414,10 +414,7 @@ void phi::d3d12::BackendD3D12::waitFenceGPU(phi::handle::fence fence, uint64_t w
 
 void phi::d3d12::BackendD3D12::free(cc::span<const phi::handle::fence> fences) { mPoolFences.free(fences); }
 
-phi::handle::query_range phi::d3d12::BackendD3D12::createQueryRange(phi::query_type type, unsigned int size)
-{
-    return mPoolQueries.create(type, size);
-}
+phi::handle::query_range phi::d3d12::BackendD3D12::createQueryRange(phi::query_type type, uint32_t size) { return mPoolQueries.create(type, size); }
 
 void phi::d3d12::BackendD3D12::free(phi::handle::query_range query_range) { mPoolQueries.free(query_range); }
 
@@ -428,7 +425,7 @@ phi::handle::pipeline_state phi::d3d12::BackendD3D12::createRaytracingPipelineSt
                                                    description.max_payload_size_bytes, description.max_attribute_size_bytes, cc::system_allocator);
 }
 
-phi::handle::accel_struct phi::d3d12::BackendD3D12::createTopLevelAccelStruct(unsigned num_instances, accel_struct_build_flags_t flags)
+phi::handle::accel_struct phi::d3d12::BackendD3D12::createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags)
 {
     CC_ASSERT(isRaytracingEnabled() && "raytracing is not enabled");
     return mPoolAccelStructs.createTopLevelAS(num_instances, flags);
@@ -457,7 +454,7 @@ phi::shader_table_strides phi::d3d12::BackendD3D12::calculateShaderTableStrides(
     return mShaderTableCtor.calculateShaderTableSizes(ray_gen_record, miss_records, hit_group_records, callable_records);
 }
 
-void phi::d3d12::BackendD3D12::writeShaderTable(std::byte* dest, handle::pipeline_state pso, unsigned stride, arg::shader_table_records records)
+void phi::d3d12::BackendD3D12::writeShaderTable(std::byte* dest, handle::pipeline_state pso, uint32_t stride, arg::shader_table_records records)
 {
     mShaderTableCtor.writeShaderTable(dest, pso, stride, records);
 }
@@ -476,7 +473,7 @@ void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::accel_struc
 
 void phi::d3d12::BackendD3D12::setDebugName(phi::handle::resource res, cc::string_view name)
 {
-    mPoolResources.setDebugName(res, name.data(), unsigned(name.length()));
+    mPoolResources.setDebugName(res, name.data(), uint32_t(name.length()));
 }
 
 void phi::d3d12::BackendD3D12::printInformation(phi::handle::resource res) const

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -261,6 +261,26 @@ phi::handle::shader_view phi::d3d12::BackendD3D12::createShaderView(cc::span<con
     return mPoolShaderViews.create(srvs, uavs, samplers);
 }
 
+phi::handle::shader_view phi::d3d12::BackendD3D12::createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool /*usage_compute*/)
+{
+    return mPoolShaderViews.createEmpty(num_srvs_uavs, num_samplers);
+}
+
+void phi::d3d12::BackendD3D12::writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs)
+{
+    mPoolShaderViews.writeShaderViewSRVs(sv, offset, srvs);
+}
+
+void phi::d3d12::BackendD3D12::writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs)
+{
+    mPoolShaderViews.writeShaderViewUAVs(sv, offset, uavs);
+}
+
+void phi::d3d12::BackendD3D12::writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers)
+{
+    mPoolShaderViews.writeShaderViewSamplers(sv, offset, samplers);
+}
+
 void phi::d3d12::BackendD3D12::free(phi::handle::shader_view sv) { mPoolShaderViews.free(sv); }
 
 void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::shader_view> svs) { mPoolShaderViews.free(svs); }

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -72,8 +72,7 @@ void phi::d3d12::BackendD3D12::initialize(const phi::backend_config& config)
             mShaderTableCtor.initialize(device, &mPoolShaderViews, &mPoolResources, &mPoolPSOs, &mPoolAccelStructs);
         }
 
-        mPoolSwapchains.initialize(&mAdapter.getFactory(), device, config.present_from_compute_queue ? mComputeQueue.command_queue : mDirectQueue.command_queue,
-                                   config.max_num_swapchains, config.static_allocator);
+        mPoolSwapchains.initialize(&mAdapter.getFactory(), device, mDirectQueue.command_queue, config.max_num_swapchains, config.static_allocator);
     }
 
     // Per-thread components and command list pool

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -232,14 +232,9 @@ phi::handle::resource phi::d3d12::BackendD3D12::createTexture(arg::texture_descr
     return mPoolResources.createTexture(desc, debug_name);
 }
 
-phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(arg::buffer_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
-}
-
-phi::handle::resource phi::d3d12::BackendD3D12::createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes, const char* debug_name)
-{
-    return createBuffer(size_bytes, stride_bytes, resource_heap::upload, false, debug_name);
+    return mPoolResources.createBuffer(desc.size_bytes, desc.stride_bytes, desc.heap, desc.allow_uav, debug_name);
 }
 
 std::byte* phi::d3d12::BackendD3D12::mapBuffer(phi::handle::resource res, int begin, int end) { return mPoolResources.mapBuffer(res, begin, end); }

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -195,7 +195,7 @@ phi::handle::resource phi::d3d12::BackendD3D12::acquireBackbuffer(handle::swapch
     return mPoolResources.injectBackbufferResource(swapchain_index, backbuffer.resource, backbuffer.state);
 }
 
-void phi::d3d12::BackendD3D12::waitOnBackbufferFromGPU(handle::swapchain sc) { mPoolSwapchains.waitForBackbufferOnGPU(sc); }
+void phi::d3d12::BackendD3D12::waitOnBackbuffer(handle::swapchain sc) { mPoolSwapchains.waitForBackbufferOnCPU(sc); }
 
 void phi::d3d12::BackendD3D12::present(phi::handle::swapchain sc) { mPoolSwapchains.present(sc); }
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -187,15 +187,13 @@ phi::handle::swapchain phi::d3d12::BackendD3D12::createSwapchain(const phi::wind
 
 void phi::d3d12::BackendD3D12::free(phi::handle::swapchain sc) { mPoolSwapchains.free(sc); }
 
-phi::handle::resource phi::d3d12::BackendD3D12::acquireBackbuffer(handle::swapchain sc, bool waitOnCPU)
+phi::handle::resource phi::d3d12::BackendD3D12::acquireBackbuffer(handle::swapchain sc)
 {
     auto const swapchain_index = mPoolSwapchains.getSwapchainIndex(sc);
-    auto const backbuffer_i = mPoolSwapchains.acquireBackbuffer(sc, waitOnCPU);
+    auto const backbuffer_i = mPoolSwapchains.acquireBackbuffer(sc);
     auto const& backbuffer = mPoolSwapchains.get(sc).backbuffers[backbuffer_i];
     return mPoolResources.injectBackbufferResource(swapchain_index, backbuffer.resource, backbuffer.state);
 }
-
-void phi::d3d12::BackendD3D12::waitOnBackbuffer(handle::swapchain sc) { mPoolSwapchains.waitForBackbufferOnCPU(sc); }
 
 void phi::d3d12::BackendD3D12::present(phi::handle::swapchain sc) { mPoolSwapchains.present(sc); }
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -227,16 +227,9 @@ phi::format phi::d3d12::BackendD3D12::getBackbufferFormat(handle::swapchain /*sc
     return util::to_pr_format(mPoolSwapchains.getBackbufferFormat());
 }
 
-phi::handle::resource phi::d3d12::BackendD3D12::createTexture(
-    phi::format format, tg::isize2 size, uint32_t mips, phi::texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::d3d12::BackendD3D12::createTexture(arg::texture_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createTexture(format, uint32_t(size.width), uint32_t(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
-}
-
-phi::handle::resource phi::d3d12::BackendD3D12::createRenderTarget(
-    phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, const phi::rt_clear_value* optimized_clear_val, const char* debug_name)
-{
-    return mPoolResources.createRenderTarget(format, uint32_t(size.width), uint32_t(size.height), samples, array_size, optimized_clear_val, debug_name);
+    return mPoolResources.createTexture(desc, debug_name);
 }
 
 phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
@@ -300,7 +293,7 @@ phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(phi::a
     return mPoolPSOs.createPipelineState(vertex_format, framebuffer_conf, shader_arg_shapes, has_root_constants, shaders, primitive_config, debug_name);
 }
 
-phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description, char const* debug_name)
+phi::handle::pipeline_state phi::d3d12::BackendD3D12::createPipelineState(const phi::arg::graphics_pipeline_state_description& description, char const* debug_name)
 {
     return mPoolPSOs.createPipelineState(description.vertices, description.framebuffer, description.shader_arg_shapes, description.has_root_constants,
                                          description.shader_binaries, description.config, debug_name);
@@ -314,7 +307,7 @@ phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState
     return mPoolPSOs.createComputePipelineState(shader_arg_shapes, shader, has_root_constants, debug_name);
 }
 
-phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description, char const* debug_name)
+phi::handle::pipeline_state phi::d3d12::BackendD3D12::createComputePipelineState(const phi::arg::compute_pipeline_state_description& description, char const* debug_name)
 {
     return mPoolPSOs.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants, debug_name);
 }
@@ -439,7 +432,7 @@ phi::handle::query_range phi::d3d12::BackendD3D12::createQueryRange(phi::query_t
 
 void phi::d3d12::BackendD3D12::free(phi::handle::query_range query_range) { mPoolQueries.free(query_range); }
 
-phi::handle::pipeline_state phi::d3d12::BackendD3D12::createRaytracingPipelineState(const arg::raytracing_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::d3d12::BackendD3D12::createRaytracingPipelineState(const arg::raytracing_pipeline_state_description& description)
 {
     CC_ASSERT(isRaytracingEnabled() && "raytracing is not enabled");
     // TODO: debug name

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -97,6 +97,14 @@ public:
                                                        cc::span<sampler_config const> samplers,
                                                        bool /*usage_compute*/) override;
 
+    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool /*usage_compute*/);
+
+    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs);
+
+    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs);
+
+    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers);
+
     void free(handle::shader_view sv) override;
 
     void freeRange(cc::span<handle::shader_view const> svs) override;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -47,8 +47,7 @@ public:
 
     void free(handle::swapchain sc) override;
 
-    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) override;
-    void waitOnBackbuffer(handle::swapchain sc) override;
+    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc) override;
     void present(handle::swapchain sc) override;
     void onResize(handle::swapchain sc, tg::isize2 size) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -24,7 +24,7 @@
 
 namespace phi::d3d12
 {
-class BackendD3D12 final : public Backend
+class PHI_API BackendD3D12 final : public Backend
 {
 public:
     void initialize(backend_config const& config) override;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -43,7 +43,7 @@ public:
     [[nodiscard]] handle::swapchain createSwapchain(window_handle const& window_handle,
                                                     tg::isize2 initial_size,
                                                     present_mode mode = present_mode::synced,
-                                                    unsigned num_backbuffers = 3) override;
+                                                    uint32_t num_backbuffers = 3) override;
 
     void free(handle::swapchain sc) override;
 
@@ -57,7 +57,7 @@ public:
         return {node.backbuf_width, node.backbuf_height};
     }
     format getBackbufferFormat(handle::swapchain sc) const override;
-    unsigned getNumBackbuffers(handle::swapchain sc) const override { return unsigned(mPoolSwapchains.get(sc).backbuffers.size()); }
+    uint32_t getNumBackbuffers(handle::swapchain sc) const override { return uint32_t(mPoolSwapchains.get(sc).backbuffers.size()); }
 
     [[nodiscard]] bool clearPendingResize(handle::swapchain sc) override { return mPoolSwapchains.clearResizeFlag(sc); }
 
@@ -66,18 +66,18 @@ public:
     //
 
     [[nodiscard]] handle::resource createTexture(
-        phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
+        phi::format format, tg::isize2 size, uint32_t mips, texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::resource createRenderTarget(phi::format format,
                                                       tg::isize2 size,
-                                                      unsigned samples,
-                                                      unsigned array_size,
+                                                      uint32_t samples,
+                                                      uint32_t array_size,
                                                       rt_clear_value const* optimized_clear_val = nullptr,
                                                       char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createUploadBuffer(unsigned size_bytes, unsigned stride_bytes = 0, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) override;
 
     [[nodiscard]] std::byte* mapBuffer(handle::resource res, int begin = 0, int end = -1) override;
 
@@ -164,7 +164,7 @@ public:
     // Query interface
     //
 
-    [[nodiscard]] handle::query_range createQueryRange(query_type type, unsigned int size) override;
+    [[nodiscard]] handle::query_range createQueryRange(query_type type, uint32_t size) override;
 
     void free(handle::query_range query_range) override;
 
@@ -174,7 +174,7 @@ public:
 
     [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_desc const& description) override;
 
-    [[nodiscard]] handle::accel_struct createTopLevelAccelStruct(unsigned num_instances, accel_struct_build_flags_t flags) override;
+    [[nodiscard]] handle::accel_struct createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags) override;
 
     [[nodiscard]] handle::accel_struct createBottomLevelAccelStruct(cc::span<arg::blas_element const> elements,
                                                                     accel_struct_build_flags_t flags,
@@ -187,7 +187,7 @@ public:
                                                                    arg::shader_table_records hit_group_records,
                                                                    arg::shader_table_records callable_records = {}) override;
 
-    void writeShaderTable(std::byte* dest, handle::pipeline_state pso, unsigned stride, arg::shader_table_records records) override;
+    void writeShaderTable(std::byte* dest, handle::pipeline_state pso, uint32_t stride, arg::shader_table_records records) override;
 
     void free(handle::accel_struct as) override;
 
@@ -260,7 +260,7 @@ private:
 
     // Logic
     per_thread_component* mThreadComponents;
-    unsigned mNumThreadComponents;
+    uint32_t mNumThreadComponents;
     void* mThreadComponentAlloc;
     phi::thread_association mThreadAssociation;
     ShaderTableConstructor mShaderTableCtor;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -118,13 +118,17 @@ public:
                                                              arg::shader_arg_shapes shader_arg_shapes,
                                                              bool has_root_constants,
                                                              arg::graphics_shaders shaders,
-                                                             phi::pipeline_config const& primitive_config) override;
+                                                             phi::pipeline_config const& primitive_config,
+                                                             char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes, arg::shader_binary shader, bool has_root_constants) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
+                                                                    arg::shader_binary shader,
+                                                                    bool has_root_constants,
+                                                                    char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
 
     void free(handle::pipeline_state ps) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -264,6 +264,7 @@ private:
     void* mThreadComponentAlloc;
     phi::thread_association mThreadAssociation;
     ShaderTableConstructor mShaderTableCtor;
+    cc::allocator* mDynamicAllocator;
 
     // Misc
     util::diagnostic_state mDiagnostics;

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -65,15 +65,7 @@ public:
     // Resource interface
     //
 
-    [[nodiscard]] handle::resource createTexture(
-        phi::format format, tg::isize2 size, uint32_t mips, texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
-
-    [[nodiscard]] handle::resource createRenderTarget(phi::format format,
-                                                      tg::isize2 size,
-                                                      uint32_t samples,
-                                                      uint32_t array_size,
-                                                      rt_clear_value const* optimized_clear_val = nullptr,
-                                                      char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
 
@@ -121,14 +113,15 @@ public:
                                                              phi::pipeline_config const& primitive_config,
                                                              char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_description const& description, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
                                                                     arg::shader_binary shader,
                                                                     bool has_root_constants,
                                                                     char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_description const& description,
+                                                                    char const* debug_name = nullptr) override;
 
     void free(handle::pipeline_state ps) override;
 
@@ -176,7 +169,7 @@ public:
     // Raytracing interface
     //
 
-    [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_description const& description) override;
 
     [[nodiscard]] handle::accel_struct createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -67,9 +67,7 @@ public:
 
     [[nodiscard]] handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
-
-    [[nodiscard]] handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createBuffer(arg::buffer_description const& desc, char const* debug_name = nullptr) override;
 
     [[nodiscard]] std::byte* mapBuffer(handle::resource res, int begin = 0, int end = -1) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -95,15 +95,15 @@ public:
     [[nodiscard]] handle::shader_view createShaderView(cc::span<resource_view const> srvs,
                                                        cc::span<resource_view const> uavs,
                                                        cc::span<sampler_config const> samplers,
-                                                       bool /*usage_compute*/) override;
+                                                       bool usage_compute) override;
 
-    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool /*usage_compute*/);
+    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute) override;
 
-    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs);
+    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) override;
 
-    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs);
+    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs) override;
 
-    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers);
+    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers) override;
 
     void free(handle::shader_view sv) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -48,7 +48,7 @@ public:
     void free(handle::swapchain sc) override;
 
     [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) override;
-    void waitOnBackbufferFromGPU(handle::swapchain sc) override;
+    void waitOnBackbuffer(handle::swapchain sc) override;
     void present(handle::swapchain sc) override;
     void onResize(handle::swapchain sc, tg::isize2 size) override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -204,6 +204,8 @@ public:
 
     backend_type getBackendType() const override { return backend_type::d3d12; }
 
+    gpu_info const& getGPUInfo() const override { return mAdapter.getGPUInfo(); }
+
 public:
     // non virtual - d3d12 specific
 

--- a/src/phantasm-hardware-interface/d3d12/Device.cc
+++ b/src/phantasm-hardware-interface/d3d12/Device.cc
@@ -122,6 +122,8 @@ void phi::d3d12::Device::initialize(IDXGIAdapter& adapter, const backend_config&
             shared_com_ptr<ID3D12InfoQueue> info_queue;
             PHI_D3D12_VERIFY(mDevice->QueryInterface(PHI_COM_WRITE(info_queue)));
             PHI_D3D12_VERIFY(info_queue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_WARNING, TRUE));
+            PHI_D3D12_VERIFY(info_queue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_ERROR, TRUE));
+            PHI_D3D12_VERIFY(info_queue->SetBreakOnSeverity(D3D12_MESSAGE_SEVERITY_CORRUPTION, TRUE));
             PHI_LOG("d3d12_break_on_warn enabled");
         }
     }

--- a/src/phantasm-hardware-interface/d3d12/Device.cc
+++ b/src/phantasm-hardware-interface/d3d12/Device.cc
@@ -139,22 +139,7 @@ void phi::d3d12::Device::destroy()
             PHI_LOG("destroying ID3D12Device, spurious crash at shutdown might be imminent");
             PHI_LOG("device destruction can be skipped by enabling d3d12_workaround_device_release_crash in the backend config native features");
 
-            try
-            {
-                detail::perform_safe_seh_call(
-                    [&] {
-                        //
-                        PHI_D3D12_SAFE_RELEASE(mDevice);
-                    },
-                    [&] {
-                        //
-                        PHI_LOG_WARN("survived a crash in SEH __try/__except");
-                    });
-            }
-            catch (...)
-            {
-                PHI_LOG_WARN("survived a crash in try/catch");
-            }
+            PHI_D3D12_SAFE_RELEASE(mDevice);
         }
         else
         {

--- a/src/phantasm-hardware-interface/d3d12/Device.hh
+++ b/src/phantasm-hardware-interface/d3d12/Device.hh
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <phantasm-hardware-interface/config.hh>
-#include <phantasm-hardware-interface/features/gpu_info.hh>
 
 #include "common/d3d12_fwd.hh"
+#include "common/gpu_feature_info.hh"
 
 namespace phi::d3d12
 {

--- a/src/phantasm-hardware-interface/d3d12/Fence.cc
+++ b/src/phantasm-hardware-interface/d3d12/Fence.cc
@@ -23,6 +23,10 @@ void phi::d3d12::SimpleFence::destroy()
     }
 }
 
+void phi::d3d12::SimpleFence::signalCPU(uint64_t new_val) { fence->Signal(new_val); }
+
+void phi::d3d12::SimpleFence::signalGPU(uint64_t new_val, ID3D12CommandQueue& queue) { queue.Signal(fence, new_val); }
+
 void phi::d3d12::SimpleFence::waitCPU(uint64_t val)
 {
     if (fence->GetCompletedValue() <= val)
@@ -36,4 +40,13 @@ void phi::d3d12::SimpleFence::waitGPU(uint64_t val, ID3D12CommandQueue& queue)
 {
     //
     PHI_D3D12_VERIFY(queue.Wait(fence, val));
+}
+
+uint64_t phi::d3d12::SimpleFence::getCurrentValue() const
+{
+    auto const res = fence->GetCompletedValue();
+#ifdef CC_ENABLE_ASSERTIONS
+    PHI_D3D12_DRED_ASSERT(res != UINT64_MAX, fence);
+#endif
+    return res;
 }

--- a/src/phantasm-hardware-interface/d3d12/Fence.hh
+++ b/src/phantasm-hardware-interface/d3d12/Fence.hh
@@ -2,9 +2,7 @@
 
 #include <cstdint>
 
-#include "common/d3d12_sanitized.hh"
-#include "common/shared_com_ptr.hh"
-#include "common/verify.hh"
+#include "common/d3d12_fwd.hh"
 
 namespace phi::d3d12
 {
@@ -14,20 +12,13 @@ public:
     void initialize(ID3D12Device& device);
     void destroy();
 
-    void signalCPU(uint64_t new_val) { fence->Signal(new_val); }
-    void signalGPU(uint64_t new_val, ID3D12CommandQueue& queue) { queue.Signal(fence, new_val); }
+    void signalCPU(uint64_t new_val);
+    void signalGPU(uint64_t new_val, ID3D12CommandQueue& queue);
 
     void waitCPU(uint64_t val);
     void waitGPU(uint64_t val, ID3D12CommandQueue& queue);
 
-    [[nodiscard]] uint64_t getCurrentValue() const
-    {
-        auto const res = fence->GetCompletedValue();
-#ifdef CC_ENABLE_ASSERTIONS
-        PHI_D3D12_DRED_ASSERT(res != UINT64_MAX, fence);
-#endif
-        return res;
-    }
+    uint64_t getCurrentValue() const;
 
     ID3D12Fence* fence = nullptr;
     ::HANDLE event;

--- a/src/phantasm-hardware-interface/d3d12/Queue.hh
+++ b/src/phantasm-hardware-interface/d3d12/Queue.hh
@@ -3,7 +3,6 @@
 #include <phantasm-hardware-interface/types.hh>
 
 #include "common/d3d12_fwd.hh"
-#include "common/shared_com_ptr.hh"
 
 namespace phi::d3d12
 {

--- a/src/phantasm-hardware-interface/d3d12/adapter_choice_util.cc
+++ b/src/phantasm-hardware-interface/d3d12/adapter_choice_util.cc
@@ -75,16 +75,14 @@ cc::vector<phi::gpu_info> phi::d3d12::get_adapter_candidates()
 
 
                 auto& new_candidate = res.emplace_back();
-                new_candidate.vendor = get_gpu_vendor_from_id(adapter_desc.VendorId);
+                new_candidate.vendor = get_gpu_info_from_pcie_id(adapter_desc.VendorId);
                 new_candidate.index = i;
 
                 new_candidate.dedicated_video_memory_bytes = adapter_desc.DedicatedVideoMemory;
                 new_candidate.dedicated_system_memory_bytes = adapter_desc.DedicatedSystemMemory;
                 new_candidate.shared_system_memory_bytes = adapter_desc.SharedSystemMemory;
 
-                char description_nonwide[sizeof(adapter_desc.Description) + 8];
-                std::snprintf(description_nonwide, sizeof(description_nonwide), "%ws", adapter_desc.Description);
-                new_candidate.description = cc::string(description_nonwide);
+                std::snprintf(new_candidate.name, sizeof(new_candidate.name), "%ws", adapter_desc.Description);
 
                 if (max_feature_level < D3D_FEATURE_LEVEL_12_0)
                     new_candidate.capabilities = gpu_capabilities::insufficient;
@@ -101,7 +99,7 @@ cc::vector<phi::gpu_info> phi::d3d12::get_adapter_candidates()
     return res;
 }
 
-phi::gpu_feature_info phi::d3d12::get_gpu_features(ID3D12Device5* device)
+phi::d3d12::gpu_feature_info phi::d3d12::get_gpu_features(ID3D12Device5* device)
 {
     gpu_feature_info res;
 

--- a/src/phantasm-hardware-interface/d3d12/adapter_choice_util.hh
+++ b/src/phantasm-hardware-interface/d3d12/adapter_choice_util.hh
@@ -2,10 +2,10 @@
 
 #include <clean-core/vector.hh>
 
-#include <phantasm-hardware-interface/features/gpu_info.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 #include "common/d3d12_sanitized.hh"
+#include "common/gpu_feature_info.hh"
 
 namespace phi::d3d12
 {

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -797,7 +797,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::update_bottom_
 
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC as_create_info = {};
     as_create_info.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
-    as_create_info.Inputs.Flags = util::to_native_flags(dest_node.flags);
+    as_create_info.Inputs.Flags = util::to_native_accel_struct_build_flags(dest_node.flags);
     as_create_info.Inputs.NumDescs = UINT(dest_node.geometries.size());
 
     as_create_info.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
@@ -830,7 +830,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::update_top_lev
 
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_DESC as_create_info = {};
     as_create_info.Inputs.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
-    as_create_info.Inputs.Flags = util::to_native_flags(dest_node.flags);
+    as_create_info.Inputs.Flags = util::to_native_accel_struct_build_flags(dest_node.flags);
     as_create_info.Inputs.NumDescs = tlas_update.num_instances;
 
     as_create_info.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -231,7 +231,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::draw& draw)
     }
     else
     {
-        _cmd_list->DrawInstanced(draw.num_indices, 1, draw.vertex_offset, 0);
+        _cmd_list->DrawInstanced(draw.num_indices, 1, draw.index_offset, 0);
     }
 }
 

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -247,13 +247,13 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::draw_indirect&
     if (_bound.update_pso(draw_indirect.pipeline_state))
     {
         _cmd_list->SetPipelineState(pso_node.raw_pso);
+        _cmd_list->IASetPrimitiveTopology(pso_node.primitive_topology);
     }
 
     // Root signature
     if (_bound.update_root_sig(pso_node.associated_root_sig->raw_root_sig))
     {
         _cmd_list->SetGraphicsRootSignature(_bound.raw_root_sig);
-        _cmd_list->IASetPrimitiveTopology(pso_node.primitive_topology);
     }
 
     // Index buffer (optional)

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -49,7 +49,7 @@ void phi::d3d12::command_list_translator::translateCommandList(
         cmd::detail::dynamic_dispatch(cmd, *this);
 
     // close the list
-    _cmd_list->Close();
+    PHI_D3D12_VERIFY(_cmd_list->Close());
 
     // done
 }

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -752,7 +752,8 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::update_top_lev
     as_create_info.Inputs.NumDescs = tlas_update.num_instances;
 
     as_create_info.Inputs.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
-    as_create_info.Inputs.InstanceDescs = _globals.pool_resources->getBufferInfo(tlas_update.source_buffer_instances).gpu_va + tlas_update.source_buffer_offset_bytes;
+    as_create_info.Inputs.InstanceDescs
+        = _globals.pool_resources->getBufferInfo(tlas_update.source_instances_addr.buffer).gpu_va + tlas_update.source_instances_addr.offset_bytes;
 
     as_create_info.DestAccelerationStructureData = dest_node.buffer_as_va;
     as_create_info.ScratchAccelerationStructureData = _globals.pool_resources->getBufferInfo(dest_node.buffer_scratch).gpu_va;
@@ -802,9 +803,9 @@ void phi::d3d12::command_list_translator::execute(const cmd::dispatch_rays& disp
     f_fill_out_buffer_range(dispatch_rays.table_hit_groups, desc.HitGroupTable);
     f_fill_out_buffer_range(dispatch_rays.table_callable, desc.CallableShaderTable);
 
-    desc.Width = dispatch_rays.width;
-    desc.Height = dispatch_rays.height;
-    desc.Depth = dispatch_rays.depth;
+    desc.Width = dispatch_rays.dispatch_x;
+    desc.Height = dispatch_rays.dispatch_y;
+    desc.Depth = dispatch_rays.dispatch_z;
 
     _cmd_list->DispatchRays(&desc);
 }

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -234,6 +234,8 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::draw& draw)
 
             if (map.cbv_param != uint32_t(-1))
             {
+                CC_ASSERT(arg.constant_buffer.is_valid() && "argument CBV is missing");
+
                 // Set the CBV / offset if it has changed
                 if (bound_arg.update_cbv(arg.constant_buffer, arg.constant_buffer_offset))
                 {

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -765,8 +765,8 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::clear_textures
     _thread_local.lin_alloc_dsvs.reset();
 }
 
-void phi::d3d12::command_list_translator::execute(cmd::code_location_marker const& marker) {
-
+void phi::d3d12::command_list_translator::execute(cmd::code_location_marker const& marker)
+{
     _last_code_location.file = marker.file;
     _last_code_location.function = marker.function;
     _last_code_location.line = marker.line;

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -515,7 +515,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::copy_buffer_to
     footprint.Height = copy_text.dest_height;
     footprint.Depth = 1;
     // footprint.RowPitch:
-    if (is_block_compressed_format(dest_info.pixel_format))
+    if (phi::util::is_block_compressed_format(dest_info.pixel_format))
     {
         // calculated differently for block-compressed textures
         unsigned const num_blocks = cc::int_div_ceil(copy_text.dest_width, 4u);
@@ -725,7 +725,7 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::clear_textures
         auto const& op = clear_tex.clear_ops[i];
         auto* const resource = _globals.pool_resources->getRawResource(op.rv.resource);
 
-        if (is_depth_format(op.rv.texture_info.pixel_format))
+        if (phi::util::is_depth_format(op.rv.texture_info.pixel_format))
         {
             auto const dsv = dynamic_dsvs.get_index(i);
 

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -3,11 +3,11 @@
 #include <phantasm-hardware-interface/common/byte_util.hh>
 #include <phantasm-hardware-interface/common/command_reading.hh>
 #include <phantasm-hardware-interface/common/format_size.hh>
-#include <phantasm-hardware-interface/common/incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/common/log.hh>
 
 #include "common/diagnostic_util.hh"
 #include "common/dxgi_format.hh"
+#include "common/incomplete_state_cache.hh"
 #include "common/native_enum.hh"
 #include "common/shared_com_ptr.hh"
 #include "common/util.hh"
@@ -30,7 +30,7 @@ void phi::d3d12::command_list_translator::initialize(
 void phi::d3d12::command_list_translator::destroy() { _thread_local.destroy(); }
 
 void phi::d3d12::command_list_translator::translateCommandList(
-    ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size)
+    ID3D12GraphicsCommandList5* list, queue_type type, incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size)
 {
     _cmd_list = list;
     _current_queue_type = type;

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -227,11 +227,11 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::draw& draw)
     // Draw command
     if (draw.index_buffer.is_valid())
     {
-        _cmd_list->DrawIndexedInstanced(draw.num_indices, 1, draw.index_offset, draw.vertex_offset, 0);
+        _cmd_list->DrawIndexedInstanced(draw.num_indices, draw.num_instances, draw.index_offset, draw.vertex_offset, 0);
     }
     else
     {
-        _cmd_list->DrawInstanced(draw.num_indices, 1, draw.index_offset, 0);
+        _cmd_list->DrawInstanced(draw.num_indices, draw.num_instances, draw.index_offset, 0);
     }
 }
 

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -579,6 +579,15 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::transition_ima
     {
         _cmd_list->ResourceBarrier(UINT(barriers.size()), barriers.data());
     }
+
+    for (auto const& state_reset : transition_images.state_resets)
+    {
+        D3D12_RESOURCE_STATES const after = util::to_native(state_reset.new_state);
+        D3D12_RESOURCE_STATES before;
+
+        bool const before_known = _state_cache->transition_resource(state_reset.resource, after, before);
+        CC_ASSERT(before_known && "state resets require a locally known before-state. transition the resources normally before using slice transitions");
+    }
 }
 
 void phi::d3d12::command_list_translator::execute(const phi::cmd::barrier_uav& barrier)

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.cc
@@ -519,7 +519,20 @@ void phi::d3d12::command_list_translator::execute(const phi::cmd::barrier_uav& b
     for (auto const res : barrier.resources)
     {
         auto const raw_res = _globals.pool_resources->getRawResource(res);
-        barriers.push_back(CD3DX12_RESOURCE_BARRIER::UAV(raw_res));
+
+        D3D12_RESOURCE_BARRIER& desc = barriers.emplace_back();
+        desc.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+        desc.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        desc.UAV.pResource = raw_res;
+    }
+
+    if (barrier.resources.empty())
+    {
+        // full UAV barrier instead
+        D3D12_RESOURCE_BARRIER& desc = barriers.emplace_back();
+        desc.Type = D3D12_RESOURCE_BARRIER_TYPE_UAV;
+        desc.Flags = D3D12_RESOURCE_BARRIER_FLAG_NONE;
+        desc.UAV.pResource = nullptr;
     }
 
     _cmd_list->ResourceBarrier(UINT(barriers.size()), barriers.data());

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -121,17 +121,17 @@ private:
     // dynamic state
     struct
     {
-        handle::pipeline_state pipeline_state;
-        handle::resource index_buffer;
+        handle::pipeline_state pipeline_state = handle::null_pipeline_state;
+        handle::resource index_buffer = handle::null_resource;
         uint64_t vertex_buffer_hash = uint64_t(-1);
 
-        ID3D12RootSignature* raw_root_sig;
+        ID3D12RootSignature* raw_root_sig = nullptr;
 
         struct shader_arg_info
         {
-            handle::shader_view sv;
-            handle::resource cbv;
-            unsigned cbv_offset;
+            handle::shader_view sv = handle::null_shader_view;
+            handle::resource cbv = handle::null_resource;
+            unsigned cbv_offset = 0;
 
             void reset()
             {

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -61,6 +61,8 @@ struct command_list_translator
 
     void execute(cmd::dispatch const& dispatch);
 
+    void execute(cmd::dispatch_indirect const& dispatch_indirect);
+
     void execute(cmd::end_render_pass const& end_rp);
 
     void execute(cmd::transition_resources const& transition_res);

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -104,6 +104,9 @@ struct command_list_translator
     void execute(cmd::code_location_marker const& marker);
 
 private:
+    void bind_vertex_buffers(handle::resource const vertex_buffers[limits::max_vertex_buffers]);
+
+private:
     // non-owning constant (global)
     translator_global_memory _globals;
 
@@ -120,7 +123,7 @@ private:
     {
         handle::pipeline_state pipeline_state;
         handle::resource index_buffer;
-        handle::resource vertex_buffer;
+        uint64_t vertex_buffer_hash = uint64_t(-1);
 
         ID3D12RootSignature* raw_root_sig;
 
@@ -167,7 +170,7 @@ private:
         {
             pipeline_state = handle::null_pipeline_state;
             index_buffer = handle::null_resource;
-            vertex_buffer = handle::null_resource;
+            vertex_buffer_hash = uint64_t(-1);
 
             set_root_sig(nullptr);
         }

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -7,6 +7,13 @@
 #include <phantasm-hardware-interface/d3d12/fwd.hh>
 #include <phantasm-hardware-interface/d3d12/pools/linear_descriptor_allocator.hh>
 
+#ifdef PHI_HAS_OPTICK
+namespace Optick
+{
+struct EventData;
+}
+#endif
+
 namespace phi::d3d12
 {
 struct translator_thread_local_memory
@@ -79,6 +86,10 @@ struct command_list_translator
     void execute(cmd::begin_debug_label const& label);
 
     void execute(cmd::end_debug_label const&);
+
+    void execute(cmd::begin_profile_scope const& scope);
+
+    void execute(cmd::end_profile_scope const&);
 
     void execute(cmd::update_bottom_level const& blas_update);
 
@@ -206,6 +217,11 @@ private:
         }
 
     } _last_code_location;
+
+// debug state - current Optick GPU Event
+#ifdef PHI_HAS_OPTICK
+    Optick::EventData* _current_optick_event = nullptr;
+#endif
 };
 
 }

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -88,6 +88,8 @@ struct command_list_translator
 
     void execute(cmd::clear_textures const& clear_tex);
 
+    void execute(cmd::code_location_marker const& marker);
+
 private:
     // non-owning constant (global)
     translator_global_memory _globals;
@@ -188,6 +190,22 @@ private:
         }
 
     } _bound;
+
+    // debug state - cmd::code_location_marker
+    struct
+    {
+        char const* function;
+        char const* file;
+        int line;
+
+        void reset()
+        {
+            function = "NONE";
+            file = "NONE";
+            line = 0;
+        }
+
+    } _last_code_location;
 };
 
 }

--- a/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
+++ b/src/phantasm-hardware-interface/d3d12/cmd_list_translation.hh
@@ -44,7 +44,7 @@ struct command_list_translator
     void initialize(ID3D12Device* device, ShaderViewPool* sv_pool, ResourcePool* resource_pool, PipelineStateObjectPool* pso_pool, AccelStructPool* as_pool, QueryPool* query_pool);
     void destroy();
 
-    void translateCommandList(ID3D12GraphicsCommandList5* list, queue_type type, d3d12_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size);
+    void translateCommandList(ID3D12GraphicsCommandList5* list, queue_type type, incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size);
 
     void execute(cmd::begin_render_pass const& begin_rp);
 
@@ -96,7 +96,7 @@ private:
     translator_thread_local_memory _thread_local;
 
     // non-owning dynamic
-    d3d12_incomplete_state_cache* _state_cache = nullptr;
+    incomplete_state_cache* _state_cache = nullptr;
     ID3D12GraphicsCommandList5* _cmd_list = nullptr;
     queue_type _current_queue_type = queue_type::direct;
 

--- a/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
@@ -16,8 +16,7 @@ inline DXGI_FORMAT to_dxgi_format(phi::format fmt)
 {
     switch (fmt)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_TO_DXGI)
-        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_TO_DXGI)
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_TO_DXGI)
 
     case format::none:
     case format::MAX_FORMAT_RANGE:
@@ -31,8 +30,7 @@ inline phi::format to_pr_format(DXGI_FORMAT format)
 {
     switch (format)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_FROM_DXGI)
-        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_FROM_DXGI)
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_FROM_DXGI)
 
     default:
         return format::none;

--- a/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
@@ -8,135 +8,39 @@
 
 #include <phantasm-hardware-interface/types.hh>
 
+#include <phantasm-hardware-interface/common/format_info_list.hh>
+
 namespace phi::d3d12::util
 {
-[[nodiscard]] constexpr DXGI_FORMAT to_dxgi_format(phi::format format)
+inline DXGI_FORMAT to_dxgi_format(phi::format fmt)
 {
-    using af = phi::format;
-    switch (format)
+    switch (fmt)
     {
-    case af::rgba32f:
-        return DXGI_FORMAT_R32G32B32A32_FLOAT;
-    case af::rgb32f:
-        return DXGI_FORMAT_R32G32B32_FLOAT;
-    case af::rg32f:
-        return DXGI_FORMAT_R32G32_FLOAT;
-    case af::r32f:
-        return DXGI_FORMAT_R32_FLOAT;
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_TO_DXGI)
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_TO_DXGI)
 
-    case af::rgba32i:
-        return DXGI_FORMAT_R32G32B32A32_SINT;
-    case af::rgb32i:
-        return DXGI_FORMAT_R32G32B32_SINT;
-    case af::rg32i:
-        return DXGI_FORMAT_R32G32_SINT;
-    case af::r32i:
-        return DXGI_FORMAT_R32_SINT;
-
-    case af::rgba32u:
-        return DXGI_FORMAT_R32G32B32A32_UINT;
-    case af::rgb32u:
-        return DXGI_FORMAT_R32G32B32_UINT;
-    case af::rg32u:
-        return DXGI_FORMAT_R32G32_UINT;
-    case af::r32u:
-        return DXGI_FORMAT_R32_UINT;
-
-    case af::rgba16i:
-        return DXGI_FORMAT_R16G16B16A16_SINT;
-    case af::rg16i:
-        return DXGI_FORMAT_R16G16_SINT;
-    case af::r16i:
-        return DXGI_FORMAT_R16_SINT;
-
-    case af::rgba16u:
-        return DXGI_FORMAT_R16G16B16A16_UINT;
-    case af::rg16u:
-        return DXGI_FORMAT_R16G16_UINT;
-    case af::r16u:
-        return DXGI_FORMAT_R16_UINT;
-
-    case af::rgba16f:
-        return DXGI_FORMAT_R16G16B16A16_FLOAT;
-    case af::rg16f:
-        return DXGI_FORMAT_R16G16_FLOAT;
-    case af::r16f:
-        return DXGI_FORMAT_R16_FLOAT;
-
-    case af::rgba8i:
-        return DXGI_FORMAT_R8G8B8A8_SINT;
-    case af::rg8i:
-        return DXGI_FORMAT_R8G8_SINT;
-    case af::r8i:
-        return DXGI_FORMAT_R8_SINT;
-
-    case af::rgba8u:
-        return DXGI_FORMAT_R8G8B8A8_UINT;
-    case af::rg8u:
-        return DXGI_FORMAT_R8G8_UINT;
-    case af::r8u:
-        return DXGI_FORMAT_R8_UINT;
-
-    case af::rgba8un:
-        return DXGI_FORMAT_R8G8B8A8_UNORM;
-    case af::rg8un:
-        return DXGI_FORMAT_R8G8_UNORM;
-    case af::r8un:
-        return DXGI_FORMAT_R8_UNORM;
-
-    case af::rgba8un_srgb:
-        return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
-
-    case af::bgra8un:
-        return DXGI_FORMAT_B8G8R8A8_UNORM;
-    case af::b10g11r11uf:
-        return DXGI_FORMAT_R11G11B10_FLOAT; // this is incorrectly named, order is as in our enum
-
-    case af::r10g10b10a2u:
-        return DXGI_FORMAT_R10G10B10A2_UINT;
-    case af::r10g10b10a2un:
-        return DXGI_FORMAT_R10G10B10A2_UNORM;
-
-    case af::bc1_8un:
-        return DXGI_FORMAT_BC1_UNORM;
-    case af::bc1_8un_srgb:
-        return DXGI_FORMAT_BC1_UNORM_SRGB;
-    case af::bc2_8un:
-        return DXGI_FORMAT_BC2_UNORM;
-    case af::bc2_8un_srgb:
-        return DXGI_FORMAT_BC2_UNORM_SRGB;
-    case af::bc3_8un:
-        return DXGI_FORMAT_BC3_UNORM;
-    case af::bc3_8un_srgb:
-        return DXGI_FORMAT_BC3_UNORM_SRGB;
-    case af::bc6h_16f:
-        return DXGI_FORMAT_BC6H_SF16;
-    case af::bc6h_16uf:
-        return DXGI_FORMAT_BC6H_UF16;
-
-    case af::r24un_g8t:
-        return DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
-    case af::r24t_g8u:
-        return DXGI_FORMAT_X24_TYPELESS_G8_UINT;
-
-    case af::depth32f:
-        return DXGI_FORMAT_D32_FLOAT;
-    case af::depth16un:
-        return DXGI_FORMAT_D16_UNORM;
-    case af::depth32f_stencil8u:
-        return DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
-    case af::depth24un_stencil8u:
-        return DXGI_FORMAT_D24_UNORM_S8_UINT;
-
-    case af::none:
-    case af::MAX_FORMAT_RANGE:
+    case format::none:
+    case format::MAX_FORMAT_RANGE:
         return DXGI_FORMAT_UNKNOWN;
     }
-    CC_UNREACHABLE_SWITCH_WORKAROUND(format);
+
+    CC_UNREACHABLE("invalid format enum");
+}
+
+inline phi::format to_pr_format(DXGI_FORMAT format)
+{
+    switch (format)
+    {
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_FROM_DXGI)
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_FROM_DXGI)
+
+    default:
+        return format::none;
+    }
 }
 
 /// Viewing some formats requires special DXGI_FORMATs
-[[nodiscard]] constexpr DXGI_FORMAT to_view_dxgi_format(phi::format format)
+inline DXGI_FORMAT to_view_dxgi_format(phi::format format)
 {
     using af = phi::format;
     switch (format)
@@ -152,130 +56,6 @@ namespace phi::d3d12::util
 
     default:
         return to_dxgi_format(format);
-    }
-}
-
-[[nodiscard]] constexpr phi::format to_pr_format(DXGI_FORMAT format)
-{
-    using af = phi::format;
-    switch (format)
-    {
-    case DXGI_FORMAT_R32G32B32A32_FLOAT:
-        return af::rgba32f;
-    case DXGI_FORMAT_R32G32B32_FLOAT:
-        return af::rgb32f;
-    case DXGI_FORMAT_R32G32_FLOAT:
-        return af::rg32f;
-    case DXGI_FORMAT_R32_FLOAT:
-        return af::r32f;
-
-    case DXGI_FORMAT_R32G32B32A32_SINT:
-        return af::rgba32i;
-    case DXGI_FORMAT_R32G32B32_SINT:
-        return af::rgb32i;
-    case DXGI_FORMAT_R32G32_SINT:
-        return af::rg32i;
-    case DXGI_FORMAT_R32_SINT:
-        return af::r32i;
-
-    case DXGI_FORMAT_R32G32B32A32_UINT:
-        return af::rgba32u;
-    case DXGI_FORMAT_R32G32B32_UINT:
-        return af::rgb32u;
-    case DXGI_FORMAT_R32G32_UINT:
-        return af::rg32u;
-    case DXGI_FORMAT_R32_UINT:
-        return af::r32u;
-
-    case DXGI_FORMAT_R16G16B16A16_SINT:
-        return af::rgba16i;
-    case DXGI_FORMAT_R16G16_SINT:
-        return af::rg16i;
-    case DXGI_FORMAT_R16_SINT:
-        return af::r16i;
-
-    case DXGI_FORMAT_R16G16B16A16_UINT:
-        return af::rgba16u;
-    case DXGI_FORMAT_R16G16_UINT:
-        return af::rg16u;
-    case DXGI_FORMAT_R16_UINT:
-        return af::r16u;
-
-    case DXGI_FORMAT_R16G16B16A16_FLOAT:
-        return af::rgba16f;
-    case DXGI_FORMAT_R16G16_FLOAT:
-        return af::rg16f;
-    case DXGI_FORMAT_R16_FLOAT:
-        return af::r16f;
-
-    case DXGI_FORMAT_R8G8B8A8_SINT:
-        return af::rgba8i;
-    case DXGI_FORMAT_R8G8_SINT:
-        return af::rg8i;
-    case DXGI_FORMAT_R8_SINT:
-        return af::r8i;
-
-    case DXGI_FORMAT_R8G8B8A8_UINT:
-        return af::rgba8u;
-    case DXGI_FORMAT_R8G8_UINT:
-        return af::rg8u;
-    case DXGI_FORMAT_R8_UINT:
-        return af::r8u;
-
-    case DXGI_FORMAT_R8G8B8A8_UNORM:
-        return af::rgba8un;
-    case DXGI_FORMAT_R8G8_UNORM:
-        return af::rg8un;
-    case DXGI_FORMAT_R8_UNORM:
-        return af::r8un;
-
-        // sRGB formats
-    case DXGI_FORMAT_R8G8B8A8_UNORM_SRGB:
-        return af::rgba8un_srgb;
-
-        // swizzled and irregular formats
-    case DXGI_FORMAT_B8G8R8A8_UNORM:
-        return af::bgra8un;
-    case DXGI_FORMAT_R11G11B10_FLOAT: // this is incorrectly named, order is as in our enum
-        return af::b10g11r11uf;
-    case DXGI_FORMAT_R10G10B10A2_UINT:
-        return af::r10g10b10a2u;
-    case DXGI_FORMAT_R10G10B10A2_UNORM:
-        return af::r10g10b10a2un;
-
-        // compressed formats
-    case DXGI_FORMAT_BC1_UNORM:
-        return af::bc1_8un;
-    case DXGI_FORMAT_BC1_UNORM_SRGB:
-        return af::bc1_8un_srgb;
-    case DXGI_FORMAT_BC2_UNORM:
-        return af::bc2_8un;
-    case DXGI_FORMAT_BC2_UNORM_SRGB:
-        return af::bc2_8un_srgb;
-    case DXGI_FORMAT_BC3_UNORM:
-        return af::bc3_8un;
-    case DXGI_FORMAT_BC3_UNORM_SRGB:
-        return af::bc3_8un_srgb;
-    case DXGI_FORMAT_BC6H_SF16:
-        return af::bc6h_16f;
-    case DXGI_FORMAT_BC6H_UF16:
-        return af::bc6h_16uf;
-
-        // depth formats
-    case DXGI_FORMAT_D32_FLOAT:
-        return af::depth32f;
-    case DXGI_FORMAT_D16_UNORM:
-        return af::depth16un;
-
-        // depth stencil formats
-    case DXGI_FORMAT_D32_FLOAT_S8X24_UINT:
-        return af::depth32f_stencil8u;
-    case DXGI_FORMAT_D24_UNORM_S8_UINT:
-        return af::depth24un_stencil8u;
-
-    default:
-        CC_ASSERT(false && "untranslatable DXGI_FORMAT");
-        return af::none;
     }
 }
 }

--- a/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/dxgi_format.hh
@@ -92,6 +92,11 @@ namespace phi::d3d12::util
     case af::b10g11r11uf:
         return DXGI_FORMAT_R11G11B10_FLOAT; // this is incorrectly named, order is as in our enum
 
+    case af::r10g10b10a2u:
+        return DXGI_FORMAT_R10G10B10A2_UINT;
+    case af::r10g10b10a2un:
+        return DXGI_FORMAT_R10G10B10A2_UNORM;
+
     case af::bc1_8un:
         return DXGI_FORMAT_BC1_UNORM;
     case af::bc1_8un_srgb:
@@ -233,6 +238,10 @@ namespace phi::d3d12::util
         return af::bgra8un;
     case DXGI_FORMAT_R11G11B10_FLOAT: // this is incorrectly named, order is as in our enum
         return af::b10g11r11uf;
+    case DXGI_FORMAT_R10G10B10A2_UINT:
+        return af::r10g10b10a2u;
+    case DXGI_FORMAT_R10G10B10A2_UNORM:
+        return af::r10g10b10a2un;
 
         // compressed formats
     case DXGI_FORMAT_BC1_UNORM:

--- a/src/phantasm-hardware-interface/d3d12/common/gpu_feature_info.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/gpu_feature_info.hh
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+
+#include <clean-core/flags.hh>
+
+namespace phi::d3d12
+{
+// explicit GPU features
+enum class gpu_feature : uint8_t
+{
+    conservative_raster,      ///< conservative rasterization (>= tier 1)
+    mesh_shaders,             ///< task/mesh shading pipeline (>= tier 1)
+    rasterizer_ordered_views, ///< rasterizer ordered views (ROVs)
+    hlsl_wave_ops             ///< HLSL SM6 wave ops
+};
+
+using gpu_feature_flags = cc::flags<gpu_feature, 32>;
+
+struct gpu_feature_info
+{
+    enum e_hlsl_shader_model_version : uint8_t
+    {
+        hlsl_sm5_1, ///< shader model >= 5.1
+        hlsl_sm6_0, ///< shader model >= 6.0
+        hlsl_sm6_1, ///< shader model >= 6.1
+        hlsl_sm6_2, ///< shader model >= 6.2
+        hlsl_sm6_3, ///< shader model >= 6.3
+        hlsl_sm6_4, ///< shader model >= 6.4
+        hlsl_sm6_5, ///< shader model >= 6.5
+        hlsl_sm6_6, ///< shader model >= 6.6
+    };
+
+    enum e_raytracing_tier : uint8_t
+    {
+        raytracing_unsupported,
+        raytracing_t1_0,
+        raytracing_t1_1
+    };
+
+    enum e_variable_rate_shading_tier : uint8_t
+    {
+        variable_rate_shading_unsupported,
+        variable_rate_shading_t1_0,
+        variable_rate_shading_t2_0
+    };
+
+    cc::flags<gpu_feature, 32> features = cc::no_flags;
+    e_hlsl_shader_model_version sm_version = hlsl_sm5_1;
+    e_raytracing_tier raytracing = raytracing_unsupported;
+    e_variable_rate_shading_tier variable_rate_shading = variable_rate_shading_unsupported;
+};
+}

--- a/src/phantasm-hardware-interface/d3d12/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/native_enum.hh
@@ -570,7 +570,7 @@ namespace phi::d3d12::util
     return D3D12_BLEND_ZERO;
 }
 
-[[nodiscard]] constexpr D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS to_native_flags(accel_struct_build_flags_t flags)
+[[nodiscard]] constexpr D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS to_native_accel_struct_build_flags(accel_struct_build_flags_t flags)
 {
     D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS res = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_NONE;
 
@@ -584,6 +584,22 @@ namespace phi::d3d12::util
         res |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_PREFER_FAST_BUILD;
     if (flags & accel_struct_build_flags::minimize_memory)
         res |= D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAG_MINIMIZE_MEMORY;
+
+    return res;
+}
+
+[[nodiscard]] constexpr D3D12_RESOURCE_FLAGS to_native_resource_usage_flags(resource_usage_flags_t flags)
+{
+    D3D12_RESOURCE_FLAGS res = D3D12_RESOURCE_FLAG_NONE;
+
+    if (flags & resource_usage_flags::allow_uav)
+        res |= D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
+    if (flags & resource_usage_flags::allow_depth_stencil)
+        res |= D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+    if (flags & resource_usage_flags::allow_render_target)
+        res |= D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET;
+    if (flags & resource_usage_flags::deny_shader_resource)
+        res |= D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE;
 
     return res;
 }

--- a/src/phantasm-hardware-interface/d3d12/common/util.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/util.cc
@@ -19,7 +19,7 @@ cc::capped_vector<D3D12_INPUT_ELEMENT_DESC, 16> phi::d3d12::util::get_native_ver
         elem.AlignedByteOffset = ai.offset;
         elem.Format = util::to_dxgi_format(ai.fmt);
         elem.SemanticIndex = 0;
-        elem.InputSlot = 0;
+        elem.InputSlot = ai.vertex_buffer_i;
         elem.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
         elem.InstanceDataStepRate = 0;
     }

--- a/src/phantasm-hardware-interface/d3d12/common/verify.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/verify.cc
@@ -146,8 +146,17 @@ DWORD get_hresult_error_message(HRESULT error_code, char* out_string, DWORD out_
     // this is a more verbose way of calling _com_error(hr).ErrorMessage(), made for two reasons:
     // 1. FORMAT_MESSAGE_MAX_WIDTH_MASK strips the \r symbol from the string
     // 2. The language can be forced to english with the fourth arg (MAKELANGID(...))
-    return FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_MAX_WIDTH_MASK, nullptr, error_code, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), // always english
-                          out_string, out_length, nullptr);
+    //      HOWEVER, under some circumstances this requires a loaded MUI file which is unlikely in general
+    //      thus, use zero
+
+    auto const res = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_MAX_WIDTH_MASK, nullptr, error_code, 0, out_string, out_length, nullptr);
+
+    if (res == 0)
+    {
+        PHI_LOG_ASSERT("FormatMessageA failed: {}", GetLastError());
+    }
+
+    return res;
 }
 
 void print_dred_information(ID3D12Device* device)
@@ -259,13 +268,17 @@ void print_dred_information(ID3D12Device* device)
 
 void show_error_alert_box(char const* /*expression*/, char const* error, char const* filename, int line)
 {
-    char buf[1024];
-    snprintf(buf, sizeof(buf), "Fatal D3D12 error:\n\n%s\n\nFile:\n%s:%d", error, filename, line);
-
-    ::MessageBeep(MB_ICONERROR);
-    ::MessageBoxA(nullptr, buf, "PHI D3D12 Error", MB_OK | MB_ICONERROR);
+#if defined(_DEBUG)
+    if (!IsDebuggerPresent())
+    {
+        // MessageBeep(MB_ICONERROR);
+        _CrtDbgReport(_CRT_ERROR, filename, line, "phantasm-hardware-interface.dll", "%s", error);
+        // we only survive this call if Retry or Ignore was clicked
+        // let control run into the __debugbreak next
+    }
+#endif // CC_OS_WINDOWS && _DEBUG
 }
-}
+} // anon namespace
 
 
 void phi::d3d12::detail::verify_failure_handler(HRESULT hr, const char* expression, const char* filename, int line, ID3D12Device* device)
@@ -299,8 +312,8 @@ void phi::d3d12::detail::verify_failure_handler(HRESULT hr, const char* expressi
 
 void phi::d3d12::detail::dred_assert_handler(void* device_child, const char* expression, const char* filename, int line)
 {
-    PHI_LOG_ASSERT("device-removal related assert on {} failed", expression);
-    PHI_LOG_ASSERT("  file {}:{}", filename, line);
+    PHI_LOG_ASSERT("device removed - assert on {} failed", expression);
+    PHI_LOG_ASSERT("  in file {}:{}", filename, line);
 
     auto* const as_device_child = static_cast<ID3D12DeviceChild*>(device_child);
 
@@ -312,8 +325,13 @@ void phi::d3d12::detail::dred_assert_handler(void* device_child, const char* exp
     }
     else
     {
-        PHI_LOG_ASSERT("Failed to recover device from ID3D12DeviceChild {} (error: {})", device_child, static_cast<char const*>(_com_error(hr).Description()));
+        char error_string[1024];
+        error_string[0] = '\0';
+        get_hresult_error_message(hr, error_string, sizeof(error_string));
+        PHI_LOG_ASSERT("Failed to recover device from ID3D12DeviceChild {}", device_child);
+        PHI_LOG_ASSERT("  error:");
+        PHI_LOG_ASSERT("    {}: \"{}\"", get_hresult_literal(hr), static_cast<char const*>(error_string));
     }
 
-    show_error_alert_box(expression, "DRED Assert (device removed)", filename, line);
+    show_error_alert_box(expression, "DRED Assert - Device Removed", filename, line);
 }

--- a/src/phantasm-hardware-interface/d3d12/common/verify.cc
+++ b/src/phantasm-hardware-interface/d3d12/common/verify.cc
@@ -295,9 +295,6 @@ void phi::d3d12::detail::verify_failure_handler(HRESULT hr, const char* expressi
     }
 
     show_error_alert_box(expression, error_string, filename, line);
-
-    // TODO: Graceful shutdown
-    std::abort();
 }
 
 void phi::d3d12::detail::dred_assert_handler(void* device_child, const char* expression, const char* filename, int line)
@@ -319,7 +316,4 @@ void phi::d3d12::detail::dred_assert_handler(void* device_child, const char* exp
     }
 
     show_error_alert_box(expression, "DRED Assert (device removed)", filename, line);
-
-    // TODO: Graceful shutdown
-    std::abort();
 }

--- a/src/phantasm-hardware-interface/d3d12/common/verify.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/verify.hh
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <clean-core/macros.hh>
+#include <clean-core/assert.hh>
 
 #include <phantasm-hardware-interface/common/value_category.hh>
 
@@ -24,18 +24,22 @@ namespace phi::d3d12::detail
 /// Attempts to recover the parent d3d12device from the given device child and
 /// query DRED diagnostic information
 #define PHI_D3D12_DRED_ASSERT(_expr_, _device_child_) \
-    (CC_UNLIKELY(!(_expr_)) ? ::phi::d3d12::detail::dred_assert_handler(_device_child_, #_expr_, __FILE__, __LINE__) : void(0))
+    (CC_UNLIKELY(!(_expr_)) ? (::phi::d3d12::detail::dred_assert_handler(_device_child_, #_expr_, __FILE__, __LINE__), CC_BREAK_AND_ABORT()) : void(0))
 
 /// Terminates with a detailed error message if the given HRESULT lvalue indicates failure
-#define PHI_D3D12_ASSERT(_val_)                                                                     \
-    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_D3D12_VERIFY for prvalue expressions"); \
-    (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(_val_)) ? ::phi::d3d12::detail::verify_failure_handler(_val_, "", __FILE__, __LINE__, nullptr) : void(0))
+#define PHI_D3D12_ASSERT(_val_)                                                                                         \
+    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_D3D12_VERIFY for prvalue expressions");                     \
+    (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(_val_))                                                                \
+         ? (::phi::d3d12::detail::verify_failure_handler(_val_, "", __FILE__, __LINE__, nullptr), CC_BREAK_AND_ABORT()) \
+         : void(0))
 
 
 /// Terminates with a detailed error message if the given HRESULT lvalue indicates failure, takes the current ID3D12 Device for further information
-#define PHI_D3D12_ASSERT_FULL(_val_, _device_ptr_)                                                       \
-    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_D3D12_VERIFY_FULL for prvalue expressions"); \
-    (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(_val_)) ? ::phi::d3d12::detail::verify_failure_handler(_val_, "", __FILE__, __LINE__, _device_ptr_) : void(0))
+#define PHI_D3D12_ASSERT_FULL(_val_, _device_ptr_)                                                                           \
+    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_D3D12_VERIFY_FULL for prvalue expressions");                     \
+    (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(_val_))                                                                     \
+         ? (::phi::d3d12::detail::verify_failure_handler(_val_, "", __FILE__, __LINE__, _device_ptr_), CC_BREAK_AND_ABORT()) \
+         : void(0))
 
 /// Executes the given expression and terminates with a detailed error message if the HRESULT indicates failure
 #define PHI_D3D12_VERIFY(_expr_)                                                                        \
@@ -46,6 +50,7 @@ namespace phi::d3d12::detail
         if (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(op_res)))                                       \
         {                                                                                               \
             ::phi::d3d12::detail::verify_failure_handler(op_res, #_expr_, __FILE__, __LINE__, nullptr); \
+            CC_BREAK_AND_ABORT();                                                                       \
         }                                                                                               \
     } while (0)
 
@@ -58,6 +63,7 @@ namespace phi::d3d12::detail
         if (CC_UNLIKELY(::phi::d3d12::detail::hr_failed(op_res)))                                            \
         {                                                                                                    \
             ::phi::d3d12::detail::verify_failure_handler(op_res, #_expr_, __FILE__, __LINE__, _device_ptr_); \
+            CC_BREAK_AND_ABORT();                                                                            \
         }                                                                                                    \
     } while (0)
 

--- a/src/phantasm-hardware-interface/d3d12/fwd.hh
+++ b/src/phantasm-hardware-interface/d3d12/fwd.hh
@@ -18,6 +18,5 @@ class QueryPool;
 class CPUDescriptorLinearAllocator;
 
 struct command_list_translator;
-
-using d3d12_incomplete_state_cache = phi::detail::generic_incomplete_state_cache<D3D12_RESOURCE_STATES>;
+struct incomplete_state_cache;
 }

--- a/src/phantasm-hardware-interface/d3d12/memory/ResourceAllocator.cc
+++ b/src/phantasm-hardware-interface/d3d12/memory/ResourceAllocator.cc
@@ -47,7 +47,6 @@ D3D12MA::Allocation* phi::d3d12::ResourceAllocator::allocate(const D3D12_RESOURC
     allocation_desc.HeapType = heap_type;
 
     D3D12MA::Allocation* res;
-    auto const hr = mAllocator->CreateResource(&allocation_desc, &desc, initial_state, clear_value, &res, __uuidof(ID3D12Resource), nullptr);
-    PHI_D3D12_ASSERT_FULL(hr, mDevice);
+    PHI_D3D12_VERIFY_FULL(mAllocator->CreateResource(&allocation_desc, &desc, initial_state, clear_value, &res, __uuidof(ID3D12Resource), nullptr), mDevice);
     return res;
 }

--- a/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
+++ b/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
@@ -42,7 +42,8 @@ ID3D12PipelineState* phi::d3d12::create_pipeline_state(ID3D12Device& device,
         }
     }
 
-    CC_ASSERT(framebuffer_format.render_targets.empty() ? true : pso_desc.PS.pShaderBytecode != nullptr && "creating a PSO with rendertargets, but missing pixel shader");
+    // this is not really a requirement
+    //CC_ASSERT(framebuffer_format.render_targets.empty() ? true : pso_desc.PS.pShaderBytecode != nullptr && "creating a PSO with rendertargets, but missing pixel shader");
 
     pso_desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     pso_desc.RasterizerState.CullMode = util::to_native(config.cull);

--- a/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
+++ b/src/phantasm-hardware-interface/d3d12/pipeline_state.cc
@@ -43,7 +43,7 @@ ID3D12PipelineState* phi::d3d12::create_pipeline_state(ID3D12Device& device,
     }
 
     // this is not really a requirement
-    //CC_ASSERT(framebuffer_format.render_targets.empty() ? true : pso_desc.PS.pShaderBytecode != nullptr && "creating a PSO with rendertargets, but missing pixel shader");
+    // CC_ASSERT(framebuffer_format.render_targets.empty() ? true : pso_desc.PS.pShaderBytecode != nullptr && "creating a PSO with rendertargets, but missing pixel shader");
 
     pso_desc.RasterizerState = CD3DX12_RASTERIZER_DESC(D3D12_DEFAULT);
     pso_desc.RasterizerState.CullMode = util::to_native(config.cull);

--- a/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/accel_struct_pool.cc
@@ -72,7 +72,7 @@ phi::handle::accel_struct phi::d3d12::AccelStructPool::createBottomLevelAS(cc::s
     // Assemble the bottom level AS object
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS as_input_info = {};
     as_input_info.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL;
-    as_input_info.Flags = util::to_native_flags(flags);
+    as_input_info.Flags = util::to_native_accel_struct_build_flags(flags);
     as_input_info.NumDescs = UINT(new_node.geometries.size());
     as_input_info.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
     as_input_info.pGeometryDescs = new_node.geometries.data();
@@ -108,7 +108,7 @@ phi::handle::accel_struct phi::d3d12::AccelStructPool::createTopLevelAS(unsigned
     // Assemble the bottom level AS object
     D3D12_BUILD_RAYTRACING_ACCELERATION_STRUCTURE_INPUTS as_input_info = {};
     as_input_info.Type = D3D12_RAYTRACING_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL;
-    as_input_info.Flags = util::to_native_flags(flags);
+    as_input_info.Flags = util::to_native_accel_struct_build_flags(flags);
     as_input_info.NumDescs = num_instances;
     as_input_info.DescsLayout = D3D12_ELEMENTS_LAYOUT_ARRAY;
     as_input_info.pGeometryDescs = nullptr;

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
@@ -208,14 +208,15 @@ void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
     // initialize the three allocator bundles (direct, compute, copy)
     for (auto i = 0u; i < thread_allocators.size(); ++i)
     {
-        thread_allocators[i]->bundle_direct.initialize(*backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_DIRECT, num_direct_allocs, num_direct_lists_per_alloc,
+        thread_allocators[i]->bundle_direct.initialize(*backend.nativeGetDevice(), static_alloc, D3D12_COMMAND_LIST_TYPE_DIRECT, num_direct_allocs,
+                                                       num_direct_lists_per_alloc,
                                                        cc::span{mRawListsDirect}.subspan(i * num_direct_lists_per_thread, num_direct_lists_per_thread));
 
         thread_allocators[i]->bundle_compute.initialize(
-            *backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_COMPUTE, num_compute_allocs, num_compute_lists_per_alloc,
+            *backend.nativeGetDevice(), static_alloc, D3D12_COMMAND_LIST_TYPE_COMPUTE, num_compute_allocs, num_compute_lists_per_alloc,
             cc::span{mRawListsCompute}.subspan(i * num_compute_lists_per_thread, num_compute_lists_per_thread));
 
-        thread_allocators[i]->bundle_copy.initialize(*backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_COPY, num_copy_allocs, num_copy_lists_per_alloc,
+        thread_allocators[i]->bundle_copy.initialize(*backend.nativeGetDevice(), static_alloc, D3D12_COMMAND_LIST_TYPE_COPY, num_copy_allocs, num_copy_lists_per_alloc,
                                                      cc::span{mRawListsCopy}.subspan(i * num_copy_lists_per_thread, num_copy_lists_per_thread));
     }
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
@@ -174,12 +174,14 @@ void phi::d3d12::CommandListPool::freeOnDiscard(cc::span<const phi::handle::comm
 }
 
 void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
+                                             cc::allocator* static_alloc,
                                              int num_direct_allocs,
                                              int num_direct_lists_per_alloc,
                                              int num_compute_allocs,
                                              int num_compute_lists_per_alloc,
                                              int num_copy_allocs,
                                              int num_copy_lists_per_alloc,
+                                             int max_num_unique_transitions_per_cmdlist,
                                              cc::span<CommandAllocatorsPerThread*> thread_allocators)
 {
     auto const num_direct_lists_per_thread = size_t(num_direct_allocs * num_direct_lists_per_alloc);
@@ -190,24 +192,30 @@ void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
     auto const num_compute_lists_total = num_compute_lists_per_thread * thread_allocators.size();
     auto const num_copy_lists_total = num_copy_lists_per_thread * thread_allocators.size();
 
+    auto const num_lists_total = num_direct_lists_total + num_compute_lists_total + num_copy_lists_total;
+
     // initialize data structures
-    mPoolDirect.initialize(num_direct_lists_total);
-    mRawListsDirect = mRawListsDirect.uninitialized(num_direct_lists_total);
-    mPoolCompute.initialize(num_compute_lists_total);
-    mRawListsCompute = mRawListsCompute.uninitialized(num_compute_lists_total);
-    mPoolCopy.initialize(num_copy_lists_total);
-    mRawListsCopy = mRawListsCopy.uninitialized(num_copy_lists_total);
+    mPoolDirect.initialize(num_direct_lists_total, static_alloc);
+    mRawListsDirect = mRawListsDirect.uninitialized(num_direct_lists_total, static_alloc);
+    mPoolCompute.initialize(num_compute_lists_total, static_alloc);
+    mRawListsCompute = mRawListsCompute.uninitialized(num_compute_lists_total, static_alloc);
+    mPoolCopy.initialize(num_copy_lists_total, static_alloc);
+    mRawListsCopy = mRawListsCopy.uninitialized(num_copy_lists_total, static_alloc);
+
+    mNumStateCacheEntriesPerCmdlist = max_num_unique_transitions_per_cmdlist;
+    mFlatStateCacheEntries = mFlatStateCacheEntries.uninitialized(num_lists_total * max_num_unique_transitions_per_cmdlist, static_alloc);
 
     // initialize the three allocator bundles (direct, compute, copy)
     for (auto i = 0u; i < thread_allocators.size(); ++i)
     {
-        thread_allocators[i]->bundle_direct.initialize(*backend.getDevice5(), D3D12_COMMAND_LIST_TYPE_DIRECT, num_direct_allocs, num_direct_lists_per_alloc,
+        thread_allocators[i]->bundle_direct.initialize(*backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_DIRECT, num_direct_allocs, num_direct_lists_per_alloc,
                                                        cc::span{mRawListsDirect}.subspan(i * num_direct_lists_per_thread, num_direct_lists_per_thread));
 
-        thread_allocators[i]->bundle_compute.initialize(*backend.getDevice5(), D3D12_COMMAND_LIST_TYPE_COMPUTE, num_compute_allocs, num_compute_lists_per_alloc,
-                                                        cc::span{mRawListsCompute}.subspan(i * num_compute_lists_per_thread, num_compute_lists_per_thread));
+        thread_allocators[i]->bundle_compute.initialize(
+            *backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_COMPUTE, num_compute_allocs, num_compute_lists_per_alloc,
+            cc::span{mRawListsCompute}.subspan(i * num_compute_lists_per_thread, num_compute_lists_per_thread));
 
-        thread_allocators[i]->bundle_copy.initialize(*backend.getDevice5(), D3D12_COMMAND_LIST_TYPE_COPY, num_copy_allocs, num_copy_lists_per_alloc,
+        thread_allocators[i]->bundle_copy.initialize(*backend.getDevice5(), static_alloc, D3D12_COMMAND_LIST_TYPE_COPY, num_copy_allocs, num_copy_lists_per_alloc,
                                                      cc::span{mRawListsCopy}.subspan(i * num_copy_lists_per_thread, num_copy_lists_per_thread));
     }
 }
@@ -229,18 +237,26 @@ phi::handle::command_list phi::d3d12::CommandListPool::acquireNodeInternal(phi::
                                                                            ID3D12GraphicsCommandList5*& out_cmdlist)
 {
     auto& pool = getPool(type);
-    unsigned const res_index = pool.acquire();
+    unsigned const res = pool.acquire();
 
-    out_node = &pool.get(res_index);
-    auto const res_handle = IndexToHandle(res_index, type);
-    out_cmdlist = getList(res_handle, type);
-    return res_handle;
+    unsigned const res_flat_index = pool.get_handle_index(res) + getFlatIndexOffset(type);
+
+    out_node = &pool.get(res);
+    out_node->state_cache.initialize(cc::span(mFlatStateCacheEntries).subspan(res_flat_index * mNumStateCacheEntriesPerCmdlist, mNumStateCacheEntriesPerCmdlist));
+
+    auto const res_with_padding_flags = AddHandlePaddingFlags(res, type);
+    out_cmdlist = getList(res_with_padding_flags, type);
+    return res_with_padding_flags;
 }
 
-void phi::d3d12::CommandAllocatorBundle::initialize(
-    ID3D12Device5& device, D3D12_COMMAND_LIST_TYPE type, int num_allocs, int num_lists_per_alloc, cc::span<ID3D12GraphicsCommandList5*> out_list)
+void phi::d3d12::CommandAllocatorBundle::initialize(ID3D12Device5& device,
+                                                    cc::allocator* static_alloc,
+                                                    D3D12_COMMAND_LIST_TYPE type,
+                                                    int num_allocs,
+                                                    int num_lists_per_alloc,
+                                                    cc::span<ID3D12GraphicsCommandList5*> out_list)
 {
-    mAllocators = mAllocators.defaulted(static_cast<size_t>(num_allocs));
+    mAllocators = mAllocators.defaulted(size_t(num_allocs), static_alloc);
 
     // Initialize allocators, create command lists
 
@@ -317,6 +333,6 @@ void phi::d3d12::CommandAllocatorBundle::internalInit(ID3D12Device5& device,
     {
         PHI_D3D12_VERIFY(device.CreateCommandList(0, list_type, raw_alloc, nullptr, IID_PPV_ARGS(&out_cmdlists[i])));
         out_cmdlists[i]->Close();
-        util::set_object_name(out_cmdlists[i], "pooled %s cmdlist #%d, alloc_bundle %zx", queuetype_literal, i, this);
+        util::set_object_name(out_cmdlists[i], "pooled %s cmdlist #%d, alloc_bundle %p", queuetype_literal, i, this);
     }
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -4,9 +4,9 @@
 #include <cstdint>
 
 #include <clean-core/array.hh>
+#include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/bits.hh>
 #include <clean-core/capped_array.hh>
-#include <clean-core/atomic_linked_pool.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/common/incomplete_state_cache.hh>

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.hh
@@ -3,16 +3,16 @@
 #include <atomic>
 #include <cstdint>
 
-#include <clean-core/array.hh>
+#include <clean-core/alloc_array.hh>
 #include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/bits.hh>
 #include <clean-core/capped_array.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
-#include <phantasm-hardware-interface/common/incomplete_state_cache.hh>
 
 #include <phantasm-hardware-interface/d3d12/Fence.hh>
 #include <phantasm-hardware-interface/d3d12/common/d3d12_sanitized.hh>
+#include <phantasm-hardware-interface/d3d12/common/incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/d3d12/fwd.hh>
 
 namespace phi::d3d12
@@ -93,7 +93,7 @@ private:
 class CommandAllocatorBundle
 {
 public:
-    void initialize(ID3D12Device5& device, D3D12_COMMAND_LIST_TYPE type, int num_allocs, int num_lists_per_alloc, cc::span<ID3D12GraphicsCommandList5*> out_list);
+    void initialize(ID3D12Device5& device, cc::allocator* static_alloc, D3D12_COMMAND_LIST_TYPE type, int num_allocs, int num_lists_per_alloc, cc::span<ID3D12GraphicsCommandList5*> out_list);
     void destroy();
 
     /// Resets the given command list to use memory by an appropriate allocator
@@ -107,7 +107,7 @@ private:
     void internalInit(ID3D12Device5& device, cmd_allocator_node& node, D3D12_COMMAND_LIST_TYPE list_type, unsigned num_cmdlists, cc::span<ID3D12GraphicsCommandList5*> out_cmdlists);
 
 private:
-    cc::array<cmd_allocator_node> mAllocators;
+    cc::alloc_array<cmd_allocator_node> mAllocators;
     size_t mActiveIndex = 0u;
 };
 
@@ -152,7 +152,7 @@ private:
         // - the command list is freshly reset using an appropriate allocator
         // - the responsible_allocator must be informed on submit or discard
         cmd_allocator_node* responsible_allocator;
-        d3d12_incomplete_state_cache state_cache;
+        incomplete_state_cache state_cache;
     };
 
     using cmdlist_linked_pool_t = cc::atomic_linked_pool<cmd_list_node>;
@@ -164,7 +164,7 @@ private:
         return queue_type(num_leading_zeroes);
     }
 
-    static constexpr handle::command_list IndexToHandle(uint32_t pool_handle, queue_type type)
+    static constexpr handle::command_list AddHandlePaddingFlags(uint32_t pool_handle, queue_type type)
     {
         // we rely on underlying values here
         static_assert(int(queue_type::direct) == 0, "unexpected enum ordering");
@@ -203,6 +203,21 @@ private:
         CC_UNREACHABLE("invalid queue_type");
     }
 
+    unsigned getFlatIndexOffset(queue_type type) const
+    {
+        switch (type)
+        {
+        case queue_type::direct:
+            return 0;
+        case queue_type::compute:
+            return mPoolDirect.max_size();
+        case queue_type::copy:
+            return mPoolDirect.max_size() + mPoolCompute.max_size();
+        }
+
+        CC_UNREACHABLE("invalid queue_type");
+    }
+
     ID3D12GraphicsCommandList5* getList(handle::command_list cl, queue_type type) const
     {
         switch (type)
@@ -236,16 +251,18 @@ public:
         return getList(cl, type);
     }
 
-    d3d12_incomplete_state_cache* getStateCache(handle::command_list cl) { return &getNodeInternal(cl)->state_cache; }
+    incomplete_state_cache* getStateCache(handle::command_list cl) { return &getNodeInternal(cl)->state_cache; }
 
 public:
     void initialize(BackendD3D12& backend,
+                    cc::allocator* static_alloc,
                     int num_direct_allocs,
                     int num_direct_lists_per_alloc,
                     int num_compute_allocs,
                     int num_compute_lists_per_alloc,
                     int num_copy_allocs,
                     int num_copy_lists_per_alloc,
+                    int max_num_unique_transitions_per_cmdlist,
                     cc::span<CommandAllocatorsPerThread*> thread_allocators);
     void destroy();
 
@@ -268,16 +285,20 @@ private:
     }
 
 private:
-    /// the linked pools per cmdlist type, managing handle association as well as additional
-    /// bookkeeping data structures
+    // the linked pools per cmdlist type, managing handle association as well as additional
+    // bookkeeping data structures
     cmdlist_linked_pool_t mPoolDirect;
     cmdlist_linked_pool_t mPoolCompute;
     cmdlist_linked_pool_t mPoolCopy;
 
-    /// parallel arrays to the pools, identically indexed
-    /// the cmdlists must stay alive even while "unallocated"
-    cc::array<ID3D12GraphicsCommandList5*> mRawListsDirect;
-    cc::array<ID3D12GraphicsCommandList5*> mRawListsCompute;
-    cc::array<ID3D12GraphicsCommandList5*> mRawListsCopy;
+    // flat memory for the state caches
+    int mNumStateCacheEntriesPerCmdlist;
+    cc::alloc_array<incomplete_state_cache::cache_entry> mFlatStateCacheEntries;
+
+    // parallel arrays to the pools, identically indexed
+    // the cmdlists must stay alive even while "unallocated"
+    cc::alloc_array<ID3D12GraphicsCommandList5*> mRawListsDirect;
+    cc::alloc_array<ID3D12GraphicsCommandList5*> mRawListsCompute;
+    cc::alloc_array<ID3D12GraphicsCommandList5*> mRawListsCopy;
 };
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/fence_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/fence_pool.cc
@@ -66,10 +66,10 @@ void phi::d3d12::FencePool::signalCPU(phi::handle::fence fence, uint64_t new_val
     internalGet(fence).fence->Signal(new_val);
 }
 
-void phi::d3d12::FencePool::signalGPU(phi::handle::fence fence, uint64_t new_val, ID3D12CommandQueue& queue) const
+void phi::d3d12::FencePool::signalGPU(phi::handle::fence fence, uint64_t new_val, ID3D12CommandQueue* queue) const
 {
     //
-    queue.Signal(internalGet(fence).fence, new_val);
+    queue->Signal(internalGet(fence).fence, new_val);
 }
 
 void phi::d3d12::FencePool::waitCPU(phi::handle::fence fence, uint64_t val) const
@@ -82,10 +82,10 @@ void phi::d3d12::FencePool::waitCPU(phi::handle::fence fence, uint64_t val) cons
     }
 }
 
-void phi::d3d12::FencePool::waitGPU(phi::handle::fence fence, uint64_t val, ID3D12CommandQueue& queue) const
+void phi::d3d12::FencePool::waitGPU(phi::handle::fence fence, uint64_t val, ID3D12CommandQueue* queue) const
 {
     //
-    PHI_D3D12_VERIFY(queue.Wait(internalGet(fence).fence, val));
+    PHI_D3D12_VERIFY(queue->Wait(internalGet(fence).fence, val));
 }
 
 uint64_t phi::d3d12::FencePool::getValue(phi::handle::fence fence) const
@@ -96,6 +96,18 @@ uint64_t phi::d3d12::FencePool::getValue(phi::handle::fence fence) const
     PHI_D3D12_DRED_ASSERT(res != UINT64_MAX, nd.fence);
 #endif
     return res;
+}
+
+phi::d3d12::FencePool::node& phi::d3d12::FencePool::internalGet(handle::fence fence)
+{
+    CC_ASSERT(fence.is_valid() && "invalid handle::fence");
+    return mPool.get(fence._value);
+}
+
+phi::d3d12::FencePool::node const& phi::d3d12::FencePool::internalGet(handle::fence fence) const
+{
+    CC_ASSERT(fence.is_valid() && "invalid handle::fence");
+    return mPool.get(fence._value);
 }
 
 void phi::d3d12::FencePool::node::create(ID3D12Device* dev)

--- a/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/fence_pool.hh
@@ -23,10 +23,10 @@ public:
     ID3D12Fence* get(handle::fence fence) const { return internalGet(fence).fence; }
 
     void signalCPU(handle::fence fence, uint64_t new_val) const;
-    void signalGPU(handle::fence fence, uint64_t new_val, ID3D12CommandQueue& queue) const;
+    void signalGPU(handle::fence fence, uint64_t new_val, ID3D12CommandQueue* queue) const;
 
     void waitCPU(handle::fence fence, uint64_t val) const;
-    void waitGPU(handle::fence fence, uint64_t val, ID3D12CommandQueue& queue) const;
+    void waitGPU(handle::fence fence, uint64_t val, ID3D12CommandQueue* queue) const;
 
     [[nodiscard]] uint64_t getValue(handle::fence fence) const;
 
@@ -40,17 +40,8 @@ private:
         void free();
     };
 
-    [[nodiscard]] node& internalGet(handle::fence fence)
-    {
-        CC_ASSERT(fence.is_valid() && "invalid handle::fence");
-        return mPool.get(fence._value);
-    }
-
-    [[nodiscard]] node const& internalGet(handle::fence fence) const
-    {
-        CC_ASSERT(fence.is_valid() && "invalid handle::fence");
-        return mPool.get(fence._value);
-    }
+    node& internalGet(handle::fence fence);
+    node const& internalGet(handle::fence fence) const;
 
 private:
     ID3D12Device* mDevice = nullptr;

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -74,7 +74,7 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
         util::set_object_name(new_node.raw_pso, "pool graphics pso #%d", int(pool_index));
     }
 
-
+    
     return {static_cast<handle::handle_t>(pool_index)};
 }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -74,7 +74,7 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
         util::set_object_name(new_node.raw_pso, "pool graphics pso #%d", int(pool_index));
     }
 
-    
+
     return {static_cast<handle::handle_t>(pool_index)};
 }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -51,7 +51,8 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
                                                                                      phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                                      bool has_root_constants,
                                                                                      phi::arg::graphics_shaders shader_stages,
-                                                                                     const phi::pipeline_config& primitive_config)
+                                                                                     const phi::pipeline_config& primitive_config,
+                                                                                     char const* dbg_name)
 {
     root_signature* root_sig;
     // Do things requiring synchronization first
@@ -71,7 +72,7 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
         // Create PSO
         auto const vert_format_native = util::get_native_vertex_format(vertex_format.attributes);
         new_node.raw_pso = create_pipeline_state(*mDevice, root_sig->raw_root_sig, vert_format_native, framebuffer_format, shader_stages, primitive_config);
-        util::set_object_name(new_node.raw_pso, "pool graphics pso #%d", int(pool_index));
+        util::set_object_name(new_node.raw_pso, "phi graphics pso %s", dbg_name ? dbg_name : "");
     }
 
 
@@ -80,7 +81,8 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createPipelineS
 
 phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createComputePipelineState(phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                                             arg::shader_binary compute_shader,
-                                                                                            bool has_root_constants)
+                                                                                            bool has_root_constants,
+                                                                                            char const* dbg_name)
 {
     root_signature* root_sig;
     // Do things requiring synchronization first
@@ -98,7 +100,7 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createComputePi
 
     // Create PSO
     new_node.raw_pso = create_compute_pipeline_state(*mDevice, root_sig->raw_root_sig, compute_shader.data, compute_shader.size);
-    util::set_object_name(new_node.raw_pso, "pool compute pso #%d", int(pool_index));
+    util::set_object_name(new_node.raw_pso, "pool compute pso %s", dbg_name ? dbg_name : "");
 
     auto const res = handle::pipeline_state{pool_index};
     CC_ASSERT(!isRaytracingPipeline(res));
@@ -111,7 +113,8 @@ phi::handle::pipeline_state phi::d3d12::PipelineStateObjectPool::createRaytracin
                                                                                                unsigned max_recursion,
                                                                                                unsigned max_payload_size_bytes,
                                                                                                unsigned max_attribute_size_bytes,
-                                                                                               cc::allocator* scratch_alloc)
+                                                                                               cc::allocator* scratch_alloc,
+                                                                                               char const* dbg_name)
 {
     CC_ASSERT(libraries.size() > 0 && arg_assocs.size() <= limits::max_raytracing_argument_assocs && "zero libraries or too many argument associations");
     CC_ASSERT(hit_groups.size() <= limits::max_raytracing_hit_groups && "too many hit groups");

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.cc
@@ -520,6 +520,7 @@ void phi::d3d12::PipelineStateObjectPool::initialize(
     // Create global (indirect drawing) command signatures for draw and indexed draw
     static_assert(sizeof(D3D12_DRAW_ARGUMENTS) == sizeof(gpu_indirect_command_draw), "gpu argument type compiles to incorrect size");
     static_assert(sizeof(D3D12_DRAW_INDEXED_ARGUMENTS) == sizeof(gpu_indirect_command_draw_indexed), "gpu argument type compiles to incorrect size");
+    static_assert(sizeof(D3D12_DISPATCH_ARGUMENTS) == sizeof(gpu_indirect_command_dispatch), "gpu argument type compiles to incorrect size");
 
     D3D12_INDIRECT_ARGUMENT_DESC indirect_arg;
     indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW;
@@ -529,11 +530,15 @@ void phi::d3d12::PipelineStateObjectPool::initialize(
     desc.pArgumentDescs = &indirect_arg;
     desc.ByteStride = sizeof(gpu_indirect_command_draw);
     desc.NodeMask = 0;
-    mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDraw));
+    PHI_D3D12_VERIFY(mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDraw)));
 
     indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED;
     desc.ByteStride = sizeof(gpu_indirect_command_draw_indexed);
-    mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDrawIndexed));
+    PHI_D3D12_VERIFY(mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDrawIndexed)));
+
+    indirect_arg.Type = D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH;
+    desc.ByteStride = sizeof(gpu_indirect_command_dispatch);
+    PHI_D3D12_VERIFY(mDevice->CreateCommandSignature(&desc, nullptr, IID_PPV_ARGS(&mGlobalComSigDispatch)));
 }
 
 void phi::d3d12::PipelineStateObjectPool::destroy()
@@ -559,6 +564,7 @@ void phi::d3d12::PipelineStateObjectPool::destroy()
 
     mGlobalComSigDraw->Release();
     mGlobalComSigDrawIndexed->Release();
+    mGlobalComSigDispatch->Release();
 }
 
 const phi::d3d12::PipelineStateObjectPool::rt_pso_node& phi::d3d12::PipelineStateObjectPool::getRaytrace(phi::handle::pipeline_state ps) const

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -116,6 +116,7 @@ public:
 
     ID3D12CommandSignature* getGlobalComSigDraw() const { return mGlobalComSigDraw; }
     ID3D12CommandSignature* getGlobalComSigDrawIndexed() const { return mGlobalComSigDrawIndexed; }
+    ID3D12CommandSignature* getGlobalComSigDispatch() const { return mGlobalComSigDrawIndexed; }
 
 private:
     ID3D12Device5* mDevice = nullptr;
@@ -125,6 +126,7 @@ private:
     ID3D12RootSignature* mEmptyRaytraceRootSignature = nullptr;
     ID3D12CommandSignature* mGlobalComSigDraw = nullptr;
     ID3D12CommandSignature* mGlobalComSigDrawIndexed = nullptr;
+    ID3D12CommandSignature* mGlobalComSigDispatch = nullptr;
 
     cc::atomic_linked_pool<pso_node> mPool;
     cc::atomic_linked_pool<rt_pso_node> mPoolRaytracing;

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -116,7 +116,7 @@ public:
 
     ID3D12CommandSignature* getGlobalComSigDraw() const { return mGlobalComSigDraw; }
     ID3D12CommandSignature* getGlobalComSigDrawIndexed() const { return mGlobalComSigDrawIndexed; }
-    ID3D12CommandSignature* getGlobalComSigDispatch() const { return mGlobalComSigDrawIndexed; }
+    ID3D12CommandSignature* getGlobalComSigDispatch() const { return mGlobalComSigDispatch; }
 
 private:
     ID3D12Device5* mDevice = nullptr;

--- a/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/pso_pool.hh
@@ -28,9 +28,13 @@ public:
                                                              arg::shader_arg_shapes shader_arg_shapes,
                                                              bool has_root_constants,
                                                              arg::graphics_shaders shader_stages,
-                                                             phi::pipeline_config const& primitive_config);
+                                                             phi::pipeline_config const& primitive_config,
+                                                             char const* dbg_name);
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes, arg::shader_binary compute_shader, bool has_root_constants);
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
+                                                                    arg::shader_binary compute_shader,
+                                                                    bool has_root_constants,
+                                                                    char const* dbg_name);
 
     [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(cc::span<arg::raytracing_shader_library const> libraries,
                                                                        cc::span<arg::raytracing_argument_association const> arg_assocs,
@@ -38,7 +42,8 @@ public:
                                                                        unsigned max_recursion,
                                                                        unsigned max_payload_size_bytes,
                                                                        unsigned max_attribute_size_bytes,
-                                                                       cc::allocator* scratch_alloc);
+                                                                       cc::allocator* scratch_alloc,
+                                                                       char const* dbg_name);
 
     void free(handle::pipeline_state ps);
 

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -327,7 +327,6 @@ phi::handle::resource phi::d3d12::ResourcePool::acquireImage(
     new_node.heap = resource_heap::gpu;
     new_node.master_state = initial_state;
     new_node.image.num_mips = num_mips;
-    new_node.image.num_array_layers = num_array_layers;
     new_node.image.pixel_format = pixel_format;
 
     return {static_cast<handle::handle_t>(res)};

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -176,7 +176,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(
                                                        samples != 1 ? DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN : 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
         auto* const alloc = mAllocator.allocate(desc, initial_state, &clear_value);
-        util::set_object_name(alloc->GetResource(), "pool depth tgt %s (%ux%u, fmt %u)", dbg_name ? dbg_name : "", w, h, unsigned(format));
+        util::set_object_name(alloc->GetResource(), "pool depth tgt %s (%ux%u, 2D[%u], fmt %u)", dbg_name ? dbg_name : "", w, h, array_size, unsigned(format));
         return acquireImage(alloc, format, initial_state, desc.MipLevels, desc.ArraySize());
     }
     else
@@ -205,7 +205,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(
                                                        samples != 1 ? DXGI_STANDARD_MULTISAMPLE_QUALITY_PATTERN : 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET);
 
         auto* const alloc = mAllocator.allocate(desc, initial_state, &clear_value);
-        util::set_object_name(alloc->GetResource(), "pool render tgt %s (%ux%u, fmt %u)", dbg_name ? dbg_name : "", w, h, unsigned(format));
+        util::set_object_name(alloc->GetResource(), "pool render tgt %s (%ux%u, 2D[%u], fmt %u)", dbg_name ? dbg_name : "", w, h, array_size, unsigned(format));
         return acquireImage(alloc, format, initial_state, desc.MipLevels, desc.ArraySize());
     }
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -275,11 +275,11 @@ void phi::d3d12::ResourcePool::free(phi::handle::resource res)
         return;
     CC_ASSERT(!isBackbuffer(res) && "the backbuffer resource must not be freed");
 
-    resource_node& freed_node = mPool.get(unsigned(res._value));
+    resource_node& freed_node = mPool.get(res._value);
     // This requires no synchronization, as D3D12MA internally syncs
     freed_node.allocation->Release();
 
-    mPool.release(unsigned(res._value));
+    mPool.release(res._value);
 }
 
 void phi::d3d12::ResourcePool::free(cc::span<const phi::handle::resource> resources)

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -4,6 +4,7 @@
 #include <clean-core/utility.hh>
 
 #include <phantasm-hardware-interface/common/log.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 
 #include <phantasm-hardware-interface/d3d12/common/d3dx12.hh>
 #include <phantasm-hardware-interface/d3d12/common/dxgi_format.hh>
@@ -153,7 +154,7 @@ phi::handle::resource phi::d3d12::ResourcePool::createRenderTarget(
     CC_CONTRACT(w > 0 && h > 0);
 
     auto const format_dxgi = util::to_dxgi_format(format);
-    if (is_depth_format(format))
+    if (phi::util::is_depth_format(format))
     {
         // Depth-stencil target
         constexpr D3D12_RESOURCE_STATES initial_state = util::to_native(resource_state::depth_write);

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -3,8 +3,8 @@
 #include <clean-core/bit_cast.hh>
 #include <clean-core/utility.hh>
 
-#include <phantasm-hardware-interface/common/log.hh>
 #include <phantasm-hardware-interface/common/format_size.hh>
+#include <phantasm-hardware-interface/common/log.hh>
 
 #include <phantasm-hardware-interface/d3d12/common/d3dx12.hh>
 #include <phantasm-hardware-interface/d3d12/common/dxgi_format.hh>

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -16,13 +16,7 @@ class ResourcePool
 public:
     // frontend-facing API
 
-    /// create a 1D, 2D or 3D texture, or a 1D/2D array
-    [[nodiscard]] handle::resource createTexture(
-        format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
-
-    /// create a render- or depth-stencil target
-    [[nodiscard]] handle::resource createRenderTarget(
-        phi::format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, rt_clear_value const* optimized_clear_val, char const* dbg_name);
+    [[nodiscard]] handle::resource createTexture(arg::texture_description const& desc, char const* dbg_name);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
     [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name);

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -95,6 +95,11 @@ public:
     [[nodiscard]] resource_node::image_info const& getImageInfo(handle::resource res) const { return internalGet(res).image; }
     [[nodiscard]] resource_node::buffer_info const& getBufferInfo(handle::resource res) const { return internalGet(res).buffer; }
 
+    [[nodiscard]] D3D12_GPU_VIRTUAL_ADDRESS getBufferAddrVA(buffer_address address) const
+    {
+        return internalGet(address.buffer).buffer.gpu_va + address.offset_bytes;
+    }
+
     bool isBufferAccessInBounds(handle::resource res, size_t offset, size_t size) const
     {
         auto const& internal = internalGet(res);
@@ -103,6 +108,13 @@ public:
 
         return internal.buffer.is_access_in_bounds(offset, size);
     }
+
+    bool isBufferAccessInBounds(buffer_address address, size_t size) const
+    {
+        return isBufferAccessInBounds(address.buffer, address.offset_bytes, size);
+    }
+
+    bool isBufferAccessInBounds(buffer_range range) const { return isBufferAccessInBounds(range.buffer, range.offset_bytes, range.size_bytes); }
 
     //
     // Master state access

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -89,11 +89,13 @@ public:
     //
 
     [[nodiscard]] ID3D12Resource* getRawResource(handle::resource res) const { return internalGet(res).resource; }
+    [[nodiscard]] ID3D12Resource* getRawResource(buffer_address const& addr) const { return internalGet(addr.buffer).resource; }
 
     // Additional information
     [[nodiscard]] bool isImage(handle::resource res) const { return internalGet(res).type == resource_node::resource_type::image; }
     [[nodiscard]] resource_node::image_info const& getImageInfo(handle::resource res) const { return internalGet(res).image; }
     [[nodiscard]] resource_node::buffer_info const& getBufferInfo(handle::resource res) const { return internalGet(res).buffer; }
+    [[nodiscard]] resource_node::buffer_info const& getBufferInfo(buffer_address const& addr) const { return internalGet(addr.buffer).buffer; }
 
     [[nodiscard]] D3D12_GPU_VIRTUAL_ADDRESS getBufferAddrVA(buffer_address address) const
     {

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -51,25 +51,25 @@ public:
 
         struct buffer_info
         {
-            D3D12_GPU_VIRTUAL_ADDRESS gpu_va;
-            uint32_t width;
-            uint32_t stride; // vertex/index size, structured buffer stride
+            D3D12_GPU_VIRTUAL_ADDRESS gpu_va; // cached
+            uint32_t width;                   // for bound checks, copy ranges, VBVs
+            uint32_t stride;                  // vertex/index size, structured buffer stride
 
             bool is_access_in_bounds(size_t offset, size_t size) const { return offset + size <= size_t(width); }
         };
 
         struct image_info
         {
-            format pixel_format;
-            unsigned num_mips;
-            unsigned num_array_layers;
+            format pixel_format; // for byte size of image
+            unsigned num_mips;   // for subresource index
         };
 
     public:
         D3D12MA::Allocation* allocation = nullptr;
         ID3D12Resource* resource = nullptr;
 
-        union {
+        union
+        {
             buffer_info buffer;
             image_info image;
         };

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.hh
@@ -68,8 +68,7 @@ public:
         D3D12MA::Allocation* allocation = nullptr;
         ID3D12Resource* resource = nullptr;
 
-        union
-        {
+        union {
             buffer_info buffer;
             image_info image;
         };

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -12,6 +12,7 @@ void phi::d3d12::DescriptorPageAllocator::initialize(ID3D12Device& device, D3D12
 {
     mPageAllocator.initialize(num_descriptors, page_size, static_alloc);
     mDescriptorSize = device.GetDescriptorHandleIncrementSize(type);
+    mDescriptorType = type;
 
     D3D12_DESCRIPTOR_HEAP_DESC desc;
     desc.NumDescriptors = UINT(num_descriptors);

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -141,6 +141,9 @@ void phi::d3d12::ShaderViewPool::free(cc::span<const phi::handle::shader_view> s
     auto lg = std::lock_guard(mMutex);
     for (auto sv : svs)
     {
+        if (!sv.is_valid())
+            continue;
+
         auto& data = mPool.get(unsigned(sv._value));
         mSRVUAVAllocator.free(data.srv_uav_alloc_handle);
         mSamplerAllocator.free(data.sampler_alloc_handle);

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
@@ -3,9 +3,9 @@
 #include <mutex>
 
 #include <clean-core/array.hh>
+#include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
-#include <clean-core/atomic_linked_pool.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/common/page_allocator.hh>

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
@@ -3,6 +3,7 @@
 #include <mutex>
 
 #include <clean-core/array.hh>
+#include <clean-core/assertf.hh>
 #include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
@@ -48,7 +49,8 @@ public:
             return -1;
 
         auto const res_page = mPageAllocator.allocate(num_descriptors);
-        CC_RUNTIME_ASSERT(res_page != -1 && "DescriptorPageAllocator overcommitted!");
+        CC_RUNTIME_ASSERTF(res_page != -1, "DescriptorPageAllocator overcommitted! Reached limit of {} {}", mPageAllocator.get_num_elements(),
+                           mDescriptorType == D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV ? "SRVs/UAVs/CBVs" : "Samplers");
         return res_page;
     }
 
@@ -91,6 +93,7 @@ private:
     D3D12_GPU_DESCRIPTOR_HANDLE mHeapStartGPU;
     phi::page_allocator mPageAllocator;
     unsigned mDescriptorSize = 0;
+    D3D12_DESCRIPTOR_HEAP_TYPE mDescriptorType;
 };
 
 class ResourcePool;

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.hh
@@ -102,7 +102,15 @@ class ShaderViewPool
 public:
     // frontend-facing API
 
-    [[nodiscard]] handle::shader_view create(cc::span<resource_view const> srvs, cc::span<resource_view const> uavs, cc::span<sampler_config const> samplers);
+    handle::shader_view createEmpty(uint32_t num_srvs_uavs, uint32_t num_samplers);
+
+    handle::shader_view create(cc::span<resource_view const> srvs, cc::span<resource_view const> uavs, cc::span<sampler_config const> samplers);
+
+    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs);
+
+    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs);
+
+    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers);
 
     void free(handle::shader_view sv);
     void free(cc::span<handle::shader_view const> svs);
@@ -159,6 +167,12 @@ private:
         CC_ASSERT(res.is_valid() && "invalid shader_view handle");
         return mPool.get(res._value);
     }
+
+    void writeSRV(D3D12_CPU_DESCRIPTOR_HANDLE handle, resource_view const& srv);
+
+    void writeUAV(D3D12_CPU_DESCRIPTOR_HANDLE handle, resource_view const& uav);
+
+    void writeSampler(D3D12_CPU_DESCRIPTOR_HANDLE handle, sampler_config const& sampler);
 
 private:
     // non-owning

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -165,12 +165,24 @@ void phi::d3d12::SwapchainPool::present(phi::handle::swapchain handle)
     node.backbuffers[backbuffer_i].fence.issueFence(*mParentQueue);
 }
 
-unsigned phi::d3d12::SwapchainPool::waitForBackbuffer(phi::handle::swapchain handle)
+unsigned phi::d3d12::SwapchainPool::acquireBackbuffer(phi::handle::swapchain handle, bool wait)
 {
     swapchain& node = mPool.get(handle._value);
     auto const backbuffer_i = node.swapchain_com->GetCurrentBackBufferIndex();
-    node.backbuffers[backbuffer_i].fence.waitOnCPU(0);
+    node.last_backbuf_i = backbuffer_i;
+
+    if (wait)
+    {
+         node.backbuffers[backbuffer_i].fence.waitOnCPU(0);
+    }
+
     return backbuffer_i;
+}
+
+void phi::d3d12::SwapchainPool::waitForBackbufferOnGPU(handle::swapchain handle) 
+{
+    swapchain& node = mPool.get(handle._value);
+    node.backbuffers[node.last_backbuf_i].fence.waitOnGPU(*mParentQueue);
 }
 
 DXGI_FORMAT phi::d3d12::SwapchainPool::getBackbufferFormat() const { return gc_pool_backbuffer_format; }

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -179,10 +179,10 @@ unsigned phi::d3d12::SwapchainPool::acquireBackbuffer(phi::handle::swapchain han
     return backbuffer_i;
 }
 
-void phi::d3d12::SwapchainPool::waitForBackbufferOnGPU(handle::swapchain handle) 
+void phi::d3d12::SwapchainPool::waitForBackbufferOnCPU(handle::swapchain handle) 
 {
     swapchain& node = mPool.get(handle._value);
-    node.backbuffers[node.last_backbuf_i].fence.waitOnGPU(*mParentQueue);
+    node.backbuffers[node.last_backbuf_i].fence.waitOnCPU(0);
 }
 
 DXGI_FORMAT phi::d3d12::SwapchainPool::getBackbufferFormat() const { return gc_pool_backbuffer_format; }

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -1,5 +1,9 @@
 #include "swapchain_pool.hh"
 
+#ifdef PHI_HAS_OPTICK
+#include <optick/optick.h>
+#endif
+
 #include <clean-core/assert.hh>
 
 #include <phantasm-hardware-interface/common/log.hh>
@@ -160,6 +164,10 @@ void phi::d3d12::SwapchainPool::present(phi::handle::swapchain handle)
 
     // CPU-wait on currently acquired backbuffer
     node.backbuffers[node.last_acquired_backbuf_i].fence.waitOnCPU(0);
+
+#ifdef PHI_HAS_OPTICK
+    OPTICK_GPU_FLIP(node.swapchain_com);
+#endif
 
     // present
     UINT const sync_interval = get_sync_interval(node.mode);

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -54,8 +54,7 @@ public:
 
     void present(handle::swapchain handle);
 
-    unsigned acquireBackbuffer(handle::swapchain handle, bool wait);
-    void waitForBackbufferOnCPU(handle::swapchain handle);
+    unsigned acquireBackbuffer(handle::swapchain handle);
 
     swapchain const& get(handle::swapchain handle) const { return mPool.get(handle._value); }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -30,6 +30,7 @@ public:
         present_mode mode;
         bool has_resized;
         cc::capped_array<backbuffer, 6> backbuffers; // all backbuffers
+        uint32_t last_backbuf_i = 0;
     };
 
 public:
@@ -53,7 +54,8 @@ public:
 
     void present(handle::swapchain handle);
 
-    unsigned waitForBackbuffer(handle::swapchain handle);
+    unsigned acquireBackbuffer(handle::swapchain handle, bool wait);
+    void waitForBackbufferOnGPU(handle::swapchain handle);
 
     swapchain const& get(handle::swapchain handle) const { return mPool.get(handle._value); }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -55,7 +55,7 @@ public:
     void present(handle::swapchain handle);
 
     unsigned acquireBackbuffer(handle::swapchain handle, bool wait);
-    void waitForBackbufferOnGPU(handle::swapchain handle);
+    void waitForBackbufferOnCPU(handle::swapchain handle);
 
     swapchain const& get(handle::swapchain handle) const { return mPool.get(handle._value); }
 

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -6,8 +6,9 @@
 #include <phantasm-hardware-interface/handles.hh>
 #include <phantasm-hardware-interface/types.hh>
 
+#include <phantasm-hardware-interface/d3d12/common/d3d12_sanitized.hh>
+
 #include <phantasm-hardware-interface/d3d12/Fence.hh>
-#include <phantasm-hardware-interface/d3d12/fwd.hh>
 
 namespace phi::d3d12
 {
@@ -30,7 +31,7 @@ public:
         present_mode mode;
         bool has_resized;
         cc::capped_array<backbuffer, 6> backbuffers; // all backbuffers
-        uint32_t last_backbuf_i = 0;
+        uint32_t last_acquired_backbuf_i = 0;
     };
 
 public:

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -16,20 +16,20 @@ class SwapchainPool
 public:
     struct backbuffer
     {
-        Fence fence;                     ///< present fence
-        D3D12_CPU_DESCRIPTOR_HANDLE rtv; ///< CPU RTV
-        ID3D12Resource* resource;        ///< resource ptr
-        D3D12_RESOURCE_STATES state;     ///< current state
+        Fence fence;                     // present fence - GPU signalled on present, CPU waited on acquire
+        D3D12_CPU_DESCRIPTOR_HANDLE rtv; // CPU RTV
+        ID3D12Resource* resource;        // resource ptr
+        D3D12_RESOURCE_STATES state;     // current state
     };
 
     struct swapchain
     {
-        IDXGISwapChain3* swapchain_com; ///< Swapchain COM Ptr
+        IDXGISwapChain3* swapchain_com; // Swapchain COM Ptr
         int backbuf_width;
         int backbuf_height;
         present_mode mode;
         bool has_resized;
-        cc::capped_array<backbuffer, 6> backbuffers; ///< all backbuffers
+        cc::capped_array<backbuffer, 6> backbuffers; // all backbuffers
     };
 
 public:

--- a/src/phantasm-hardware-interface/features/gpu_info.cc
+++ b/src/phantasm-hardware-interface/features/gpu_info.cc
@@ -52,6 +52,7 @@ size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::ada
                 return i;
         }
 
+        PHI_LOG_ERROR("Fatal: Found no suitable GPU (in {} candidate{})", candidates.size(), candidates.size() == 1 ? "" : "s");
         return candidates.size();
     };
 
@@ -77,7 +78,7 @@ size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::ada
         {
             auto highest_vram_index = get_first_capable();
 
-            for (auto i = 1u; i < candidates.size(); ++i)
+            for (auto i = 0u; i < candidates.size(); ++i)
             {
                 if (candidates[i].capabilities != gpu_capabilities::insufficient
                     && candidates[i].dedicated_video_memory_bytes > candidates[highest_vram_index].dedicated_video_memory_bytes)
@@ -88,7 +89,8 @@ size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::ada
         }
         case adapter_preference::highest_feature_level:
         {
-            auto highest_capability_index = 0u;
+            auto highest_capability_index = get_first_capable();
+
             for (auto i = 1u; i < candidates.size(); ++i)
             {
                 if (candidates[i].capabilities > candidates[highest_capability_index].capabilities)

--- a/src/phantasm-hardware-interface/features/gpu_info.cc
+++ b/src/phantasm-hardware-interface/features/gpu_info.cc
@@ -97,7 +97,7 @@ size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::ada
     return make_choice();
 }
 
-phi::gpu_vendor phi::get_gpu_vendor_from_id(unsigned vendor_id)
+phi::gpu_vendor phi::get_gpu_info_from_pcie_id(unsigned vendor_id)
 {
     switch (vendor_id)
     {
@@ -132,7 +132,7 @@ void phi::print_startup_message(cc::span<const phi::gpu_info> gpu_candidates, si
     if (chosen_index < gpu_candidates.size())
     {
         PHI_LOG("   chose gpu #{} ({}) from {} candidate{}, preference: {}", //
-                chosen_index, gpu_candidates[chosen_index].description.c_str(), gpu_candidates.size(), (gpu_candidates.size() == 1 ? "" : "s"),
+                chosen_index, gpu_candidates[chosen_index].name, gpu_candidates.size(), (gpu_candidates.size() == 1 ? "" : "s"),
                 get_preference_literal(config.adapter));
     }
     else

--- a/src/phantasm-hardware-interface/features/gpu_info.cc
+++ b/src/phantasm-hardware-interface/features/gpu_info.cc
@@ -2,9 +2,11 @@
 
 #include <clean-core/assert.hh>
 
-#include <phantasm-hardware-interface/common/log.hh>
 #include <phantasm-hardware-interface/config.hh>
 #include <phantasm-hardware-interface/types.hh>
+
+#include <phantasm-hardware-interface/common/enums_from_string.hh>
+#include <phantasm-hardware-interface/common/log.hh>
 
 namespace
 {
@@ -24,22 +26,6 @@ constexpr char const* get_preference_literal(phi::adapter_preference pref)
         return "highest feature level";
     }
     CC_UNREACHABLE_SWITCH_WORKAROUND(pref);
-}
-
-constexpr char const* get_validation_literal(phi::validation_level level)
-{
-    switch (level)
-    {
-    case phi::validation_level::off:
-        return "off";
-    case phi::validation_level::on:
-        return "on";
-    case phi::validation_level::on_extended:
-        return "on_extended";
-    case phi::validation_level::on_extended_dred:
-        return "on_extended_dred";
-    }
-    CC_UNREACHABLE_SWITCH_WORKAROUND(level);
 }
 }
 
@@ -138,7 +124,7 @@ void phi::print_startup_message(cc::span<const phi::gpu_info> gpu_candidates, si
         return;
 
     PHI_LOG("{} backend initialized, validation: {}", //
-            is_d3d12 ? "d3d12" : "vulkan", get_validation_literal(config.validation));
+            is_d3d12 ? "d3d12" : "vulkan", enum_to_string(config.validation));
 
     PHI_LOG("   {} threads, max {} resources, max {} PSOs", //
             config.num_threads, config.max_num_resources, config.max_num_pipeline_states);

--- a/src/phantasm-hardware-interface/features/gpu_info.hh
+++ b/src/phantasm-hardware-interface/features/gpu_info.hh
@@ -2,9 +2,7 @@
 
 #include <cstdint>
 
-#include <clean-core/flags.hh>
 #include <clean-core/span.hh>
-#include <clean-core/string.hh>
 
 #include <phantasm-hardware-interface/fwd.hh>
 
@@ -31,54 +29,9 @@ enum class gpu_capabilities : uint8_t
     level_3
 };
 
-// explicit GPU features
-enum class gpu_feature : uint8_t
-{
-    conservative_raster,      ///< conservative rasterization (>= tier 1)
-    mesh_shaders,             ///< task/mesh shading pipeline (>= tier 1)
-    rasterizer_ordered_views, ///< rasterizer ordered views (ROVs)
-    hlsl_wave_ops             ///< HLSL SM6 wave ops
-};
-
-using gpu_feature_flags = cc::flags<gpu_feature, 32>;
-
-struct gpu_feature_info
-{
-    enum e_hlsl_shader_model_version : uint8_t
-    {
-        hlsl_sm5_1, ///< shader model >= 5.1
-        hlsl_sm6_0, ///< shader model >= 6.0
-        hlsl_sm6_1, ///< shader model >= 6.1
-        hlsl_sm6_2, ///< shader model >= 6.2
-        hlsl_sm6_3, ///< shader model >= 6.3
-        hlsl_sm6_4, ///< shader model >= 6.4
-        hlsl_sm6_5, ///< shader model >= 6.5
-        hlsl_sm6_6, ///< shader model >= 6.6
-    };
-
-    enum e_raytracing_tier : uint8_t
-    {
-        raytracing_unsupported,
-        raytracing_t1_0,
-        raytracing_t1_1
-    };
-
-    enum e_variable_rate_shading_tier : uint8_t
-    {
-        variable_rate_shading_unsupported,
-        variable_rate_shading_t1_0,
-        variable_rate_shading_t2_0
-    };
-
-    cc::flags<gpu_feature, 32> features = cc::no_flags;
-    e_hlsl_shader_model_version sm_version = hlsl_sm5_1;
-    e_raytracing_tier raytracing = raytracing_unsupported;
-    e_variable_rate_shading_tier variable_rate_shading = variable_rate_shading_unsupported;
-};
-
 struct gpu_info
 {
-    cc::string description;
+    char name[256];
     unsigned index; ///< an index into an API-specific ordering
 
     size_t dedicated_video_memory_bytes;
@@ -90,9 +43,9 @@ struct gpu_info
     bool has_raytracing;
 };
 
-[[nodiscard]] gpu_vendor get_gpu_vendor_from_id(unsigned vendor_id);
+gpu_vendor get_gpu_info_from_pcie_id(unsigned vendor_id);
 
-[[nodiscard]] size_t get_preferred_gpu(cc::span<gpu_info const> candidates, adapter_preference preference);
+size_t get_preferred_gpu(cc::span<gpu_info const> candidates, adapter_preference preference);
 
 void print_startup_message(cc::span<gpu_info const> gpu_candidates, size_t chosen_index, backend_config const& config, bool is_d3d12);
 }

--- a/src/phantasm-hardware-interface/features/gpu_stats.cc
+++ b/src/phantasm-hardware-interface/features/gpu_stats.cc
@@ -166,7 +166,10 @@ phi::gpustats::gpu_handle_t phi::gpustats::get_gpu_by_index(unsigned index)
 {
     CC_ASSERT(g_nvml._dll != nullptr && "gpustats not initialized");
     nvmlDevice_t ret;
-    if (g_nvml._nvmlDeviceGetHandleByIndex(index, &ret) == 0)
+
+    auto const operationResult = g_nvml._nvmlDeviceGetHandleByIndex(index, &ret);
+
+    if (operationResult == 0)
     {
         return static_cast<void*>(ret);
     }

--- a/src/phantasm-hardware-interface/features/gpu_stats.hh
+++ b/src/phantasm-hardware-interface/features/gpu_stats.hh
@@ -1,20 +1,22 @@
 #pragma once
 
+#include <phantasm-hardware-interface/common/api.hh>
+
 namespace phi::gpustats
 {
 using gpu_handle_t = void*;
 
 // initialize and shut down GPU stat subsystem (loading NVML or AMD GPUinfo)
 // everything but these two calls are threadsafe
-bool initialize();
-void shutdown();
+PHI_API bool initialize();
+PHI_API void shutdown();
 
 /// retrieve a GPU handle by the device index, nullptr if invalid
-gpu_handle_t get_gpu_by_index(unsigned index);
+PHI_API gpu_handle_t get_gpu_by_index(unsigned index);
 
 /// returns the GPU die temperature in degrees celsius, -1 for invalid handles
-int get_temperature(gpu_handle_t handle);
+PHI_API int get_temperature(gpu_handle_t handle);
 /// returns the GPU fanspeed in percent, -1 for invalid handles
-int get_fanspeed_percent(gpu_handle_t handle);
+PHI_API int get_fanspeed_percent(gpu_handle_t handle);
 
 }

--- a/src/phantasm-hardware-interface/fwd.hh
+++ b/src/phantasm-hardware-interface/fwd.hh
@@ -79,8 +79,8 @@ struct vertex_format;
 struct shader_arg_shape;
 struct shader_binary;
 struct graphics_shader;
-struct graphics_pipeline_state_desc;
-struct compute_pipeline_state_desc;
+struct graphics_pipeline_state_description;
+struct compute_pipeline_state_description;
 
 using shader_arg_shapes = cc::span<shader_arg_shape const>;
 using graphics_shaders = cc::span<graphics_shader const>;
@@ -89,14 +89,14 @@ struct blas_element;
 struct raytracing_shader_library;
 struct raytracing_argument_association;
 struct raytracing_hit_group;
-struct raytracing_pipeline_state_desc;
+struct raytracing_pipeline_state_description;
 struct shader_table_record;
 
 using shader_table_records = cc::span<shader_table_record const>;
 
-struct create_render_target_info;
-struct create_texture_info;
-struct create_buffer_info;
-struct create_resource_info;
+struct render_target_description;
+struct texture_description;
+struct buffer_description;
+struct resource_description;
 
 }

--- a/src/phantasm-hardware-interface/limits.hh
+++ b/src/phantasm-hardware-interface/limits.hh
@@ -29,6 +29,9 @@ enum limits_e : unsigned
     /// configurable in increments of 4, also concerns CPU memory (cmd::draw, cmd::dispatch)
     max_root_constant_bytes = 16u,
 
+    /// the maximum amount of usable vertex buffers (per drawcall and in a graphics PSO)
+    max_vertex_buffers = 4u,
+
     /// the maximum amount of argument associations
     /// configurable
     max_raytracing_argument_assocs = 8u,

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -300,15 +300,26 @@ public:
         // no need to specify
     }
 
-    void init_as_tex2d(handle::resource res, format pf, bool multisampled = false, uint32_t mip_start = 0, uint32_t mip_size = uint32_t(-1), uint32_t array_index = 0)
+    void init_as_tex2d(handle::resource res, format pf, bool multisampled = false, uint32_t mip_slice = 0)
     {
         dimension = multisampled ? resource_view_dimension::texture2d_ms : resource_view_dimension::texture2d;
         resource = res;
         texture_info.pixel_format = pf;
-        texture_info.mip_start = mip_start;
-        texture_info.mip_size = mip_size;
-        texture_info.array_start = array_index;
+        texture_info.mip_start = mip_slice;
+        texture_info.mip_size = 1;
+        texture_info.array_start = 0;
         texture_info.array_size = 1;
+    }
+
+    void init_as_tex2d_array(handle::resource res, format pf, bool multisampled, uint32_t array_start = 0, uint32_t array_size = 1, uint32_t mip_slice = 0)
+    {
+        dimension = multisampled ? resource_view_dimension::texture2d_ms_array : resource_view_dimension::texture2d_array;
+        resource = res;
+        texture_info.pixel_format = pf;
+        texture_info.mip_start = mip_slice;
+        texture_info.mip_size = 1;
+        texture_info.array_start = array_start;
+        texture_info.array_size = array_size;
     }
 
     void init_as_texcube(handle::resource res, format pf)
@@ -353,10 +364,10 @@ public:
         rv.init_as_backbuffer(res);
         return rv;
     }
-    static resource_view tex2d(handle::resource res, format pf, bool multisampled = false, uint32_t mip_start = 0, uint32_t mip_size = uint32_t(-1), uint32_t array_index = 0)
+    static resource_view tex2d(handle::resource res, format pf, bool multisampled = false, uint32_t mip_slice = 0)
     {
         resource_view rv;
-        rv.init_as_tex2d(res, pf, multisampled, mip_start, mip_size, array_index);
+        rv.init_as_tex2d(res, pf, multisampled, mip_slice);
         return rv;
     }
     static resource_view texcube(handle::resource res, format pf)

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -322,6 +322,17 @@ public:
         texture_info.array_size = array_size;
     }
 
+    void init_as_tex3d(handle::resource res, format pf, uint32_t array_start, uint32_t array_size, uint32_t mip_slice = 0)
+    {
+        dimension = resource_view_dimension::texture3d;
+        resource = res;
+        texture_info.pixel_format = pf;
+        texture_info.mip_start = mip_slice;
+        texture_info.mip_size = 1;
+        texture_info.array_start = array_start;
+        texture_info.array_size = array_size;
+    }
+
     void init_as_texcube(handle::resource res, format pf)
     {
         dimension = resource_view_dimension::texturecube;

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -769,6 +769,11 @@ struct accel_struct_instance
 
 static_assert(sizeof(accel_struct_instance) == 64, "accel_struct_instance compiles to incorrect size");
 
+struct buffer_address
+{
+    handle::resource buffer = handle::null_resource;
+    uint32_t offset_bytes = 0;
+};
 
 struct buffer_range
 {

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -718,6 +718,14 @@ struct gpu_indirect_command_draw_indexed
     uint32_t instance_offset;
 };
 
+/// indirect compute dispatch command, as it is laid out in a GPU buffer
+struct gpu_indirect_command_dispatch
+{
+    uint32_t dispatch_x;
+    uint32_t dispatch_y;
+    uint32_t dispatch_z;
+};
+
 /// flags to configure the building process of a raytracing acceleration structure
 enum class accel_struct_build_flags : uint8_t
 {

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -275,8 +275,7 @@ struct resource_view
         handle::accel_struct accel_struct;
     };
 
-    union
-    {
+    union {
         texture_info_t texture_info;
         buffer_info_t buffer_info;
         accel_struct_info_t accel_struct_info;

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -170,12 +170,14 @@ enum class format : uint8_t
     rg8un,
     r8un,
 
-    // sRGB formats
+    // sRGB versions of regular formats
     rgba8un_srgb,
 
     // swizzled and irregular formats
     bgra8un,
     b10g11r11uf,
+    r10g10b10a2u,
+    r10g10b10a2un,
 
     // block-compressed formats
     bc1_8un,
@@ -212,10 +214,10 @@ constexpr bool is_view_format(format fmt) { return fmt >= format::r24un_g8t && f
 constexpr bool is_block_compressed_format(format fmt) { return fmt >= format::bc1_8un && fmt <= format::bc6h_16uf; }
 
 /// returns true if the format is a depth OR depth stencil format
-constexpr bool is_depth_format(format fmt) { return fmt >= format::depth32f; }
+constexpr bool is_depth_format(format fmt) { return fmt >= format::depth32f && fmt <= format::depth24un_stencil8u; }
 
 /// returns true if the format is a depth stencil format
-constexpr bool is_depth_stencil_format(format fmt) { return fmt >= format::depth32f_stencil8u; }
+constexpr bool is_depth_stencil_format(format fmt) { return fmt >= format::depth32f_stencil8u && fmt <= format::depth24un_stencil8u; }
 
 /// information about a single vertex attribute
 struct vertex_attribute_info

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -224,9 +224,10 @@ constexpr bool is_valid_format(format fmt) { return fmt > format::none && fmt < 
 /// information about a single vertex attribute
 struct vertex_attribute_info
 {
-    char const* semantic_name;
-    uint32_t offset;
-    format fmt;
+    char const* semantic_name = nullptr;
+    uint32_t offset = 0;
+    format fmt = format::none;
+    uint8_t vertex_buffer_i = 0;
 };
 
 enum class texture_dimension : uint8_t

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -175,19 +175,25 @@ enum class format : uint8_t
 
     // swizzled and irregular formats
     bgra8un,
+    bgra4un,
     b10g11r11uf,
     r10g10b10a2u,
     r10g10b10a2un,
+    b5g6r5un,
+    b5g5r5a1un,
+    r9g9b9e5_sharedexp_uf, // three ufloats sharing a single 5 bit exponent, 32b in total
 
     // block-compressed formats
-    bc1_8un,
-    bc1_8un_srgb,
-    bc2_8un,
-    bc2_8un_srgb,
-    bc3_8un,
-    bc3_8un_srgb,
+    bc1,
+    bc1_srgb,
+    bc2,
+    bc2_srgb,
+    bc3,
+    bc3_srgb,
     bc6h_16f,
     bc6h_16uf,
+    bc7,
+    bc7_srgb,
 
     // view-only formats - depth
     r24un_g8t, // view the depth part of depth24un_stencil8u
@@ -206,18 +212,6 @@ enum class format : uint8_t
 };
 
 constexpr bool is_valid_format(format fmt) { return fmt > format::none && fmt < format::MAX_FORMAT_RANGE; }
-
-/// returns true if the format is a view-only format
-constexpr bool is_view_format(format fmt) { return fmt >= format::r24un_g8t && fmt < format::depth32f; }
-
-/// returns true if the format is a block-compressed format
-constexpr bool is_block_compressed_format(format fmt) { return fmt >= format::bc1_8un && fmt <= format::bc6h_16uf; }
-
-/// returns true if the format is a depth OR depth stencil format
-constexpr bool is_depth_format(format fmt) { return fmt >= format::depth32f && fmt <= format::depth24un_stencil8u; }
-
-/// returns true if the format is a depth stencil format
-constexpr bool is_depth_stencil_format(format fmt) { return fmt >= format::depth32f_stencil8u && fmt <= format::depth24un_stencil8u; }
 
 /// information about a single vertex attribute
 struct vertex_attribute_info

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -531,7 +531,7 @@ struct pipeline_config
     cull_mode cull = cull_mode::none;
     int32_t samples = 1;
     bool conservative_raster = false;
-    bool frontface_counterclockwise = true;
+    bool frontface_counterclockwise = true; // TODO: this default should be flipped
     bool wireframe = false;
 };
 

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -10,6 +10,12 @@
     using _flags_t_ = cc::flags<_enum_t_, uint32_t(_max_num_)>; \
     CC_FLAGS_ENUM_SIZED(_enum_t_, uint32_t(_max_num_));
 
+#define PHI_DEFINE_FLAG_OPERATORS(FlagT, RealT)                                                                  \
+    [[maybe_unused]] constexpr FlagT operator|(FlagT a, FlagT b) noexcept { return FlagT(RealT(a) | RealT(b)); } \
+    [[maybe_unused]] constexpr FlagT operator&(FlagT a, FlagT b) noexcept { return FlagT(RealT(a) & RealT(b)); } \
+    [[maybe_unused]] constexpr FlagT operator^(FlagT a, FlagT b) noexcept { return FlagT(RealT(a) ^ RealT(b)); } \
+    [[maybe_unused]] constexpr FlagT operator~(FlagT a) noexcept { return FlagT(~RealT(a)); }
+
 namespace phi
 {
 /// resources bound to a shader, up to 4 per draw or dispatch command
@@ -726,6 +732,22 @@ struct gpu_indirect_command_dispatch
     uint32_t dispatch_z;
 };
 
+struct resource_usage_flags
+{
+    enum : uint32_t
+    {
+        none = 0,
+        allow_uav = 1 << 0,
+        allow_render_target = 1 << 1,
+        allow_depth_stencil = 1 << 2,
+        deny_shader_resource = 1 << 3,
+        use_optimized_clear_value = 1 << 4,
+    };
+};
+using resource_usage_flags_t = uint32_t;
+
+// PHI_DEFINE_FLAG_OPERATORS(resource_usage_flags, uint32_t)
+
 /// flags to configure the building process of a raytracing acceleration structure
 enum class accel_struct_build_flags : uint8_t
 {
@@ -739,18 +761,18 @@ enum class accel_struct_build_flags : uint8_t
 PHI_DEFINE_FLAG_TYPE(accel_struct_build_flags_t, accel_struct_build_flags, 8);
 
 // these flags align exactly with both vulkan and d3d12, and are not translated
-using accel_struct_instance_flags_t = uint32_t;
-namespace accel_struct_instance_flags
+struct accel_struct_instance_flags
 {
-enum accel_struct_instance_flags_e : uint32_t
-{
-    none = 0x0000,
-    triangle_cull_disable = 0x0001,
-    triangle_front_counterclockwise = 0x0002,
-    force_opaque = 0x0004,
-    force_no_opaque = 0x0008
+    enum : uint32_t
+    {
+        none = 0,
+        triangle_cull_disable = 1 << 0,
+        triangle_front_counterclockwise = 1 << 1,
+        force_opaque = 1 << 2,
+        force_no_opaque = 1 << 3
+    };
 };
-}
+using accel_struct_instance_flags_t = uint32_t;
 
 /// bottom level accel struct instance within a top level accel struct (layout dictated by DXR/Vulkan RT Extension)
 struct accel_struct_instance

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -166,6 +166,10 @@ enum class format : uint8_t
     rg16f,
     r16f,
 
+    rgba16un,
+    rg16un,
+    r16un,
+
     rgba8i,
     rg8i,
     r8i,

--- a/src/phantasm-hardware-interface/util.cc
+++ b/src/phantasm-hardware-interface/util.cc
@@ -6,7 +6,7 @@
 
 #include <clean-core/span.hh>
 
-unsigned phi::util::get_texture_size_bytes(tg::isize3 size, phi::format fmt, int num_mips, bool is_d3d12)
+uint32_t phi::util::get_texture_size_bytes(tg::isize3 size, phi::format fmt, int num_mips, bool is_d3d12)
 {
     // calculate number of mips if zero is given
     num_mips = num_mips > 0 ? num_mips : get_num_mips(size.width, size.height);
@@ -18,7 +18,7 @@ unsigned phi::util::get_texture_size_bytes(tg::isize3 size, phi::format fmt, int
         auto const mip_width = get_mip_size(size.width, mip);
         auto const mip_height = get_mip_size(size.height, mip);
 
-        unsigned row_pitch = bytes_per_pixel * mip_width;
+        uint32_t row_pitch = bytes_per_pixel * mip_width;
 
         if (is_d3d12)
             row_pitch = phi::util::align_up(row_pitch, 256);
@@ -30,12 +30,12 @@ unsigned phi::util::get_texture_size_bytes(tg::isize3 size, phi::format fmt, int
     return res_bytes * size.depth;
 }
 
-unsigned phi::util::get_texture_pixel_byte_offset(tg::isize2 size, phi::format fmt, tg::ivec2 pixel, bool is_d3d12)
+uint32_t phi::util::get_texture_pixel_byte_offset(tg::isize2 size, phi::format fmt, tg::ivec2 pixel, bool is_d3d12)
 {
     CC_ASSERT(pixel.x < size.width && pixel.y < size.height && "pixel out of bounds");
     auto const bytes_per_pixel = get_format_size_bytes(fmt);
 
-    unsigned row_width = bytes_per_pixel * size.width;
+    uint32_t row_width = bytes_per_pixel * size.width;
 
     if (is_d3d12)
         row_width = phi::util::align_up(row_width, 256);

--- a/src/phantasm-hardware-interface/util.hh
+++ b/src/phantasm-hardware-interface/util.hh
@@ -8,6 +8,7 @@
 #include <phantasm-hardware-interface/types.hh>
 
 #include <phantasm-hardware-interface/common/byte_util.hh>
+#include <phantasm-hardware-interface/common/api.hh>
 
 namespace phi::util
 {
@@ -29,13 +30,13 @@ inline int get_num_mips(int width, int height) { return int(cc::bit_log2(cc::uin
 inline int get_num_mips(tg::isize2 size) { return get_num_mips(size.width, size.height); }
 
 /// returns the amount of bytes needed to store the contents of a texture in a GPU buffer
-unsigned get_texture_size_bytes(tg::isize3 size, format fmt, int num_mips, bool is_d3d12);
+PHI_API unsigned get_texture_size_bytes(tg::isize3 size, format fmt, int num_mips, bool is_d3d12);
 
 /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
-unsigned get_texture_pixel_byte_offset(tg::isize2 size, format fmt, tg::ivec2 pixel, bool is_d3d12);
+PHI_API unsigned get_texture_pixel_byte_offset(tg::isize2 size, format fmt, tg::ivec2 pixel, bool is_d3d12);
 
 /// converts texture data from bgra8 to rgba8
-void unswizzle_bgra_texture_data(cc::span<std::byte> in_out_texture_data);
+PHI_API void unswizzle_bgra_texture_data(cc::span<std::byte> in_out_texture_data);
 
 /// returns the offset in bytes of the next element of size 'next_size_bytes' in a HLSL constant buffer
 /// where head_offset_bytes is the amount of bytes already in use

--- a/src/phantasm-hardware-interface/util.hh
+++ b/src/phantasm-hardware-interface/util.hh
@@ -7,8 +7,8 @@
 
 #include <phantasm-hardware-interface/types.hh>
 
-#include <phantasm-hardware-interface/common/byte_util.hh>
 #include <phantasm-hardware-interface/common/api.hh>
+#include <phantasm-hardware-interface/common/byte_util.hh>
 
 namespace phi::util
 {

--- a/src/phantasm-hardware-interface/util.hh
+++ b/src/phantasm-hardware-interface/util.hh
@@ -30,17 +30,17 @@ inline int get_num_mips(int width, int height) { return int(cc::bit_log2(cc::uin
 inline int get_num_mips(tg::isize2 size) { return get_num_mips(size.width, size.height); }
 
 /// returns the amount of bytes needed to store the contents of a texture in a GPU buffer
-PHI_API unsigned get_texture_size_bytes(tg::isize3 size, format fmt, int num_mips, bool is_d3d12);
+PHI_API uint32_t get_texture_size_bytes(tg::isize3 size, format fmt, int num_mips, bool is_d3d12);
 
 /// returns the offset in bytes of the given pixel position in a texture of given size and format (in a GPU buffer)
-PHI_API unsigned get_texture_pixel_byte_offset(tg::isize2 size, format fmt, tg::ivec2 pixel, bool is_d3d12);
+PHI_API uint32_t get_texture_pixel_byte_offset(tg::isize2 size, format fmt, tg::ivec2 pixel, bool is_d3d12);
 
 /// converts texture data from bgra8 to rgba8
 PHI_API void unswizzle_bgra_texture_data(cc::span<std::byte> in_out_texture_data);
 
 /// returns the offset in bytes of the next element of size 'next_size_bytes' in a HLSL constant buffer
 /// where head_offset_bytes is the amount of bytes already in use
-constexpr unsigned get_hlsl_constant_buffer_offset(unsigned head_offset_bytes, unsigned next_size_bytes)
+constexpr uint32_t get_hlsl_constant_buffer_offset(uint32_t head_offset_bytes, uint32_t next_size_bytes)
 {
     // ref: https://docs.microsoft.com/en-us/windows/win32/direct3dhlsl/dx-graphics-hlsl-packing-rules
     CC_ASSERT(next_size_bytes <= 16 && "unexpectedly large element");

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -1,5 +1,9 @@
 #include "BackendVulkan.hh"
 
+#ifdef PHI_HAS_OPTICK
+#include <optick/optick.h>
+#endif
+
 #include <clean-core/array.hh>
 #include <clean-core/native/win32_util.hh>
 
@@ -171,6 +175,17 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
                                  config.max_num_unique_transitions_per_cmdlist, //
                                  thread_allocator_ptrs, config.static_allocator, config.dynamic_allocator);
     }
+
+#ifdef PHI_HAS_OPTICK
+    {
+        VkDevice dev = mDevice.getDevice();
+        VkPhysicalDevice physDev = mDevice.getPhysicalDevice();
+        VkQueue dirQueue = mDevice.getRawQueue(phi::queue_type::direct);
+        uint32_t dirQueueIdx = uint32_t(mDevice.getQueueFamilyDirect());
+
+        OPTICK_GPU_INIT_VULKAN(&dev, &physDev, &dirQueue, &dirQueueIdx, 1, nullptr);
+    }
+#endif
 }
 
 void phi::vk::BackendVulkan::destroy()

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -213,13 +213,12 @@ phi::handle::swapchain phi::vk::BackendVulkan::createSwapchain(const phi::window
 
 void phi::vk::BackendVulkan::free(phi::handle::swapchain sc) { mPoolSwapchains.free(sc); }
 
-phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchain sc, bool waitOnCPU)
+phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchain sc)
 {
-    CC_ASSERT(waitOnCPU && "deferred backbuffer waiting unimplemented");
     auto const swapchain_index = mPoolSwapchains.getSwapchainIndex(sc);
     auto const& swapchain = mPoolSwapchains.get(sc);
     auto const prev_backbuffer_index = swapchain.active_image_index;
-    bool const acquire_success = mPoolSwapchains.waitForBackbuffer(sc);
+    bool const acquire_success = mPoolSwapchains.acquireBackbuffer(sc);
 
     if (!acquire_success)
     {
@@ -235,11 +234,6 @@ phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchai
         mPoolSwapchains.setBackbufferState(sc, prev_backbuffer_index, prev_state);
         return res;
     }
-}
-
-void phi::vk::BackendVulkan::waitOnBackbuffer(handle::swapchain sc) 
-{
-    CC_ASSERT(false && "unimplemented");
 }
 
 void phi::vk::BackendVulkan::present(phi::handle::swapchain sc) { mPoolSwapchains.present(sc); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -121,7 +121,13 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
         volkLoadDevice(mDevice.getDevice());
 
         print_startup_message(gpu_infos, chosen_index, config, false);
-        PHI_LOG("   compiled with vulkan sdk v{}.{}.{}", vkver::major, vkver::minor, vkver::patch);
+
+        if (config.print_startup_message)
+        {
+            PHI_LOG("   compiled with vulkan sdk v{}.{}.{}", vkver::major, vkver::minor, vkver::patch);
+        }
+
+        mGPUInfo = gpu_infos[chosen_index];
     }
 
     // Pool init

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -213,8 +213,9 @@ phi::handle::swapchain phi::vk::BackendVulkan::createSwapchain(const phi::window
 
 void phi::vk::BackendVulkan::free(phi::handle::swapchain sc) { mPoolSwapchains.free(sc); }
 
-phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchain sc)
+phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchain sc, bool waitOnCPU)
 {
+    CC_ASSERT(waitOnCPU && "deferred backbuffer waiting unimplemented");
     auto const swapchain_index = mPoolSwapchains.getSwapchainIndex(sc);
     auto const& swapchain = mPoolSwapchains.get(sc);
     auto const prev_backbuffer_index = swapchain.active_image_index;
@@ -234,6 +235,11 @@ phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchai
         mPoolSwapchains.setBackbufferState(sc, prev_backbuffer_index, prev_state);
         return res;
     }
+}
+
+void phi::vk::BackendVulkan::waitOnBackbufferFromGPU(handle::swapchain sc) 
+{
+    CC_ASSERT(false && "unimplemented");
 }
 
 void phi::vk::BackendVulkan::present(phi::handle::swapchain sc) { mPoolSwapchains.present(sc); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -59,10 +59,10 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
 
     VkApplicationInfo app_info = {};
     app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-    app_info.pApplicationName = "phantasm-hardware-interface application";
+    app_info.pApplicationName = "Phantasm Hardware Interface Application";
     app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
-    app_info.pEngineName = "phantasm-hardware-interface";
-    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = "Phantasm Hardware Interface";
+    app_info.engineVersion = VK_MAKE_VERSION(1, 2, 0);
     app_info.apiVersion = VK_API_VERSION_1_1;
 
     VkInstanceCreateInfo instance_info = {};
@@ -73,14 +73,9 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
     instance_info.enabledLayerCount = uint32_t(active_lay_ext.layers.size());
     instance_info.ppEnabledLayerNames = active_lay_ext.layers.empty() ? nullptr : active_lay_ext.layers.data();
 
-#ifdef VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT
-    cc::array<VkValidationFeatureEnableEXT, 3> extended_validation_enables
+    VkValidationFeatureEnableEXT extended_validation_enables[]
         = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
            VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};
-#else
-    cc::array<VkValidationFeatureEnableEXT, 2> extended_validation_enables
-        = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT};
-#endif
 
     VkValidationFeaturesEXT extended_validation_features = {};
 
@@ -88,8 +83,8 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
     {
         // enable GPU-assisted validation
         extended_validation_features.sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
-        extended_validation_features.enabledValidationFeatureCount = static_cast<uint32_t>(extended_validation_enables.size());
-        extended_validation_features.pEnabledValidationFeatures = extended_validation_enables.data();
+        extended_validation_features.enabledValidationFeatureCount = CC_COUNTOF(extended_validation_enables);
+        extended_validation_features.pEnabledValidationFeatures = extended_validation_enables;
 
         instance_info.pNext = &extended_validation_features;
     }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -237,7 +237,7 @@ phi::handle::resource phi::vk::BackendVulkan::acquireBackbuffer(handle::swapchai
     }
 }
 
-void phi::vk::BackendVulkan::waitOnBackbufferFromGPU(handle::swapchain sc) 
+void phi::vk::BackendVulkan::waitOnBackbuffer(handle::swapchain sc) 
 {
     CC_ASSERT(false && "unimplemented");
 }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -227,7 +227,7 @@ void phi::vk::BackendVulkan::destroy()
 
 phi::vk::BackendVulkan::~BackendVulkan() { destroy(); }
 
-phi::handle::swapchain phi::vk::BackendVulkan::createSwapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, phi::present_mode mode, unsigned num_backbuffers)
+phi::handle::swapchain phi::vk::BackendVulkan::createSwapchain(const phi::window_handle& window_handle, tg::isize2 initial_size, phi::present_mode mode, uint32_t num_backbuffers)
 {
     return mPoolSwapchains.createSwapchain(window_handle, initial_size.width, initial_size.height, num_backbuffers, mode);
 }
@@ -271,23 +271,23 @@ phi::format phi::vk::BackendVulkan::getBackbufferFormat(phi::handle::swapchain s
 }
 
 phi::handle::resource phi::vk::BackendVulkan::createTexture(
-    phi::format format, tg::isize2 size, unsigned mips, phi::texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, const char* debug_name)
+    phi::format format, tg::isize2 size, uint32_t mips, phi::texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, const char* debug_name)
 {
-    return mPoolResources.createTexture(format, unsigned(size.width), unsigned(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
+    return mPoolResources.createTexture(format, uint32_t(size.width), uint32_t(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
 }
 
 phi::handle::resource phi::vk::BackendVulkan::createRenderTarget(
-    phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, const phi::rt_clear_value*, const char* debug_name)
+    phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, const phi::rt_clear_value*, const char* debug_name)
 {
-    return mPoolResources.createRenderTarget(format, unsigned(size.width), unsigned(size.height), samples, array_size, debug_name);
+    return mPoolResources.createRenderTarget(format, uint32_t(size.width), uint32_t(size.height), samples, array_size, debug_name);
 }
 
-phi::handle::resource phi::vk::BackendVulkan::createBuffer(unsigned int size_bytes, unsigned int stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::vk::BackendVulkan::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
 {
     return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
 }
 
-phi::handle::resource phi::vk::BackendVulkan::createUploadBuffer(unsigned size_bytes, unsigned stride_bytes, const char* debug_name)
+phi::handle::resource phi::vk::BackendVulkan::createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes, const char* debug_name)
 {
     return createBuffer(size_bytes, stride_bytes, resource_heap::upload, false, debug_name);
 }
@@ -378,7 +378,7 @@ void phi::vk::BackendVulkan::submit(cc::span<const phi::handle::command_list> cl
                                     cc::span<const phi::fence_operation> fence_waits_before,
                                     cc::span<const phi::fence_operation> fence_signals_after)
 {
-    constexpr unsigned c_max_num_command_lists = 32u;
+    constexpr uint32_t c_max_num_command_lists = 32u;
     cc::capped_vector<VkCommandBuffer, c_max_num_command_lists * 2> cmd_bufs_to_submit;
     cc::capped_vector<handle::command_list, c_max_num_command_lists> barrier_lists;
     CC_ASSERT(cls.size() <= c_max_num_command_lists && "too many commandlists submitted at once");
@@ -440,7 +440,7 @@ void phi::vk::BackendVulkan::submit(cc::span<const phi::handle::command_list> cl
 
     // submission
 
-    constexpr unsigned c_max_num_signals_waits = 8;
+    constexpr uint32_t c_max_num_signals_waits = 8;
 
     uint64_t wait_values[c_max_num_signals_waits];
     VkSemaphore wait_semaphores[c_max_num_signals_waits];
@@ -474,7 +474,7 @@ void phi::vk::BackendVulkan::submit(cc::span<const phi::handle::command_list> cl
     submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submit_info.pNext = &timeline_info;
     // command buffers
-    submit_info.commandBufferCount = unsigned(cmd_bufs_to_submit.size());
+    submit_info.commandBufferCount = uint32_t(cmd_bufs_to_submit.size());
     submit_info.pCommandBuffers = cmd_bufs_to_submit.data();
     // wait semaphores
     submit_info.waitSemaphoreCount = uint32_t(fence_waits_before.size());
@@ -504,7 +504,7 @@ void phi::vk::BackendVulkan::waitFenceCPU(phi::handle::fence fence, uint64_t wai
 
 void phi::vk::BackendVulkan::free(cc::span<const phi::handle::fence> fences) { mPoolFences.free(fences); }
 
-phi::handle::query_range phi::vk::BackendVulkan::createQueryRange(phi::query_type type, unsigned int size) { return mPoolQueries.create(type, size); }
+phi::handle::query_range phi::vk::BackendVulkan::createQueryRange(phi::query_type type, uint32_t size) { return mPoolQueries.create(type, size); }
 
 void phi::vk::BackendVulkan::free(phi::handle::query_range query_range) { mPoolQueries.free(query_range); }
 
@@ -515,7 +515,7 @@ phi::handle::pipeline_state phi::vk::BackendVulkan::createRaytracingPipelineStat
                                                         description.max_payload_size_bytes, description.max_attribute_size_bytes, cc::system_allocator);
 }
 
-phi::handle::accel_struct phi::vk::BackendVulkan::createTopLevelAccelStruct(unsigned num_instances, accel_struct_build_flags_t flags)
+phi::handle::accel_struct phi::vk::BackendVulkan::createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags)
 {
     CC_ASSERT(isRaytracingEnabled() && "raytracing is not enabled");
     return mPoolAccelStructs.createTopLevelAS(num_instances);
@@ -549,7 +549,7 @@ phi::shader_table_strides phi::vk::BackendVulkan::calculateShaderTableStrides(co
     return {};
 }
 
-void phi::vk::BackendVulkan::writeShaderTable(std::byte* dest, handle::pipeline_state pso, unsigned stride, arg::shader_table_records records)
+void phi::vk::BackendVulkan::writeShaderTable(std::byte* dest, handle::pipeline_state pso, uint32_t stride, arg::shader_table_records records)
 {
     CC_ASSERT(false && "writeShaderTable unimplemented");
 }
@@ -568,7 +568,7 @@ void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::accel_struct>
 
 void phi::vk::BackendVulkan::setDebugName(phi::handle::resource res, cc::string_view name)
 {
-    mPoolResources.setDebugName(res, name.data(), unsigned(name.length()));
+    mPoolResources.setDebugName(res, name.data(), uint32_t(name.length()));
 }
 
 void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
@@ -582,7 +582,7 @@ void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
         {
             auto const& info = mPoolResources.getImageInfo(res);
             PHI_LOG << " image, raw pointer: " << info.raw_image;
-            PHI_LOG << " " << info.num_mips << " mips, " << info.num_array_layers << " array layers, format: " << unsigned(info.pixel_format);
+            PHI_LOG << " " << info.num_mips << " mips, " << info.num_array_layers << " array layers, format: " << uint32_t(info.pixel_format);
         }
         else
         {

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -164,7 +164,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
         {
             auto& thread_comp = mThreadComponents[i];
             thread_comp.translator.initialize(mDevice.getDevice(), &mPoolShaderViews, &mPoolResources, &mPoolPipelines, &mPoolCmdLists, &mPoolQueries,
-                                              &mPoolAccelStructs);
+                                              &mPoolAccelStructs, mDevice.hasRaytracing());
             thread_allocator_ptrs[i] = &thread_comp.cmd_list_allocator;
         }
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -110,7 +110,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
         auto const vk_gpu_infos = get_all_vulkan_gpu_infos(mInstance);
         auto const gpu_infos = get_available_gpus(vk_gpu_infos);
         auto const chosen_index = get_preferred_gpu(gpu_infos, config.adapter);
-        CC_RUNTIME_ASSERT(chosen_index < gpu_infos.size());
+        CC_RUNTIME_ASSERT(chosen_index < gpu_infos.size() && "Found no GPU candidates");
 
         auto const& chosen_gpu = gpu_infos[chosen_index];
         auto const& chosen_vk_gpu = vk_gpu_infos[chosen_gpu.index];

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -308,6 +308,24 @@ phi::handle::shader_view phi::vk::BackendVulkan::createShaderView(cc::span<const
     return mPoolShaderViews.create(srvs, uavs, samplers, usage_compute);
 }
 
+phi::handle::shader_view phi::vk::BackendVulkan::createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute)
+{
+    CC_ASSERT(false && "unimplemented");
+    return handle::null_shader_view;
+}
+
+void phi::vk::BackendVulkan::writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs)
+{
+    CC_ASSERT(false && "unimplemented");
+}
+
+void phi::vk::BackendVulkan::writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs)
+{
+    CC_ASSERT(false && "unimplemented");
+}
+
+void phi::vk::BackendVulkan::writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers) {}
+
 void phi::vk::BackendVulkan::free(phi::handle::shader_view sv) { mPoolShaderViews.free(sv); }
 
 void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::shader_view> svs) { mPoolShaderViews.free(svs); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -270,16 +270,9 @@ phi::format phi::vk::BackendVulkan::getBackbufferFormat(phi::handle::swapchain s
     return util::to_pr_format(mPoolSwapchains.get(sc).backbuf_format.format);
 }
 
-phi::handle::resource phi::vk::BackendVulkan::createTexture(
-    phi::format format, tg::isize2 size, uint32_t mips, phi::texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::vk::BackendVulkan::createTexture(arg::texture_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createTexture(format, uint32_t(size.width), uint32_t(size.height), mips, dim, depth_or_array_size, allow_uav, debug_name);
-}
-
-phi::handle::resource phi::vk::BackendVulkan::createRenderTarget(
-    phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, const phi::rt_clear_value*, const char* debug_name)
-{
-    return mPoolResources.createRenderTarget(format, uint32_t(size.width), uint32_t(size.height), samples, array_size, debug_name);
+    return mPoolResources.createTexture(desc, debug_name);
 }
 
 phi::handle::resource phi::vk::BackendVulkan::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
@@ -342,7 +335,7 @@ phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(phi::arg
                                               cc::system_allocator, debug_name);
 }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description, char const* debug_name)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(const phi::arg::graphics_pipeline_state_description& description, char const* debug_name)
 {
     return mPoolPipelines.createPipelineState(description.vertices, description.framebuffer, description.shader_arg_shapes, description.has_root_constants,
                                               description.shader_binaries, description.config, cc::system_allocator, debug_name);
@@ -356,7 +349,7 @@ phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(p
     return mPoolPipelines.createComputePipelineState(shader_arg_shapes, shader, has_root_constants, cc::system_allocator, debug_name);
 }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description, char const* debug_name)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(const phi::arg::compute_pipeline_state_description& description, char const* debug_name)
 {
     return mPoolPipelines.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants,
                                                      cc::system_allocator, debug_name);
@@ -514,7 +507,7 @@ phi::handle::query_range phi::vk::BackendVulkan::createQueryRange(phi::query_typ
 
 void phi::vk::BackendVulkan::free(phi::handle::query_range query_range) { mPoolQueries.free(query_range); }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createRaytracingPipelineState(const arg::raytracing_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createRaytracingPipelineState(const arg::raytracing_pipeline_state_description& description)
 {
     CC_ASSERT(isRaytracingEnabled() && "raytracing is not enabled");
     return mPoolPipelines.createRaytracingPipelineState(description.libraries, description.argument_associations, description.hit_groups, description.max_recursion,

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -335,25 +335,31 @@ phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(phi::arg
                                                                         phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                         bool has_root_constants,
                                                                         phi::arg::graphics_shaders shaders,
-                                                                        const phi::pipeline_config& primitive_config)
+                                                                        const phi::pipeline_config& primitive_config,
+                                                                        char const* debug_name)
 {
-    return mPoolPipelines.createPipelineState(vertex_format, framebuffer_conf, shader_arg_shapes, has_root_constants, shaders, primitive_config, cc::system_allocator);
+    return mPoolPipelines.createPipelineState(vertex_format, framebuffer_conf, shader_arg_shapes, has_root_constants, shaders, primitive_config,
+                                              cc::system_allocator, debug_name);
 }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createPipelineState(const phi::arg::graphics_pipeline_state_desc& description, char const* debug_name)
 {
-    return mPoolPipelines.createPipelineState(description.vertices, description.framebuffer, description.shader_arg_shapes,
-                                              description.has_root_constants, description.shader_binaries, description.config, cc::system_allocator);
+    return mPoolPipelines.createPipelineState(description.vertices, description.framebuffer, description.shader_arg_shapes, description.has_root_constants,
+                                              description.shader_binaries, description.config, cc::system_allocator, debug_name);
 }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(phi::arg::shader_arg_shapes shader_arg_shapes, phi::arg::shader_binary shader, bool has_root_constants)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(phi::arg::shader_arg_shapes shader_arg_shapes,
+                                                                               phi::arg::shader_binary shader,
+                                                                               bool has_root_constants,
+                                                                               char const* debug_name)
 {
-    return mPoolPipelines.createComputePipelineState(shader_arg_shapes, shader, has_root_constants, cc::system_allocator);
+    return mPoolPipelines.createComputePipelineState(shader_arg_shapes, shader, has_root_constants, cc::system_allocator, debug_name);
 }
 
-phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description)
+phi::handle::pipeline_state phi::vk::BackendVulkan::createComputePipelineState(const phi::arg::compute_pipeline_state_desc& description, char const* debug_name)
 {
-    return mPoolPipelines.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants, cc::system_allocator);
+    return mPoolPipelines.createComputePipelineState(description.shader_arg_shapes, description.shader, description.has_root_constants,
+                                                     cc::system_allocator, debug_name);
 }
 
 void phi::vk::BackendVulkan::free(phi::handle::pipeline_state ps) { mPoolPipelines.free(ps); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -275,14 +275,9 @@ phi::handle::resource phi::vk::BackendVulkan::createTexture(arg::texture_descrip
     return mPoolResources.createTexture(desc, debug_name);
 }
 
-phi::handle::resource phi::vk::BackendVulkan::createBuffer(uint32_t size_bytes, uint32_t stride_bytes, phi::resource_heap heap, bool allow_uav, const char* debug_name)
+phi::handle::resource phi::vk::BackendVulkan::createBuffer(arg::buffer_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createBuffer(size_bytes, stride_bytes, heap, allow_uav, debug_name);
-}
-
-phi::handle::resource phi::vk::BackendVulkan::createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes, const char* debug_name)
-{
-    return createBuffer(size_bytes, stride_bytes, resource_heap::upload, false, debug_name);
+    return mPoolResources.createBuffer(desc.size_bytes, desc.stride_bytes, desc.heap, desc.allow_uav, debug_name);
 }
 
 std::byte* phi::vk::BackendVulkan::mapBuffer(phi::handle::resource res, int begin, int end) { return mPoolResources.mapBuffer(res, begin, end); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -112,13 +112,17 @@ public:
                                                              arg::shader_arg_shapes shader_arg_shapes,
                                                              bool has_root_constants,
                                                              arg::graphics_shaders shaders,
-                                                             phi::pipeline_config const& primitive_config) override;
+                                                             phi::pipeline_config const& primitive_config,
+                                                             char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes, arg::shader_binary shader, bool has_root_constants) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
+                                                                    arg::shader_binary shader,
+                                                                    bool has_root_constants,
+                                                                    char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
 
     void free(handle::pipeline_state ps) override;
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -40,9 +40,7 @@ public:
 
     void free(handle::swapchain sc) override;
 
-    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) override;
-
-    void waitOnBackbuffer(handle::swapchain sc) override;
+    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc) override;
 
     void present(handle::swapchain sc) override;
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -66,9 +66,7 @@ public:
 
     [[nodiscard]] handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
-
-    [[nodiscard]] handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createBuffer(arg::buffer_description const& desc, char const* debug_name = nullptr) override;
 
     [[nodiscard]] std::byte* mapBuffer(handle::resource res, int begin = 0, int end = -1) override;
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -37,7 +37,7 @@ public:
     [[nodiscard]] handle::swapchain createSwapchain(window_handle const& window_handle,
                                                     tg::isize2 initial_size,
                                                     present_mode mode = present_mode::synced,
-                                                    unsigned num_backbuffers = 3) override;
+                                                    uint32_t num_backbuffers = 3) override;
 
     void free(handle::swapchain sc) override;
 
@@ -55,7 +55,7 @@ public:
 
     format getBackbufferFormat(handle::swapchain sc) const override;
 
-    unsigned getNumBackbuffers(handle::swapchain sc) const override { return unsigned(mPoolSwapchains.get(sc).backbuffers.size()); }
+    uint32_t getNumBackbuffers(handle::swapchain sc) const override { return uint32_t(mPoolSwapchains.get(sc).backbuffers.size()); }
 
     [[nodiscard]] bool clearPendingResize(handle::swapchain sc) override { return mPoolSwapchains.clearResizeFlag(sc); }
 
@@ -65,14 +65,14 @@ public:
     //
 
     [[nodiscard]] handle::resource createTexture(
-        phi::format format, tg::isize2 size, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
+        phi::format format, tg::isize2 size, uint32_t mips, texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::resource createRenderTarget(
-        phi::format format, tg::isize2 size, unsigned samples, unsigned array_size, rt_clear_value const* = nullptr, char const* debug_name = nullptr) override;
+        phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, rt_clear_value const* = nullptr, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createBuffer(unsigned int size_bytes, unsigned int stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::resource createUploadBuffer(unsigned size_bytes, unsigned stride_bytes = 0, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createUploadBuffer(uint32_t size_bytes, uint32_t stride_bytes = 0, char const* debug_name = nullptr) override;
 
     [[nodiscard]] std::byte* mapBuffer(handle::resource res, int begin = 0, int end = -1) override;
 
@@ -154,7 +154,7 @@ public:
     // Query interface
     //
 
-    [[nodiscard]] handle::query_range createQueryRange(query_type type, unsigned int size) override;
+    [[nodiscard]] handle::query_range createQueryRange(query_type type, uint32_t size) override;
 
     void free(handle::query_range query_range) override;
 
@@ -164,7 +164,7 @@ public:
 
     [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_desc const& description) override;
 
-    handle::accel_struct createTopLevelAccelStruct(unsigned num_instances, accel_struct_build_flags_t flags) override;
+    handle::accel_struct createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags) override;
 
     handle::accel_struct createBottomLevelAccelStruct(cc::span<arg::blas_element const> elements,
                                                       accel_struct_build_flags_t flags,
@@ -177,7 +177,7 @@ public:
                                                                    arg::shader_table_records hit_group_records,
                                                                    arg::shader_table_records callable_records = {}) override;
 
-    void writeShaderTable(std::byte* dest, handle::pipeline_state pso, unsigned stride, arg::shader_table_records records) override;
+    void writeShaderTable(std::byte* dest, handle::pipeline_state pso, uint32_t stride, arg::shader_table_records records) override;
 
     void free(handle::accel_struct as) override;
 
@@ -237,7 +237,7 @@ private:
 
     // Logic
     per_thread_component* mThreadComponents;
-    unsigned mNumThreadComponents;
+    uint32_t mNumThreadComponents;
     void* mThreadComponentAlloc;
     phi::thread_association mThreadAssociation;
     ShaderTableConstructor mShaderTableCtor;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -40,7 +40,9 @@ public:
 
     void free(handle::swapchain sc) override;
 
-    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc) override;
+    [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) override;
+
+    void waitOnBackbufferFromGPU(handle::swapchain sc) override;
 
     void present(handle::swapchain sc) override;
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -42,7 +42,7 @@ public:
 
     [[nodiscard]] handle::resource acquireBackbuffer(handle::swapchain sc, bool waitOnCPU = true) override;
 
-    void waitOnBackbufferFromGPU(handle::swapchain sc) override;
+    void waitOnBackbuffer(handle::swapchain sc) override;
 
     void present(handle::swapchain sc) override;
 

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -91,6 +91,14 @@ public:
                                                        cc::span<sampler_config const> samplers,
                                                        bool usage_compute) override;
 
+    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute) override;
+
+    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) override;
+
+    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs) override;
+
+    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers) override;
+
     void free(handle::shader_view sv) override;
 
     void freeRange(cc::span<handle::shader_view const> svs) override;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -2,6 +2,7 @@
 
 #include <phantasm-hardware-interface/Backend.hh>
 #include <phantasm-hardware-interface/common/thread_association.hh>
+#include <phantasm-hardware-interface/features/gpu_info.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 #include "Device.hh"
@@ -196,6 +197,8 @@ public:
 
     backend_type getBackendType() const override;
 
+    gpu_info const& getGPUInfo() const override { return mGPUInfo; }
+
 public:
     // backend-internal
 
@@ -209,6 +212,7 @@ private:
     per_thread_component& getCurrentThreadComponent();
 
 private:
+    gpu_info mGPUInfo;
     VkInstance mInstance = nullptr;
     VkDebugUtilsMessengerEXT mDebugMessenger = nullptr;
     Device mDevice;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -19,7 +19,7 @@
 
 namespace phi::vk
 {
-class BackendVulkan final : public Backend
+class PHI_API BackendVulkan final : public Backend
 {
 public:
     void initialize(backend_config const& config_arg) override;

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -64,11 +64,7 @@ public:
     // Resource interface
     //
 
-    [[nodiscard]] handle::resource createTexture(
-        phi::format format, tg::isize2 size, uint32_t mips, texture_dimension dim, uint32_t depth_or_array_size, bool allow_uav, char const* debug_name = nullptr) override;
-
-    [[nodiscard]] handle::resource createRenderTarget(
-        phi::format format, tg::isize2 size, uint32_t samples, uint32_t array_size, rt_clear_value const* = nullptr, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::resource createTexture(arg::texture_description const& desc, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::resource createBuffer(uint32_t size_bytes, uint32_t stride_bytes, resource_heap heap, bool allow_uav, char const* debug_name = nullptr) override;
 
@@ -115,14 +111,15 @@ public:
                                                              phi::pipeline_config const& primitive_config,
                                                              char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::pipeline_state createPipelineState(arg::graphics_pipeline_state_description const& description, char const* debug_name = nullptr) override;
 
     [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
                                                                     arg::shader_binary shader,
                                                                     bool has_root_constants,
                                                                     char const* debug_name = nullptr) override;
 
-    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_desc const& description, char const* debug_name = nullptr) override;
+    [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::compute_pipeline_state_description const& description,
+                                                                    char const* debug_name = nullptr) override;
 
     void free(handle::pipeline_state ps) override;
 
@@ -166,7 +163,7 @@ public:
     // Raytracing interface
     //
 
-    [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_desc const& description) override;
+    [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(arg::raytracing_pipeline_state_description const& description) override;
 
     handle::accel_struct createTopLevelAccelStruct(uint32_t num_instances, accel_struct_build_flags_t flags) override;
 

--- a/src/phantasm-hardware-interface/vulkan/Device.cc
+++ b/src/phantasm-hardware-interface/vulkan/Device.cc
@@ -36,7 +36,7 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
     device_info.ppEnabledLayerNames = active_lay_ext.layers.empty() ? nullptr : active_lay_ext.layers.data();
 
     // assemble queue creation struct
-    float const global_queue_priorities[3] = {1.f, 1.f, 1.f};
+    float const global_queue_priorities[] = {1.f, 1.f, 1.f};
     cc::capped_vector<VkDeviceQueueCreateInfo, 3> queue_create_infos;
     auto const f_add_queue = [&](int family_index) -> void {
         for (auto& info : queue_create_infos)

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -682,7 +682,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::update_bottom_lev
     VkAccelerationStructureInfoNV build_info = {};
     build_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
     build_info.pNext = nullptr;
-    build_info.flags = util::to_native_flags(dest_node.flags);
+    build_info.flags = util::to_native_accel_struct_build_flags(dest_node.flags);
     build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;
     build_info.geometryCount = uint32_t(dest_node.geometries.size());
     build_info.pGeometries = dest_node.geometries.empty() ? nullptr : dest_node.geometries.data();
@@ -707,7 +707,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::update_top_level&
     VkAccelerationStructureInfoNV build_info = {};
     build_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
     build_info.pNext = nullptr;
-    build_info.flags = util::to_native_flags(dest_node.flags);
+    build_info.flags = util::to_native_accel_struct_build_flags(dest_node.flags);
     build_info.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
     build_info.geometryCount = 0;
     build_info.pGeometries = nullptr;

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -2,7 +2,6 @@
 
 #include <phantasm-hardware-interface/common/byte_util.hh>
 #include <phantasm-hardware-interface/common/command_reading.hh>
-#include <phantasm-hardware-interface/common/incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/common/log.hh>
 #include <phantasm-hardware-interface/util.hh>
 

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -2,6 +2,7 @@
 
 #include <phantasm-hardware-interface/common/byte_util.hh>
 #include <phantasm-hardware-interface/common/command_reading.hh>
+#include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/common/log.hh>
 #include <phantasm-hardware-interface/util.hh>
 
@@ -499,7 +500,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::resolve_texture& 
 
     VkImageResolve region = {};
 
-    region.srcSubresource.aspectMask = is_depth_format(dest_info.pixel_format) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
+    region.srcSubresource.aspectMask = phi::util::is_depth_format(dest_info.pixel_format) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
     region.srcSubresource.mipLevel = resolve.src_mip_index;
     region.srcSubresource.layerCount = 1;
     region.srcSubresource.baseArrayLayer = resolve.src_array_index;
@@ -655,7 +656,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::clear_textures& c
         range.layerCount = op.rv.texture_info.array_size;
 
 
-        if (is_depth_format(op.rv.texture_info.pixel_format))
+        if (phi::util::is_depth_format(op.rv.texture_info.pixel_format))
         {
             VkClearDepthStencilValue clearval = {};
             clearval.depth = op.value.red_or_depth / 255.f;

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -241,11 +241,11 @@ void phi::vk::command_list_translator::execute(const phi::cmd::draw& draw)
     // Draw command
     if (draw.index_buffer.is_valid())
     {
-        vkCmdDrawIndexed(_cmd_list, draw.num_indices, 1, draw.index_offset, draw.vertex_offset, 0);
+        vkCmdDrawIndexed(_cmd_list, draw.num_indices, draw.num_instances, draw.index_offset, draw.vertex_offset, 0);
     }
     else
     {
-        vkCmdDraw(_cmd_list, draw.num_indices, 1, draw.index_offset, 0);
+        vkCmdDraw(_cmd_list, draw.num_indices, draw.num_instances, draw.index_offset, 0);
     }
 }
 

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -27,6 +27,7 @@ void phi::vk::command_list_translator::translateCommandList(
 
     _bound.reset();
     _state_cache->reset();
+    _last_code_location.reset();
 
     // translate all contained commands
     command_stream_parser parser(buffer, buffer_size);
@@ -673,6 +674,13 @@ void phi::vk::command_list_translator::execute(const phi::cmd::clear_textures& c
             vkCmdClearColorImage(_cmd_list, resource, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clearval, 1, &range);
         }
     }
+}
+
+void phi::vk::command_list_translator::execute(cmd::code_location_marker const& marker)
+{
+    _last_code_location.file = marker.file;
+    _last_code_location.function = marker.function;
+    _last_code_location.line = marker.line;
 }
 
 void phi::vk::command_list_translator::bind_shader_arguments(phi::handle::pipeline_state pso,

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -241,11 +241,11 @@ void phi::vk::command_list_translator::execute(const phi::cmd::draw& draw)
     // Draw command
     if (draw.index_buffer.is_valid())
     {
-        vkCmdDrawIndexed(_cmd_list, draw.num_indices, 1, draw.index_offset, int32_t(draw.vertex_offset), 0);
+        vkCmdDrawIndexed(_cmd_list, draw.num_indices, 1, draw.index_offset, draw.vertex_offset, 0);
     }
     else
     {
-        vkCmdDraw(_cmd_list, draw.num_indices, 1, draw.vertex_offset, 0);
+        vkCmdDraw(_cmd_list, draw.num_indices, 1, draw.index_offset, 0);
     }
 }
 

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -676,8 +676,8 @@ void phi::vk::command_list_translator::execute(const phi::cmd::update_top_level&
     build_info.pGeometries = nullptr;
     build_info.instanceCount = tlas_update.num_instances;
 
-    vkCmdBuildAccelerationStructureNV(_cmd_list, &build_info, _globals.pool_resources->getRawBuffer(tlas_update.source_buffer_instances),
-                                      tlas_update.source_buffer_offset_bytes, VK_FALSE, dest_node.raw_as, nullptr, dest_scratch, 0);
+    vkCmdBuildAccelerationStructureNV(_cmd_list, &build_info, _globals.pool_resources->getRawBuffer(tlas_update.source_instances_addr.buffer),
+                                      tlas_update.source_instances_addr.offset_bytes, VK_FALSE, dest_node.raw_as, nullptr, dest_scratch, 0);
 
     VkMemoryBarrier mem_barrier = {};
     mem_barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
@@ -709,7 +709,7 @@ void phi::vk::command_list_translator::execute(const cmd::dispatch_rays& dispatc
                      miss_buf, dispatch_rays.table_miss.offset_bytes, dispatch_rays.table_miss.stride_bytes,               //
                      hitgrp_buf, dispatch_rays.table_hit_groups.offset_bytes, dispatch_rays.table_hit_groups.stride_bytes, //
                      callable_buf, dispatch_rays.table_callable.offset_bytes, dispatch_rays.table_callable.stride_bytes,   //
-                     dispatch_rays.width, dispatch_rays.height, dispatch_rays.depth);
+                     dispatch_rays.dispatch_x, dispatch_rays.dispatch_y, dispatch_rays.dispatch_z);
 }
 
 void phi::vk::command_list_translator::execute(const phi::cmd::clear_textures& clear_tex)

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -124,6 +124,8 @@ struct command_list_translator
     void execute(cmd::code_location_marker const& marker);
 
 private:
+    void bind_vertex_buffers(handle::resource const vertex_buffers[limits::max_vertex_buffers]);
+
     void bind_shader_arguments(handle::pipeline_state pso, std::byte const* root_consts, cc::span<shader_argument const> shader_args, VkPipelineBindPoint bind_point);
 
     VkBuffer get_buffer_or_null(handle::resource buf) const;
@@ -142,7 +144,7 @@ private:
     {
         handle::pipeline_state pipeline_state = handle::null_pipeline_state;
         handle::resource index_buffer = handle::null_resource;
-        handle::resource vertex_buffer = handle::null_resource;
+        uint64_t vertex_buffer_hash = uint64_t(-1);
 
         struct shader_arg_info
         {
@@ -192,7 +194,7 @@ private:
         {
             pipeline_state = handle::null_pipeline_state;
             index_buffer = handle::null_resource;
-            vertex_buffer = handle::null_resource;
+            vertex_buffer_hash = uint64_t(-1);
 
             raw_render_pass = nullptr;
             raw_framebuffer = nullptr;

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -81,6 +81,8 @@ struct command_list_translator
 
     void execute(cmd::dispatch const& dispatch);
 
+    void execute(cmd::dispatch_indirect const& dispatch_indirect);
+
     void execute(cmd::end_render_pass const& end_rp);
 
     void execute(cmd::transition_resources const& transition_res);

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -7,6 +7,13 @@
 #include <phantasm-hardware-interface/vulkan/common/vk_incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/vulkan/loader/volk.hh>
 
+#ifdef PHI_HAS_OPTICK
+namespace Optick
+{
+struct EventData;
+}
+#endif
+
 namespace phi::vk
 {
 class ShaderViewPool;
@@ -83,6 +90,10 @@ struct command_list_translator
     void execute(cmd::begin_debug_label const& label);
 
     void execute(cmd::end_debug_label const&);
+
+    void execute(cmd::begin_profile_scope const& scope);
+
+    void execute(cmd::end_profile_scope const&);
 
     void execute(cmd::update_bottom_level const& blas_update);
 
@@ -219,6 +230,11 @@ private:
         }
 
     } _last_code_location;
+
+// debug state - current Optick GPU Event
+#ifdef PHI_HAS_OPTICK
+    Optick::EventData* _current_optick_event = nullptr;
+#endif
 };
 
 }

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -25,7 +25,14 @@ class QueryPool;
 
 struct translator_global_memory
 {
-    void initialize(VkDevice device, ShaderViewPool* sv_pool, ResourcePool* resource_pool, PipelinePool* pso_pool, CommandListPool* cmd_pool, QueryPool* query_pool, AccelStructPool* as_pool)
+    void initialize(VkDevice device,
+                    ShaderViewPool* sv_pool,
+                    ResourcePool* resource_pool,
+                    PipelinePool* pso_pool,
+                    CommandListPool* cmd_pool,
+                    QueryPool* query_pool,
+                    AccelStructPool* as_pool,
+                    bool has_rt)
     {
         this->device = device;
         this->pool_shader_views = sv_pool;
@@ -34,6 +41,7 @@ struct translator_global_memory
         this->pool_cmd_lists = cmd_pool;
         this->pool_queries = query_pool;
         this->pool_accel_structs = as_pool;
+        this->has_raytracing = has_rt;
     }
 
     VkDevice device = nullptr;
@@ -43,6 +51,7 @@ struct translator_global_memory
     CommandListPool* pool_cmd_lists = nullptr;
     QueryPool* pool_queries = nullptr;
     AccelStructPool* pool_accel_structs = nullptr;
+    bool has_raytracing = false;
 
     translator_global_memory() = default;
 };
@@ -50,9 +59,16 @@ struct translator_global_memory
 /// responsible for filling command lists, 1 per thread
 struct command_list_translator
 {
-    void initialize(VkDevice device, ShaderViewPool* sv_pool, ResourcePool* resource_pool, PipelinePool* pso_pool, CommandListPool* cmd_pool, QueryPool* query_pool, AccelStructPool* as_pool)
+    void initialize(VkDevice device,
+                    ShaderViewPool* sv_pool,
+                    ResourcePool* resource_pool,
+                    PipelinePool* pso_pool,
+                    CommandListPool* cmd_pool,
+                    QueryPool* query_pool,
+                    AccelStructPool* as_pool,
+                    bool has_rt)
     {
-        _globals.initialize(device, sv_pool, resource_pool, pso_pool, cmd_pool, query_pool, as_pool);
+        _globals.initialize(device, sv_pool, resource_pool, pso_pool, cmd_pool, query_pool, as_pool, has_rt);
     }
 
     void translateCommandList(VkCommandBuffer list, handle::command_list list_handle, vk_incomplete_state_cache* state_cache, std::byte const* buffer, size_t buffer_size);

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.hh
@@ -92,6 +92,8 @@ struct command_list_translator
 
     void execute(cmd::clear_textures const& clear_tex);
 
+    void execute(cmd::code_location_marker const& marker);
+
 private:
     void bind_shader_arguments(handle::pipeline_state pso, std::byte const* root_consts, cc::span<shader_argument const> shader_args, VkPipelineBindPoint bind_point);
 
@@ -201,6 +203,22 @@ private:
         }
 
     } _bound;
+
+    // debug state - cmd::code_location_marker
+    struct
+    {
+        char const* function;
+        char const* file;
+        int line;
+
+        void reset()
+        {
+            function = "NONE";
+            file = "NONE";
+            line = 0;
+        }
+
+    } _last_code_location;
 };
 
 }

--- a/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
@@ -713,7 +713,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(bf);
 }
 
-[[nodiscard]] constexpr VkBuildAccelerationStructureFlagsNV to_native_flags(accel_struct_build_flags_t flags)
+[[nodiscard]] constexpr VkBuildAccelerationStructureFlagsNV to_native_accel_struct_build_flags(accel_struct_build_flags_t flags)
 {
     VkBuildAccelerationStructureFlagsNV res = 0;
 

--- a/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
@@ -2,6 +2,7 @@
 
 #include <clean-core/assert.hh>
 
+#include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/types.hh>
 
 #include <phantasm-hardware-interface/vulkan/loader/volk.hh>
@@ -419,7 +420,7 @@ namespace phi::vk::util
 
 [[nodiscard]] constexpr VkImageAspectFlags to_native_image_aspect(format fmt)
 {
-    if (is_view_format(fmt))
+    if (phi::util::is_view_format(fmt))
     {
         if (fmt == format::r24un_g8t)
         {
@@ -431,11 +432,11 @@ namespace phi::vk::util
             return VK_IMAGE_ASPECT_STENCIL_BIT;
         }
     }
-    else if (is_depth_stencil_format(fmt))
+    else if (phi::util::is_depth_stencil_format(fmt))
     {
         return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     }
-    else if (is_depth_format(fmt))
+    else if (phi::util::is_depth_format(fmt))
     {
         return VK_IMAGE_ASPECT_DEPTH_BIT;
     }

--- a/src/phantasm-hardware-interface/vulkan/common/util.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/util.cc
@@ -11,7 +11,7 @@ cc::capped_vector<VkVertexInputAttributeDescription, 16> phi::vk::util::get_nati
     for (auto const& ai : attrib_info)
     {
         VkVertexInputAttributeDescription& elem = res.emplace_back();
-        elem.binding = 0;
+        elem.binding = ai.vertex_buffer_i;
         elem.location = uint32_t(res.size() - 1);
         elem.format = util::to_vk_format(ai.fmt);
         elem.offset = ai.offset;

--- a/src/phantasm-hardware-interface/vulkan/common/util.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/util.hh
@@ -49,7 +49,8 @@ inline constexpr VkObjectType as_obj_type_enum = get_object_type<VkT>();
 }
 
 template <class VkT>
-CC_PRINTF_FUNC(3) void set_object_name(VkDevice device, VkT* object, char const* fmt, ...)
+CC_PRINTF_FUNC(3)
+void set_object_name(VkDevice device, VkT* object, char const* fmt, ...)
 {
     char buf[1024];
 

--- a/src/phantasm-hardware-interface/vulkan/common/util.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/util.hh
@@ -34,6 +34,8 @@ inline constexpr VkObjectType get_object_type()
         return VK_OBJECT_TYPE_FENCE;
     else if constexpr (std::is_same_v<VkT, VkSemaphore_T>)
         return VK_OBJECT_TYPE_SEMAPHORE;
+    else if constexpr (std::is_same_v<VkT, VkPipeline_T>)
+        return VK_OBJECT_TYPE_PIPELINE;
     // NOTE: there is some chaos surrounding this struct in the KHR/NV transition, this works however
     else if constexpr (std::is_same_v<VkT, std::remove_pointer_t<VkAccelerationStructureNV>>)
         return VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV;

--- a/src/phantasm-hardware-interface/vulkan/common/verify.cc
+++ b/src/phantasm-hardware-interface/vulkan/common/verify.cc
@@ -73,7 +73,4 @@ void phi::vk::detail::verify_failure_handler(VkResult vr, const char* expression
     PHI_LOG_ASSERT("backend verify on {} failed", expression);
     PHI_LOG_ASSERT("  error: {}", error_string);
     PHI_LOG_ASSERT("  file {}:{}", filename, line);
-
-    // TODO: Graceful shutdown, possibly memory dump n
-    std::abort();
 }

--- a/src/phantasm-hardware-interface/vulkan/common/verify.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/verify.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <clean-core/assert.hh>
 #include <clean-core/macros.hh>
 
 #include <phantasm-hardware-interface/common/value_category.hh>
@@ -14,14 +15,17 @@ namespace phi::vk::detail
 // NOTE: possibly merge this somehow with CC_ASSERT
 
 /// Terminates with a detailed error message if the given VkResult lvalue is not VK_SUCCESS
-#define PHI_VK_ASSERT_SUCCESS(_val_)                                                                     \
-    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_VK_VERIFY_SUCCESS for prvalue expressions"); \
-    (CC_UNLIKELY(_val_ != VK_SUCCESS) ? ::phi::vk::detail::verify_failure_handler(_val_, #_val_ " is not VK_SUCCESS", __FILE__, __LINE__) : void(0))
+#define PHI_VK_ASSERT_SUCCESS(_val_)                                                                                                 \
+    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_VK_VERIFY_SUCCESS for prvalue expressions");                             \
+    (CC_UNLIKELY(_val_ != VK_SUCCESS)                                                                                                \
+         ? (::phi::vk::detail::verify_failure_handler(_val_, #_val_ " is not VK_SUCCESS", __FILE__, __LINE__), CC_BREAK_AND_ABORT()) \
+         : void(0))
 
 /// Terminates with a detailed error message if the given VkResult lvalue is not an error (less strict)
-#define PHI_VK_ASSERT_NONERROR(_val_)                                                                     \
-    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_VK_VERIFY_NONERROR for prvalue expressions"); \
-    (CC_UNLIKELY(_val_ < VK_SUCCESS) ? ::phi::vk::detail::verify_failure_handler(_val_, #_val_ " is an error value", __FILE__, __LINE__) : void(0))
+#define PHI_VK_ASSERT_NONERROR(_val_)                                                                                                                            \
+    static_assert(PHI_IS_LVALUE_EXPRESSION(_val_), "Use PHI_VK_VERIFY_NONERROR for prvalue expressions");                                                        \
+    (CC_UNLIKELY(_val_ < VK_SUCCESS) ? (::phi::vk::detail::verify_failure_handler(_val_, #_val_ " is an error value", __FILE__, __LINE__), CC_BREAK_AND_ABORT()) \
+                                     : void(0))
 
 /// Executes the given expression and terminates with a detailed error message if the VkResult is not VK_SUCCESS
 #define PHI_VK_VERIFY_SUCCESS(_expr_)                                                                     \
@@ -32,6 +36,7 @@ namespace phi::vk::detail
         if (CC_UNLIKELY(op_res != VK_SUCCESS))                                                            \
         {                                                                                                 \
             ::phi::vk::detail::verify_failure_handler(op_res, #_expr_, __FILE__, __LINE__);               \
+            CC_BREAK_AND_ABORT();                                                                         \
         }                                                                                                 \
     } while (0)
 
@@ -44,5 +49,6 @@ namespace phi::vk::detail
         if (CC_UNLIKELY(op_res < VK_SUCCESS))                                                              \
         {                                                                                                  \
             ::phi::vk::detail::verify_failure_handler(op_res, #_expr_, __FILE__, __LINE__);                \
+            CC_BREAK_AND_ABORT();                                                                          \
         }                                                                                                  \
     } while (0)

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -15,8 +15,7 @@ inline VkFormat to_vk_format(phi::format fmt)
 {
     switch (fmt)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_TO_VK)
-        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_TO_VK)
+        PHI_FORMAT_INFO_LIST_ALL(PHI_FORMAT_INFO_X_TO_VK)
 
     case format::none:
     case format::MAX_FORMAT_RANGE:
@@ -30,7 +29,8 @@ inline phi::format to_pr_format(VkFormat format)
 {
     switch (format)
     {
-        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_FROM_VK)
+        // only regular formats, view-only formats map to the same VkFormat in Vulkan
+        PHI_FORMAT_INFO_LIST_REGULAR(PHI_FORMAT_INFO_X_FROM_VK)
 
     default:
         return format::none;

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -12,7 +12,7 @@ namespace phi::vk::util
 {
     using bf = phi::format;
     switch (format)
-    {
+    {        
     case bf::rgba32f:
         return VK_FORMAT_R32G32B32A32_SFLOAT;
     case bf::rgb32f:
@@ -89,6 +89,10 @@ namespace phi::vk::util
         return VK_FORMAT_B8G8R8A8_UNORM;
     case bf::b10g11r11uf:
         return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+    case bf::r10g10b10a2u:
+        return VK_FORMAT_A2R10G10B10_UINT_PACK32;
+    case bf::r10g10b10a2un:
+        return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
 
     case bf::bc1_8un:
         return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;

--- a/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/vk_format.hh
@@ -1,230 +1,39 @@
 #pragma once
 
+
 #include <clean-core/assert.hh>
 
 #include <phantasm-hardware-interface/types.hh>
+
+#include <phantasm-hardware-interface/common/format_info_list.hh>
 
 #include <phantasm-hardware-interface/vulkan/loader/volk.hh>
 
 namespace phi::vk::util
 {
-[[nodiscard]] inline constexpr VkFormat to_vk_format(phi::format format)
+inline VkFormat to_vk_format(phi::format fmt)
 {
-    using bf = phi::format;
-    switch (format)
-    {        
-    case bf::rgba32f:
-        return VK_FORMAT_R32G32B32A32_SFLOAT;
-    case bf::rgb32f:
-        return VK_FORMAT_R32G32B32_SFLOAT;
-    case bf::rg32f:
-        return VK_FORMAT_R32G32_SFLOAT;
-    case bf::r32f:
-        return VK_FORMAT_R32_SFLOAT;
+    switch (fmt)
+    {
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_TO_VK)
+        PHI_FORMAT_INFO_LIST_VIEWONLY(PHI_FORMAT_INFO_X_TO_VK)
 
-    case bf::rgba32i:
-        return VK_FORMAT_R32G32B32A32_SINT;
-    case bf::rgb32i:
-        return VK_FORMAT_R32G32B32_SINT;
-    case bf::rg32i:
-        return VK_FORMAT_R32G32_SINT;
-    case bf::r32i:
-        return VK_FORMAT_R32_SINT;
-
-    case bf::rgba32u:
-        return VK_FORMAT_R32G32B32A32_UINT;
-    case bf::rgb32u:
-        return VK_FORMAT_R32G32B32_UINT;
-    case bf::rg32u:
-        return VK_FORMAT_R32G32_UINT;
-    case bf::r32u:
-        return VK_FORMAT_R32_UINT;
-
-    case bf::rgba16i:
-        return VK_FORMAT_R16G16B16A16_SINT;
-    case bf::rg16i:
-        return VK_FORMAT_R16G16_SINT;
-    case bf::r16i:
-        return VK_FORMAT_R16_SINT;
-
-    case bf::rgba16u:
-        return VK_FORMAT_R16G16B16A16_UINT;
-    case bf::rg16u:
-        return VK_FORMAT_R16G16_UINT;
-    case bf::r16u:
-        return VK_FORMAT_R16_UINT;
-
-    case bf::rgba16f:
-        return VK_FORMAT_R16G16B16A16_SFLOAT;
-    case bf::rg16f:
-        return VK_FORMAT_R16G16_SFLOAT;
-    case bf::r16f:
-        return VK_FORMAT_R16_SFLOAT;
-
-    case bf::rgba8i:
-        return VK_FORMAT_R8G8B8A8_SINT;
-    case bf::rg8i:
-        return VK_FORMAT_R8G8_SINT;
-    case bf::r8i:
-        return VK_FORMAT_R8_SINT;
-
-    case bf::rgba8u:
-        return VK_FORMAT_R8G8B8A8_UINT;
-    case bf::rg8u:
-        return VK_FORMAT_R8G8_UINT;
-    case bf::r8u:
-        return VK_FORMAT_R8_UINT;
-
-    case bf::rgba8un:
-        return VK_FORMAT_R8G8B8A8_UNORM;
-    case bf::rg8un:
-        return VK_FORMAT_R8G8_UNORM;
-    case bf::r8un:
-        return VK_FORMAT_R8_UNORM;
-
-    case bf::rgba8un_srgb:
-        return VK_FORMAT_R8G8B8A8_SRGB;
-
-    case bf::bgra8un:
-        return VK_FORMAT_B8G8R8A8_UNORM;
-    case bf::b10g11r11uf:
-        return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
-    case bf::r10g10b10a2u:
-        return VK_FORMAT_A2R10G10B10_UINT_PACK32;
-    case bf::r10g10b10a2un:
-        return VK_FORMAT_A2R10G10B10_UNORM_PACK32;
-
-    case bf::bc1_8un:
-        return VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    case bf::bc1_8un_srgb:
-        return VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
-    case bf::bc2_8un:
-        return VK_FORMAT_BC2_UNORM_BLOCK;
-    case bf::bc2_8un_srgb:
-        return VK_FORMAT_BC2_SRGB_BLOCK;
-    case bf::bc3_8un:
-        return VK_FORMAT_BC3_UNORM_BLOCK;
-    case bf::bc3_8un_srgb:
-        return VK_FORMAT_BC3_SRGB_BLOCK;
-    case bf::bc6h_16f:
-        return VK_FORMAT_BC6H_SFLOAT_BLOCK;
-    case bf::bc6h_16uf:
-        return VK_FORMAT_BC6H_UFLOAT_BLOCK;
-
-        // view-only formats are handled in image aspect bits
-    case bf::r24un_g8t:
-        return VK_FORMAT_D24_UNORM_S8_UINT;
-    case bf::r24t_g8u:
-        return VK_FORMAT_D24_UNORM_S8_UINT;
-
-    case bf::depth32f:
-        return VK_FORMAT_D32_SFLOAT;
-    case bf::depth16un:
-        return VK_FORMAT_D16_UNORM;
-    case bf::depth32f_stencil8u:
-        return VK_FORMAT_D32_SFLOAT_S8_UINT;
-    case bf::depth24un_stencil8u:
-        return VK_FORMAT_D24_UNORM_S8_UINT;
-
-    case bf::none:
-    case bf::MAX_FORMAT_RANGE:
+    case format::none:
+    case format::MAX_FORMAT_RANGE:
         return VK_FORMAT_UNDEFINED;
     }
-    CC_UNREACHABLE_SWITCH_WORKAROUND(format);
+
+    CC_UNREACHABLE("invalid format enum");
 }
 
-[[nodiscard]] inline constexpr phi::format to_pr_format(VkFormat format)
+inline phi::format to_pr_format(VkFormat format)
 {
-    using bf = phi::format;
     switch (format)
     {
-    case VK_FORMAT_R32G32B32A32_SFLOAT:
-        return bf::rgba32f;
-    case VK_FORMAT_R32G32B32_SFLOAT:
-        return bf::rgb32f;
-    case VK_FORMAT_R32G32_SFLOAT:
-        return bf::rg32f;
-    case VK_FORMAT_R32_SFLOAT:
-        return bf::r32f;
-
-    case VK_FORMAT_R32G32B32A32_SINT:
-        return bf::rgba32i;
-    case VK_FORMAT_R32G32B32_SINT:
-        return bf::rgb32i;
-    case VK_FORMAT_R32G32_SINT:
-        return bf::rg32i;
-    case VK_FORMAT_R32_SINT:
-        return bf::r32i;
-
-    case VK_FORMAT_R32G32B32A32_UINT:
-        return bf::rgba32u;
-    case VK_FORMAT_R32G32B32_UINT:
-        return bf::rgb32u;
-    case VK_FORMAT_R32G32_UINT:
-        return bf::rg32u;
-    case VK_FORMAT_R32_UINT:
-        return bf::r32u;
-
-    case VK_FORMAT_R16G16B16A16_SINT:
-        return bf::rgba16i;
-    case VK_FORMAT_R16G16_SINT:
-        return bf::rg16i;
-    case VK_FORMAT_R16_SINT:
-        return bf::r16i;
-
-    case VK_FORMAT_R16G16B16A16_UINT:
-        return bf::rgba16u;
-    case VK_FORMAT_R16G16_UINT:
-        return bf::rg16u;
-    case VK_FORMAT_R16_UINT:
-        return bf::r16u;
-
-    case VK_FORMAT_R16G16B16A16_SFLOAT:
-        return bf::rgba16f;
-    case VK_FORMAT_R16G16_SFLOAT:
-        return bf::rg16f;
-    case VK_FORMAT_R16_SFLOAT:
-        return bf::r16f;
-
-    case VK_FORMAT_R8G8B8A8_SINT:
-        return bf::rgba8i;
-    case VK_FORMAT_R8G8_SINT:
-        return bf::rg8i;
-    case VK_FORMAT_R8_SINT:
-        return bf::r8i;
-
-    case VK_FORMAT_R8G8B8A8_UINT:
-        return bf::rgba8u;
-    case VK_FORMAT_R8G8_UINT:
-        return bf::rg8u;
-    case VK_FORMAT_R8_UINT:
-        return bf::r8u;
-
-    case VK_FORMAT_R8G8B8A8_UNORM:
-        return bf::rgba8un;
-    case VK_FORMAT_R8G8_UNORM:
-        return bf::rg8un;
-    case VK_FORMAT_R8_UNORM:
-        return bf::r8un;
-
-    case VK_FORMAT_R8G8B8A8_SRGB:
-        return bf::rgba8un_srgb;
-
-    case VK_FORMAT_B8G8R8A8_UNORM:
-        return bf::bgra8un;
-
-    case VK_FORMAT_D32_SFLOAT:
-        return bf::depth32f;
-    case VK_FORMAT_D16_UNORM:
-        return bf::depth16un;
-    case VK_FORMAT_D32_SFLOAT_S8_UINT:
-        return bf::depth32f_stencil8u;
-    case VK_FORMAT_D24_UNORM_S8_UINT:
-        return bf::depth24un_stencil8u;
+        PHI_FORMAT_INFO_LIST(PHI_FORMAT_INFO_X_FROM_VK)
 
     default:
-        CC_ASSERT(false && "untranslatable VkFormat");
-        return bf::rgba8u;
+        return format::none;
     }
 }
 }

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -236,6 +236,9 @@ bool phi::vk::set_or_test_device_features(VkPhysicalDeviceFeatures2* arg, bool e
 
     VkPhysicalDeviceTimelineSemaphoreFeatures& p_next_chain_1 = *static_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(arg->pNext);
     CC_ASSERT(p_next_chain_1.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES && "pNext chain ordered unexpectedly");
+    CC_ASSERT(p_next_chain_1.pNext != nullptr && "pNext chain not long enough");
+    VkPhysicalDeviceDescriptorIndexingFeatures& p_next_chain_2 = *static_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(p_next_chain_1.pNext);
+    CC_ASSERT(p_next_chain_2.sType == VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES && "pNext chain ordered unexpectedly");
 
 #define PHI_VK_SET_OR_TEST_PROPERTY(_prop_, _prop_name_)                                                                           \
     if (test_mode)                                                                                                                 \
@@ -309,7 +312,14 @@ bool phi::vk::set_or_test_device_features(VkPhysicalDeviceFeatures2* arg, bool e
         PHI_VK_SET_OR_TEST(vertexPipelineStoresAndAtomics);
     }
 
+    // timeline semaphores (hard requirement for fence API)
     PHI_VK_SET_OR_TEST_PROPERTY(p_next_chain_1.timelineSemaphore, timelineSemaphore);
+
+    // dynamic descriptor indexing (required for empty shader view API / "bindless", currently hard requirement)
+    PHI_VK_SET_OR_TEST_PROPERTY(p_next_chain_2.shaderSampledImageArrayNonUniformIndexing, shaderSampledImageArrayNonUniformIndexing);
+    PHI_VK_SET_OR_TEST_PROPERTY(p_next_chain_2.runtimeDescriptorArray, runtimeDescriptorArray);
+    PHI_VK_SET_OR_TEST_PROPERTY(p_next_chain_2.descriptorBindingVariableDescriptorCount, descriptorBindingVariableDescriptorCount);
+    PHI_VK_SET_OR_TEST_PROPERTY(p_next_chain_2.descriptorBindingPartiallyBound, descriptorBindingPartiallyBound);
 
     return true;
 

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -197,8 +197,8 @@ cc::vector<phi::gpu_info> phi::vk::get_available_gpus(cc::span<const vulkan_gpu_
 
         auto& new_gpu = res.emplace_back();
         new_gpu.index = i;
-        new_gpu.vendor = get_gpu_vendor_from_id(ll_info.physical_device_props.vendorID);
-        new_gpu.description = cc::string(ll_info.physical_device_props.deviceName);
+        new_gpu.vendor = get_gpu_info_from_pcie_id(ll_info.physical_device_props.vendorID);
+        std::snprintf(new_gpu.name, sizeof(new_gpu.name), "%s", ll_info.physical_device_props.deviceName);
 
         // TODO: differentiate this somehow
         new_gpu.capabilities = ll_info.is_suitable ? gpu_capabilities::level_1 : gpu_capabilities::insufficient;
@@ -212,9 +212,13 @@ cc::vector<phi::gpu_info> phi::vk::get_available_gpus(cc::span<const vulkan_gpu_
             auto const& heap = ll_info.mem_props.memoryHeaps[i];
 
             if (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT && ll_info.physical_device_props.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+            {
                 new_gpu.dedicated_video_memory_bytes += heap.size;
+            }
             else
+            {
                 new_gpu.shared_system_memory_bytes += heap.size;
+            }
         }
     }
 

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
@@ -35,14 +35,20 @@ struct physical_device_feature_bundle
 {
     VkPhysicalDeviceFeatures2 features = {};
     VkPhysicalDeviceTimelineSemaphoreFeatures features_time_sem = {};
+    VkPhysicalDeviceDescriptorIndexingFeatures features_descriptor_indexing = {};
 
     physical_device_feature_bundle()
     {
         features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
         features.pNext = &features_time_sem;
         features_time_sem.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES;
+        features_time_sem.pNext = &features_descriptor_indexing;
+        features_descriptor_indexing.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
     }
     VkPhysicalDeviceFeatures2* get() { return &features; }
+
+    physical_device_feature_bundle(physical_device_feature_bundle const&) = delete;
+    physical_device_feature_bundle(physical_device_feature_bundle&&) = delete;
 };
 
 bool set_or_test_device_features(VkPhysicalDeviceFeatures2* arg, bool enable_gbv, bool test_mode, char const* gpu_name_for_logging = nullptr);

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
@@ -18,7 +18,7 @@ struct vulkan_gpu_info
     VkPhysicalDevice physical_device;
     VkPhysicalDeviceProperties physical_device_props;
     VkPhysicalDeviceMemoryProperties mem_props;
-    lay_ext_set available_layers_extensions;
+    layer_extension_set available_layers_extensions;
     suitable_queues queues;
 
     bool is_suitable = false;

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
@@ -45,7 +45,7 @@ struct physical_device_feature_bundle
     VkPhysicalDeviceFeatures2* get() { return &features; }
 };
 
-bool set_or_test_device_features(VkPhysicalDeviceFeatures2* arg, bool enable_gbv, bool test_mode);
+bool set_or_test_device_features(VkPhysicalDeviceFeatures2* arg, bool enable_gbv, bool test_mode, char const* gpu_name_for_logging = nullptr);
 
 /// receive all physical devices visible to the instance
 [[nodiscard]] cc::array<VkPhysicalDevice> get_physical_devices(VkInstance instance);

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -226,7 +226,10 @@ phi::vk::layer_extension_array phi::vk::get_used_instance_lay_ext(const phi::vk:
     return used_res;
 }
 
-phi::vk::layer_extension_array phi::vk::get_used_device_lay_ext(const phi::vk::layer_extension_set& available, const phi::backend_config& config, bool& has_raytracing, bool& has_conservative_raster)
+phi::vk::layer_extension_array phi::vk::get_used_device_lay_ext(const phi::vk::layer_extension_set& available,
+                                                                const phi::backend_config& config,
+                                                                bool& has_raytracing,
+                                                                bool& has_conservative_raster)
 {
     layer_extension_array used_res;
 

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -58,9 +58,9 @@ void phi::vk::write_device_extensions(cc::vector<VkExtensionProperties>& out_ext
     out_extensions.resize(res_count);
 }
 
-phi::vk::lay_ext_set phi::vk::get_available_instance_lay_ext()
+phi::vk::layer_extension_set phi::vk::get_available_instance_lay_ext()
 {
-    lay_ext_set available_res;
+    layer_extension_set available_res;
 
     // Add global instance layer's extensions
     {
@@ -104,9 +104,9 @@ phi::vk::lay_ext_set phi::vk::get_available_instance_lay_ext()
 }
 
 
-phi::vk::lay_ext_set phi::vk::get_available_device_lay_ext(VkPhysicalDevice physical)
+phi::vk::layer_extension_set phi::vk::get_available_device_lay_ext(VkPhysicalDevice physical)
 {
-    lay_ext_set available_res;
+    layer_extension_set available_res;
 
     cc::vector<layer_extension_bundle> layer_extensions;
 
@@ -150,9 +150,9 @@ phi::vk::lay_ext_set phi::vk::get_available_device_lay_ext(VkPhysicalDevice phys
 }
 
 
-phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext_set& available, const phi::backend_config& config)
+phi::vk::layer_extension_array phi::vk::get_used_instance_lay_ext(const phi::vk::layer_extension_set& available, const phi::backend_config& config)
 {
-    lay_ext_array used_res;
+    layer_extension_array used_res;
 
     auto const add_layer = [&](char const* layer_name) {
         if (available.layers.contains(layer_name))
@@ -226,9 +226,9 @@ phi::vk::lay_ext_array phi::vk::get_used_instance_lay_ext(const phi::vk::lay_ext
     return used_res;
 }
 
-phi::vk::lay_ext_array phi::vk::get_used_device_lay_ext(const phi::vk::lay_ext_set& available, const phi::backend_config& config, bool& has_raytracing, bool& has_conservative_raster)
+phi::vk::layer_extension_array phi::vk::get_used_device_lay_ext(const phi::vk::layer_extension_set& available, const phi::backend_config& config, bool& has_raytracing, bool& has_conservative_raster)
 {
-    lay_ext_array used_res;
+    layer_extension_array used_res;
 
     [[maybe_unused]] auto const f_add_layer = [&](char const* layer_name) {
         if (available.layers.contains(layer_name))

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
@@ -22,15 +22,13 @@ struct layer_extension_bundle
 void write_instance_extensions(cc::vector<VkExtensionProperties>& out_extensions, const char* layername);
 void write_device_extensions(cc::vector<VkExtensionProperties>& out_extensions, VkPhysicalDevice device, const char* layername);
 
-// TODO: Name
-struct lay_ext_set
+struct layer_extension_set
 {
     unique_name_set<vk_name_type::layer> layers;
     unique_name_set<vk_name_type::extension> extensions;
 };
 
-// TODO: Name
-struct lay_ext_array
+struct layer_extension_array
 {
     // These are char const* intentionally for Vulkan interop
     // Only add literals!
@@ -38,10 +36,10 @@ struct lay_ext_array
     cc::vector<char const*> extensions;
 };
 
-[[nodiscard]] lay_ext_set get_available_instance_lay_ext();
-[[nodiscard]] lay_ext_set get_available_device_lay_ext(VkPhysicalDevice physical);
+[[nodiscard]] layer_extension_set get_available_instance_lay_ext();
+[[nodiscard]] layer_extension_set get_available_device_lay_ext(VkPhysicalDevice physical);
 
-[[nodiscard]] lay_ext_array get_used_instance_lay_ext(lay_ext_set const& available, backend_config const& config);
-[[nodiscard]] lay_ext_array get_used_device_lay_ext(lay_ext_set const& available, backend_config const& config, bool& has_raytracing, bool& has_conservative_raster);
+[[nodiscard]] layer_extension_array get_used_instance_lay_ext(layer_extension_set const& available, backend_config const& config);
+[[nodiscard]] layer_extension_array get_used_device_lay_ext(layer_extension_set const& available, backend_config const& config, bool& has_raytracing, bool& has_conservative_raster);
 
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.cc
@@ -101,7 +101,7 @@ phi::handle::accel_struct phi::vk::AccelStructPool::createBottomLevelAS(cc::span
     as_create_info.info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV;
     as_create_info.info.pNext = nullptr;
     as_create_info.info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV;
-    as_create_info.info.flags = util::to_native_flags(flags);
+    as_create_info.info.flags = util::to_native_accel_struct_build_flags(flags);
     as_create_info.info.instanceCount = 0;
     as_create_info.info.geometryCount = uint32_t(element_geometries.size());
     as_create_info.info.pGeometries = element_geometries.data();

--- a/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/accel_struct_pool.hh
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/span.hh>
 #include <clean-core/vector.hh>
-#include <clean-core/atomic_linked_pool.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/types.hh>

--- a/src/phantasm-hardware-interface/vulkan/pools/cmd_list_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/cmd_list_pool.hh
@@ -7,7 +7,6 @@
 #include <clean-core/alloc_vector.hh>
 #include <clean-core/atomic_linked_pool.hh>
 
-#include <phantasm-hardware-interface/common/incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/vulkan/common/verify.hh>
 #include <phantasm-hardware-interface/vulkan/common/vk_incomplete_state_cache.hh>
 #include <phantasm-hardware-interface/vulkan/loader/volk.hh>
@@ -279,6 +278,7 @@ public:
                     int num_compute_lists_per_alloc,
                     int num_copy_allocs,
                     int num_copy_lists_per_alloc,
+                    int max_num_unique_transitions_per_cmdlist,
                     cc::span<CommandAllocatorsPerThread*> thread_allocators,
                     cc::allocator* static_alloc,
                     cc::allocator* dynamic_alloc);
@@ -288,15 +288,15 @@ private:
     // non-owning
     VkDevice mDevice;
 
-    /// the fence ringbuffer
+    // the fence ringbuffer
     FenceRingbuffer mFenceRing;
 
-    /// the linked pools per cmdlist type, managing handle association as well as additional
-    /// bookkeeping data structures
-    cmdlist_linked_pool_t mPoolDirect;
-    cmdlist_linked_pool_t mPoolCompute;
-    cmdlist_linked_pool_t mPoolCopy;
+    // the linked pool
     cmdlist_linked_pool_t mPool;
+
+    // flat memory for the state caches
+    int mNumStateCacheEntriesPerCmdlist;
+    cc::alloc_array<vk_incomplete_state_cache::cache_entry> mFlatStateCacheEntries;
 
     std::mutex mMutex;
 };

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
@@ -15,7 +15,8 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
                                                                        bool should_have_push_constants,
                                                                        phi::arg::graphics_shaders shader_stages,
                                                                        const phi::pipeline_config& primitive_config,
-                                                                       cc::allocator* scratch_alloc)
+                                                                       cc::allocator* scratch_alloc,
+                                                                       char const* dbg_name)
 {
     // Patch and reflect SPIR-V binaries
     cc::capped_vector<util::patched_spirv_stage, 6> patched_shader_stages;
@@ -76,6 +77,8 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
         new_node.raw_pipeline = create_pipeline(mDevice, dummy_render_pass, new_node.associated_pipeline_layout->raw_layout, patched_shader_stages,
                                                 primitive_config, vert_format_native, vertex_format.vertex_size_bytes, framebuffer_config);
 
+        util::set_object_name(mDevice, new_node.raw_pipeline, "phi graphics pso %s", dbg_name ? dbg_name : "");
+
         vkDestroyRenderPass(mDevice, dummy_render_pass, nullptr);
     }
 
@@ -85,7 +88,8 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
 phi::handle::pipeline_state phi::vk::PipelinePool::createComputePipelineState(phi::arg::shader_arg_shapes shader_arg_shapes,
                                                                               arg::shader_binary compute_shader,
                                                                               bool should_have_push_constants,
-                                                                              cc::allocator* scratch_alloc)
+                                                                              cc::allocator* scratch_alloc,
+                                                                              char const* dbg_name)
 {
     // Patch and reflect SPIR-V binary
     util::patched_spirv_stage patched_shader_stage;
@@ -123,6 +127,7 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createComputePipelineState(ph
 
 
     new_node.raw_pipeline = create_compute_pipeline(mDevice, new_node.associated_pipeline_layout->raw_layout, patched_shader_stage);
+    util::set_object_name(mDevice, new_node.raw_pipeline, "phi compute pso %s", dbg_name ? dbg_name : "");
 
     return {pool_index};
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
@@ -46,7 +46,8 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
 
     if (!!has_push_constants != !!should_have_push_constants)
     {
-        PHI_LOG_WARN("createPipelineState: Call {} root constants but SPIR-V reflection {}", should_have_push_constants ? "enables" : "disables", has_push_constants ? "finds push constants" : "finds none");
+        PHI_LOG_WARN("createPipelineState: Call {} root constants but SPIR-V reflection {}", should_have_push_constants ? "enables" : "disables",
+                     has_push_constants ? "finds push constants" : "finds none");
         CC_ASSERT(!!has_push_constants == !!should_have_push_constants && "Given root constant state inconsistent with SPIR-V reflection");
     }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
@@ -43,7 +43,12 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
     // In debug, calculate the amount of descriptors in the SPIR-V reflection and assert that the
     // amount declared in the shader arg shapes is the same
     CC_ASSERT(util::is_consistent_with_reflection(shader_descriptor_ranges, shader_arg_shapes) && "Given shader argument shapes inconsistent with SPIR-V reflection");
-    CC_ASSERT(has_push_constants == should_have_push_constants && "Shader push constant reflection inconsistent with creation argument");
+
+    if (!!has_push_constants != !!should_have_push_constants)
+    {
+        PHI_LOG_WARN("createPipelineState: Call {} root constants but SPIR-V reflection {}", should_have_push_constants ? "enables" : "disables", has_push_constants ? "finds push constants" : "finds none");
+        CC_ASSERT(!!has_push_constants == !!should_have_push_constants && "Given root constant state inconsistent with SPIR-V reflection");
+    }
 
 
     pipeline_layout* layout;

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.cc
@@ -75,7 +75,7 @@ phi::handle::pipeline_state phi::vk::PipelinePool::createPipelineState(phi::arg:
         VkRenderPass dummy_render_pass = create_render_pass(mDevice, framebuffer_config, primitive_config);
 
         new_node.raw_pipeline = create_pipeline(mDevice, dummy_render_pass, new_node.associated_pipeline_layout->raw_layout, patched_shader_stages,
-                                                primitive_config, vert_format_native, vertex_format.vertex_size_bytes, framebuffer_config);
+                                                primitive_config, vert_format_native, vertex_format.vertex_sizes_bytes, framebuffer_config);
 
         util::set_object_name(mDevice, new_node.raw_pipeline, "phi graphics pso %s", dbg_name ? dbg_name : "");
 

--- a/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/pipeline_pool.hh
@@ -29,12 +29,14 @@ public:
                                                              bool should_have_push_constants,
                                                              arg::graphics_shaders shader_stages,
                                                              phi::pipeline_config const& primitive_config,
-                                                             cc::allocator* scratch_alloc);
+                                                             cc::allocator* scratch_alloc,
+                                                             char const* dbg_name);
 
     [[nodiscard]] handle::pipeline_state createComputePipelineState(arg::shader_arg_shapes shader_arg_shapes,
                                                                     arg::shader_binary compute_shader,
                                                                     bool should_have_push_constants,
-                                                                    cc::allocator* scratch_alloc);
+                                                                    cc::allocator* scratch_alloc,
+                                                                    char const* dbg_name);
 
     [[nodiscard]] handle::pipeline_state createRaytracingPipelineState(cc::span<arg::raytracing_shader_library const> libraries,
                                                                        cc::span<arg::raytracing_argument_association const> arg_assocs,

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -5,6 +5,7 @@
 
 #include <typed-geometry/tg.hh>
 
+#include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/common/log.hh>
 
 #include <phantasm-hardware-interface/util.hh>
@@ -137,7 +138,7 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
     // Attachment bits so we can render to it
-    if (phi::is_depth_format(format))
+    if (phi::util::is_depth_format(format))
         image_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     else
         image_info.usage |= VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -152,7 +153,7 @@ phi::handle::resource phi::vk::ResourcePool::createRenderTarget(phi::format form
     VkImage res_image;
     PHI_VK_VERIFY_SUCCESS(vmaCreateImage(mAllocator, &image_info, &alloc_info, &res_image, &res_alloc, nullptr));
 
-    util::set_object_name(mDevice, res_image, "pool %s tgt %s (%ux%u, fmt %u)", phi::is_depth_format(format) ? "depth" : "render",
+    util::set_object_name(mDevice, res_image, "pool %s tgt %s (%ux%u, fmt %u)", phi::util::is_depth_format(format) ? "depth" : "render",
                           dbg_name ? dbg_name : "", w, h, unsigned(format));
 
     return acquireImage(res_alloc, res_image, format, image_info.mipLevels, image_info.arrayLayers, samples, w, h);

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -100,6 +100,7 @@ public:
     // Raw VkBuffer / VkImage access
     //
 
+    [[nodiscard]] VkBuffer getRawBufferOrNull(handle::resource res) const { return res.is_valid() ? internalGet(res).buffer.raw_buffer : nullptr; }
     [[nodiscard]] VkBuffer getRawBuffer(handle::resource res) const { return internalGet(res).buffer.raw_buffer; }
     [[nodiscard]] VkBuffer getRawBuffer(buffer_address addr) const { return internalGet(addr.buffer).buffer.raw_buffer; }
     [[nodiscard]] VkImage getRawImage(handle::resource res) const { return internalGet(res).image.raw_image; }

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -23,11 +23,7 @@ public:
     // frontend-facing API
 
     /// create a 1D, 2D or 3D texture, or a 1D/2D array
-    [[nodiscard]] handle::resource createTexture(
-        format format, unsigned w, unsigned h, unsigned mips, texture_dimension dim, unsigned depth_or_array_size, bool allow_uav, char const* dbg_name);
-
-    /// create a render- or depth-stencil target
-    [[nodiscard]] handle::resource createRenderTarget(format format, unsigned w, unsigned h, unsigned samples, unsigned array_size, char const* dbg_name);
+    handle::resource createTexture(arg::texture_description const& description, char const* dbg_name);
 
     /// create a buffer, with an element stride if its an index or vertex buffer
     [[nodiscard]] handle::resource createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name);

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.hh
@@ -105,6 +105,7 @@ public:
     //
 
     [[nodiscard]] VkBuffer getRawBuffer(handle::resource res) const { return internalGet(res).buffer.raw_buffer; }
+    [[nodiscard]] VkBuffer getRawBuffer(buffer_address addr) const { return internalGet(addr.buffer).buffer.raw_buffer; }
     [[nodiscard]] VkImage getRawImage(handle::resource res) const { return internalGet(res).image.raw_image; }
 
     [[nodiscard]] VkDeviceMemory getRawDeviceMemory(handle::resource res) const;
@@ -137,6 +138,13 @@ public:
 
         return internal.buffer.is_access_in_bounds(offset, size);
     }
+
+    bool isBufferAccessInBounds(buffer_address address, size_t size) const
+    {
+        return isBufferAccessInBounds(address.buffer, address.offset_bytes, size);
+    }
+
+    bool isBufferAccessInBounds(buffer_range range) const { return isBufferAccessInBounds(range.buffer, range.offset_bytes, range.size_bytes); }
 
     //
     // Master state access

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
@@ -177,6 +177,9 @@ phi::handle::shader_view phi::vk::ShaderViewPool::create(cc::span<resource_view 
 
 void phi::vk::ShaderViewPool::free(phi::handle::shader_view sv)
 {
+    if (!sv.is_valid())
+        return;
+
     shader_view_node& freed_node = mPool.get(sv._value);
     internalFree(freed_node);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
@@ -2,10 +2,10 @@
 
 #include <mutex>
 
+#include <clean-core/atomic_linked_pool.hh>
 #include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
 #include <clean-core/vector.hh>
-#include <clean-core/atomic_linked_pool.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/limits.hh>

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -177,9 +177,11 @@ bool phi::vk::SwapchainPool::present(phi::handle::swapchain handle)
     }
 }
 
-bool phi::vk::SwapchainPool::waitForBackbuffer(phi::handle::swapchain handle)
+bool phi::vk::SwapchainPool::acquireBackbuffer(phi::handle::swapchain handle)
 {
     auto& node = mPool.get(handle._value);
+    // according to NVidia, this can never block (despite having a timeout param)
+    // it thus doesn't sync anything at all
     auto const res = vkAcquireNextImageKHR(mDevice, node.swapchain, UINT64_MAX, node.backbuffers[node.active_fence_index].sem_image_available,
                                            nullptr, &node.active_image_index);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -1,5 +1,9 @@
 #include "swapchain_pool.hh"
 
+#ifdef PHI_HAS_OPTICK
+#include <optick/optick.h>
+#endif
+
 #include <clean-core/assert.hh>
 #include <clean-core/utility.hh>
 
@@ -145,6 +149,10 @@ bool phi::vk::SwapchainPool::present(phi::handle::swapchain handle)
 
         PHI_VK_VERIFY_SUCCESS(vkQueueSubmit(mPresentQueue, 1, &submit_info, active_backbuffer.fence_command_buf_executed));
     }
+
+#ifdef PHI_HAS_OPTICK
+    OPTICK_GPU_FLIP(node.swapchain);
+#endif
 
     // present proper
     {

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -211,8 +211,10 @@ void phi::vk::SwapchainPool::initialize(VkInstance instance, const phi::vk::Devi
     mInstance = instance;
     mDevice = device.getDevice();
     mPhysicalDevice = device.getPhysicalDevice();
-    mPresentQueue = config.present_from_compute_queue ? device.getRawQueue(queue_type::compute) : device.getRawQueue(queue_type::direct);
-    mPresentQueueFamilyIndex = config.present_from_compute_queue ? device.getQueueFamilyCompute() : device.getQueueFamilyDirect();
+
+    bool presentFromCompute = (config.native_features & phi::backend_config::native_feature_vk_present_from_compute) != 0;
+    mPresentQueue = presentFromCompute ? device.getRawQueue(queue_type::compute) : device.getRawQueue(queue_type::direct);
+    mPresentQueueFamilyIndex = presentFromCompute ? device.getQueueFamilyCompute() : device.getQueueFamilyDirect();
 
     mPool.initialize(config.max_num_swapchains, config.static_allocator);
 

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
@@ -21,7 +21,7 @@ public:
         // sync objects
         /// reset and signalled in ::performPresentSubmit, waited on (CPU) in ::present
         VkFence fence_command_buf_executed;
-        /// signalled in ::waitForBackbuffer, waited on (GPU) in ::performPresentSubmit
+        /// signalled in ::acquireBackbuffer, waited on (GPU) in ::performPresentSubmit
         VkSemaphore sem_image_available;
         /// signalled in ::performPresentSubmit, waited on (GPU) in ::present
         VkSemaphore sem_render_finished;
@@ -70,7 +70,7 @@ public:
 
     bool present(handle::swapchain handle);
 
-    bool waitForBackbuffer(handle::swapchain handle);
+    bool acquireBackbuffer(handle::swapchain handle);
 
     swapchain const& get(handle::swapchain handle) const { return mPool.get(handle._value); }
 

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <clean-core/capped_array.hh>
 #include <clean-core/atomic_linked_pool.hh>
+#include <clean-core/capped_array.hh>
 
 #include <phantasm-hardware-interface/fwd.hh>
 #include <phantasm-hardware-interface/types.hh>

--- a/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.hh
+++ b/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.hh
@@ -27,7 +27,7 @@ struct patched_shader_intermediates;
                                          cc::span<util::patched_spirv_stage const> shaders,
                                          phi::pipeline_config const& config,
                                          cc::span<VkVertexInputAttributeDescription const> vertex_attribs,
-                                         uint32_t vertex_size,
+                                         uint32_t vertex_sizes[limits::max_vertex_buffers],
                                          const arg::framebuffer_config& framebuf_config);
 
 [[nodiscard]] VkPipeline create_compute_pipeline(VkDevice device, VkPipelineLayout pipeline_layout, const util::patched_spirv_stage& compute_shader);


### PR DESCRIPTION
- Add common/enums_from_string.hh, for now supporting `primitive_topology`, `cull_mode`, and `depth_function`
- Fix D3D12 freeRange for shader views not skipping invalid handles
- Improve Vk output on mismatching root constant reflection
- Add instancing support 
    - new field `num_instances` in `cmd::draw`
- DLL Support
- New texture formats
- Improved D3D12 backbuffer acquire/present blocking behavior