### PR TITLE
Improved Vulkan startup, public description API, minor changes

### DIFF
--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -224,15 +224,22 @@ public:
     virtual void freeRange(cc::span<handle::accel_struct const> as) = 0;
 
     //
+    // Resource info interface
+    //
+
+    virtual arg::resource_description const& getResourceDescription(handle::resource res) const = 0;
+
+    virtual arg::texture_description const& getResourceTextureDescription(handle::resource res) const = 0;
+
+    virtual arg::buffer_description const& getResourceBufferDescription(handle::resource res) const = 0;
+
+    //
     // Debug interface
     //
 
     /// resets the debug name of a resource
     /// this is the name visible to diagnostic tools and referred to by validation warnings
     virtual void setDebugName(handle::resource res, cc::string_view name) = 0;
-
-    /// prints diagnostic information about the given resource
-    virtual void printInformation(handle::resource res) const = 0;
 
     /// attempts to detect graphics diagnostic tools (PIX, NSight, Renderdoc)
     /// and forces a capture start, returns true on success

--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -76,6 +76,10 @@ struct backend_config
 
         // Vulkan: present from the discrete compute queue (instead of the default direct queue)
         native_feature_vk_present_from_compute = 1 << 3,
+
+        // Vulkan: Enable the best practices validation layer (VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT)
+        // has proved to be of questionable reliability, requires at least validation_level::on
+        native_feature_vk_best_practices_layer = 1 << 4
     };
 
     /// native features to enable

--- a/src/phantasm-hardware-interface/d3d12/Adapter.hh
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.hh
@@ -16,14 +16,14 @@ public:
 
     bool isValid() const { return mAdapter != nullptr; }
 
-    IDXGIAdapter& getAdapter() const { return *mAdapter; }
+    IDXGIAdapter3& getAdapter() const { return *mAdapter; }
     IDXGIFactory4& getFactory() const { return *mFactory; }
 
     gpu_info const& getGPUInfo() const { return mGPUInfo; }
 
 private:
     gpu_info mGPUInfo;
-    IDXGIAdapter* mAdapter = nullptr;
+    IDXGIAdapter3* mAdapter = nullptr;
     IDXGIFactory4* mFactory = nullptr;
     IDXGIInfoQueue* mInfoQueue = nullptr;
 };

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -210,7 +210,7 @@ phi::handle::resource phi::d3d12::BackendD3D12::acquireBackbuffer(handle::swapch
     auto const swapchain_index = mPoolSwapchains.getSwapchainIndex(sc);
     auto const backbuffer_i = mPoolSwapchains.acquireBackbuffer(sc);
     auto const& backbuffer = mPoolSwapchains.get(sc).backbuffers[backbuffer_i];
-    return mPoolResources.injectBackbufferResource(swapchain_index, backbuffer.resource, backbuffer.state);
+    return mPoolResources.injectBackbufferResource(swapchain_index, getBackbufferSize(sc), backbuffer.resource, backbuffer.state);
 }
 
 void phi::d3d12::BackendD3D12::present(phi::handle::swapchain sc) { mPoolSwapchains.present(sc); }
@@ -233,7 +233,7 @@ phi::handle::resource phi::d3d12::BackendD3D12::createTexture(arg::texture_descr
 
 phi::handle::resource phi::d3d12::BackendD3D12::createBuffer(arg::buffer_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createBuffer(desc.size_bytes, desc.stride_bytes, desc.heap, desc.allow_uav, debug_name);
+    return mPoolResources.createBuffer(desc, debug_name);
 }
 
 std::byte* phi::d3d12::BackendD3D12::mapBuffer(phi::handle::resource res, int begin, int end) { return mPoolResources.mapBuffer(res, begin, end); }
@@ -247,7 +247,7 @@ void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::resource> r
 phi::handle::shader_view phi::d3d12::BackendD3D12::createShaderView(cc::span<const phi::resource_view> srvs,
                                                                     cc::span<const phi::resource_view> uavs,
                                                                     cc::span<const phi::sampler_config> samplers,
-                                                                    bool)
+                                                                    bool /*usage_compute*/)
 {
     return mPoolShaderViews.create(srvs, uavs, samplers);
 }
@@ -480,15 +480,24 @@ void phi::d3d12::BackendD3D12::freeRange(cc::span<const phi::handle::accel_struc
     mPoolAccelStructs.free(as);
 }
 
+phi::arg::resource_description const& phi::d3d12::BackendD3D12::getResourceDescription(handle::resource res) const
+{
+    return mPoolResources.getResourceDescription(res);
+}
+
+phi::arg::texture_description const& phi::d3d12::BackendD3D12::getResourceTextureDescription(handle::resource res) const
+{
+    return mPoolResources.getTextureDescription(res);
+}
+
+phi::arg::buffer_description const& phi::d3d12::BackendD3D12::getResourceBufferDescription(handle::resource res) const
+{
+    return mPoolResources.getBufferDescription(res);
+}
+
 void phi::d3d12::BackendD3D12::setDebugName(phi::handle::resource res, cc::string_view name)
 {
     mPoolResources.setDebugName(res, name.data(), uint32_t(name.length()));
-}
-
-void phi::d3d12::BackendD3D12::printInformation(phi::handle::resource res) const
-{
-    (void)res;
-    PHI_LOG << "printInformation unimplemented";
 }
 
 bool phi::d3d12::BackendD3D12::startForcedDiagnosticCapture() { return mDiagnostics.start_capture(); }

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -513,6 +513,19 @@ uint64_t phi::d3d12::BackendD3D12::getGPUTimestampFrequency() const
 
 bool phi::d3d12::BackendD3D12::isRaytracingEnabled() const { return mDevice.hasRaytracing(); }
 
+phi::vram_state_info phi::d3d12::BackendD3D12::nativeGetVRAMStateInfo()
+{
+    DXGI_QUERY_VIDEO_MEMORY_INFO nativeInfo = {};
+    PHI_D3D12_VERIFY(mAdapter.getAdapter().QueryVideoMemoryInfo(0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &nativeInfo));
+
+    vram_state_info res;
+    res.os_budget_bytes = nativeInfo.Budget;
+    res.current_usage_bytes = nativeInfo.CurrentUsage;
+    res.available_for_reservation_bytes = nativeInfo.AvailableForReservation;
+    res.current_reservation_bytes = nativeInfo.CurrentReservation;
+    return res;
+}
+
 phi::d3d12::BackendD3D12::per_thread_component& phi::d3d12::BackendD3D12::getCurrentThreadComponent()
 {
     auto const current_index = mThreadAssociation.get_current_index();

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -189,11 +189,18 @@ public:
     void freeRange(cc::span<handle::accel_struct const> as) override;
 
     //
+    // Resource info interface
+    //
+
+    arg::resource_description const& getResourceDescription(handle::resource res) const override;
+    arg::texture_description const& getResourceTextureDescription(handle::resource res) const override;
+    arg::buffer_description const& getResourceBufferDescription(handle::resource res) const override;
+
+    //
     // Debug interface
     //
 
     void setDebugName(handle::resource res, cc::string_view name) override;
-    void printInformation(handle::resource res) const override;
     bool startForcedDiagnosticCapture() override;
     bool endForcedDiagnosticCapture() override;
 

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -219,6 +219,8 @@ public:
 public:
     // non virtual - d3d12 specific
 
+    vram_state_info nativeGetVRAMStateInfo();
+
     ID3D12Device5* nativeGetDevice() { return mDevice.getDevice(); }
     ID3D12CommandQueue* nativeGetDirectQueue() { return mDirectQueue.command_queue; }
     ID3D12CommandQueue* nativeGetCopyQueue() { return mCopyQueue.command_queue; }

--- a/src/phantasm-hardware-interface/d3d12/common/d3d12_fwd.hh
+++ b/src/phantasm-hardware-interface/d3d12/common/d3d12_fwd.hh
@@ -24,6 +24,7 @@ struct ID3D12DeviceRemovedExtendedDataSettings;
 struct ID3D12StateObjectProperties;
 
 struct IDXGIAdapter;
+struct IDXGIAdapter3;
 struct IDXGIFactory4;
 struct IDXGISwapChain3;
 struct IDXGIInfoQueue;

--- a/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/resource_pool.cc
@@ -124,8 +124,7 @@ phi::handle::resource phi::d3d12::ResourcePool::injectBackbufferResource(unsigne
 
 
     arg::resource_description& storedDesc = mParallelResourceDescriptions[swapchain_index];
-    storedDesc.type = arg::resource_description::e_resource_texture;
-    storedDesc.texture(format::bgra8un, size);
+    storedDesc = arg::resource_description::texture(format::bgra8un, size);
 
     return {res_handle};
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.cc
@@ -94,7 +94,7 @@ phi::handle::swapchain phi::d3d12::SwapchainPool::createSwapchain(HWND window_ha
     new_node.mode = mode;
     new_node.has_resized = false;
     CC_ASSERT(num_backbuffers < 6 && "too many backbuffers configured");
-    new_node.backbuffers.emplace(num_backbuffers);
+    new_node.backbuffers.resize(num_backbuffers);
 
     // Create fences
     for (auto i = 0u; i < new_node.backbuffers.size(); ++i)

--- a/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/d3d12/pools/swapchain_pool.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <clean-core/atomic_linked_pool.hh>
-#include <clean-core/capped_array.hh>
+#include <clean-core/capped_vector.hh>
 
 #include <phantasm-hardware-interface/handles.hh>
 #include <phantasm-hardware-interface/types.hh>
@@ -30,7 +30,7 @@ public:
         int backbuf_height;
         present_mode mode;
         bool has_resized;
-        cc::capped_array<backbuffer, 6> backbuffers; // all backbuffers
+        cc::capped_vector<backbuffer, 6> backbuffers; // all backbuffers
         uint32_t last_acquired_backbuf_i = 0;
     };
 

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -255,7 +255,10 @@ enum class resource_view_dimension : uint8_t
     texture3d,
     texturecube,
     texturecube_array,
-    raytracing_accel_struct
+    raytracing_accel_struct,
+
+    MAX_DIMENSION_RANGE,
+    NUM_DIMENSIONS = MAX_DIMENSION_RANGE - 1
 };
 
 /// describes an element (either SRV or UAV) of a handle::shader_view
@@ -286,7 +289,8 @@ struct resource_view
         handle::accel_struct accel_struct;
     };
 
-    union {
+    union
+    {
         texture_info_t texture_info;
         buffer_info_t buffer_info;
         accel_struct_info_t accel_struct_info;

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -842,4 +842,13 @@ struct shader_table_strides
     uint32_t size_callable = 0;
     uint32_t stride_callable = 0;
 };
+
+struct vram_state_info
+{
+    // OS-provided VRAM budget in bytes, usage should stay below this
+    uint64_t os_budget_bytes = 0;
+    uint64_t current_usage_bytes = 0;
+    uint64_t available_for_reservation_bytes = 0;
+    uint64_t current_reservation_bytes = 0;
+};
 }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -289,7 +289,7 @@ phi::handle::resource phi::vk::BackendVulkan::createTexture(arg::texture_descrip
 
 phi::handle::resource phi::vk::BackendVulkan::createBuffer(arg::buffer_description const& desc, char const* debug_name)
 {
-    return mPoolResources.createBuffer(desc.size_bytes, desc.stride_bytes, desc.heap, desc.allow_uav, debug_name);
+    return mPoolResources.createBuffer(desc, debug_name);
 }
 
 std::byte* phi::vk::BackendVulkan::mapBuffer(phi::handle::resource res, int begin, int end) { return mPoolResources.mapBuffer(res, begin, end); }
@@ -572,32 +572,24 @@ void phi::vk::BackendVulkan::freeRange(cc::span<const phi::handle::accel_struct>
     mPoolAccelStructs.free(as);
 }
 
+phi::arg::resource_description const& phi::vk::BackendVulkan::getResourceDescription(handle::resource res) const
+{
+    return mPoolResources.getResourceDescription(res);
+}
+
+phi::arg::texture_description const& phi::vk::BackendVulkan::getResourceTextureDescription(handle::resource res) const
+{
+    return mPoolResources.getTextureDescription(res);
+}
+
+phi::arg::buffer_description const& phi::vk::BackendVulkan::getResourceBufferDescription(handle::resource res) const
+{
+    return mPoolResources.getBufferDescription(res);
+}
+
 void phi::vk::BackendVulkan::setDebugName(phi::handle::resource res, cc::string_view name)
 {
     mPoolResources.setDebugName(res, name.data(), uint32_t(name.length()));
-}
-
-void phi::vk::BackendVulkan::printInformation(phi::handle::resource res) const
-{
-    PHI_LOG << "Inspecting resource " << res._value;
-    if (!res.is_valid())
-        PHI_LOG << "  invalid (== handle::null_resource)";
-    else
-    {
-        if (mPoolResources.isImage(res))
-        {
-            auto const& info = mPoolResources.getImageInfo(res);
-            PHI_LOG << " image, raw pointer: " << info.raw_image;
-            PHI_LOG << " " << info.num_mips << " mips, " << info.num_array_layers << " array layers, format: " << uint32_t(info.pixel_format);
-        }
-        else
-        {
-            auto const& info = mPoolResources.getBufferInfo(res);
-            PHI_LOG << " buffer, raw pointer: " << info.raw_buffer;
-            PHI_LOG << " " << info.width << " width, " << info.stride << " stride";
-            PHI_LOG << " raw dynamic CBV descriptor set: " << info.raw_uniform_dynamic_ds;
-        }
-    }
 }
 
 bool phi::vk::BackendVulkan::startForcedDiagnosticCapture() { return mDiagnostics.start_capture(); }

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -183,12 +183,18 @@ public:
     void freeRange(cc::span<handle::accel_struct const> as) override;
 
     //
+    // Resource info interface
+    //
+
+    arg::resource_description const& getResourceDescription(handle::resource res) const override;
+    arg::texture_description const& getResourceTextureDescription(handle::resource res) const override;
+    arg::buffer_description const& getResourceBufferDescription(handle::resource res) const override;
+
+    //
     // Debug interface
     //
 
     void setDebugName(handle::resource res, cc::string_view name) override;
-
-    void printInformation(handle::resource res) const override;
 
     bool startForcedDiagnosticCapture() override;
 

--- a/src/phantasm-hardware-interface/vulkan/Device.cc
+++ b/src/phantasm-hardware-interface/vulkan/Device.cc
@@ -17,7 +17,7 @@ void phi::vk::Device::initialize(vulkan_gpu_info const& device, backend_config c
 
     mHasRaytracing = false;
     mHasConservativeRaster = false;
-    auto const active_lay_ext = get_used_device_lay_ext(device.available_layers_extensions, config, mHasRaytracing, mHasConservativeRaster);
+    auto const active_lay_ext = getUsedDeviceExtensions(device.available_layers_extensions, config, mHasRaytracing, mHasConservativeRaster);
 
     // chose queues
     mQueueIndices = get_chosen_queues(device.queues);

--- a/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
+++ b/src/phantasm-hardware-interface/vulkan/cmd_buf_translation.cc
@@ -139,7 +139,7 @@ void phi::vk::command_list_translator::execute(const phi::cmd::begin_render_pass
 
         if (rv != nullptr)
         {
-            auto const& img_info = _globals.pool_resources->getImageInfo(rv->resource);
+            auto const& img_info = _globals.pool_resources->getTextureDescription(rv->resource);
             num_fb_samples = img_info.num_samples;
             fb_size = phi::util::get_mip_size({img_info.width, img_info.height}, rv->texture_info.mip_start);
         }

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -59,7 +59,7 @@ phi::vk::vulkan_gpu_info phi::vk::get_vulkan_gpu_info(VkPhysicalDevice device)
         res.is_suitable = false;
     }
 
-    res.available_layers_extensions = get_available_device_lay_ext(device);
+    res.available_layers_extensions = getAvailableDeviceExtensions(device);
 
     // swapchain extensions
     if (!res.available_layers_extensions.extensions.contains(VK_KHR_SWAPCHAIN_EXTENSION_NAME))

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.hh
@@ -18,7 +18,7 @@ struct vulkan_gpu_info
     VkPhysicalDevice physical_device;
     VkPhysicalDeviceProperties physical_device_props;
     VkPhysicalDeviceMemoryProperties mem_props;
-    layer_extension_set available_layers_extensions;
+    LayerExtensionSet available_layers_extensions;
     suitable_queues queues;
 
     bool is_suitable = false;

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -253,22 +253,22 @@ phi::vk::layer_extension_array phi::vk::get_used_device_lay_ext(const phi::vk::l
 
     if (!f_add_ext(VK_KHR_SWAPCHAIN_EXTENSION_NAME))
     {
-        PHI_LOG_ERROR << "missing swapchain extension";
+        PHI_LOG_ERROR(R"(Fatal: Missing vulkan swapchain extension "{}")", VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     }
 
     if (!f_add_ext(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
     {
-        PHI_LOG_ERROR << "missing timeline semaphore extension, try updating GPU drivers";
+        PHI_LOG_ERROR(R"(Missing vulkan timeline semaphore extension "{}", try updating GPU drivers)", VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     }
 
-    // VK_KHR_relaxed_block_layout
-    // prevents debug layers from warning about non-std430 layouts,
-    // which occur ie. with the -fvk-use-dx-layout DXC flag
-    // spec: https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_relaxed_block_layout.html
-    if (!f_add_ext(VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME))
-    {
-        PHI_LOG_WARN("missing relaxed block layout extension");
-    }
+    // VK_KHR_relaxed_block_layout - core in Vk 1.1
+    // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_relaxed_block_layout.html
+    //// prevents debug layers from warning about non-std430 layouts,
+    //// which occur ie. with the -fvk-use-dx-layout DXC flag
+    // if (!f_add_ext(VK_KHR_RELAXED_BLOCK_LAYOUT_EXTENSION_NAME))
+    //{
+    //    PHI_LOG_WARN("missing relaxed block layout extension");
+    //}
 
     // additional extensions
     has_conservative_raster = false;
@@ -290,12 +290,17 @@ phi::vk::layer_extension_array phi::vk::get_used_device_lay_ext(const phi::vk::l
                 if (!f_add_ext(name))
                 {
                     all_dependencies_present = false;
-                    PHI_LOG_ERROR("missing raytracing extension dependency {}, try updating GPU drivers", name);
+                    PHI_LOG_ERROR(R"(missing raytracing extension dependency "{}", try updating GPU drivers)", name);
                 }
             };
 
-            // f_add_rt_dependency(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME); part of Vulkan 1.1
-            f_add_rt_dependency(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+            // VK_KHR_get_physical_device_properties2 - core in Vk 1.1
+            // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_get_physical_device_properties2.html
+            // f_add_rt_dependency(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+
+            // VK_KHR_get_memory_requirements2 - core in Vk 1.1
+            // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_get_memory_requirements2.html
+            // f_add_rt_dependency(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
 
             // extensions below are required for KHR, but not NV
             // f_add_rt_dependency(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.hh
@@ -10,25 +10,25 @@
 
 namespace phi::vk
 {
-struct layer_extension_bundle
+struct LayerExtensionBundle
 {
-    VkLayerProperties layer_properties;
-    cc::vector<VkExtensionProperties> extension_properties;
+    VkLayerProperties layerProperties;
+    cc::vector<VkExtensionProperties> extensionProperties;
 
-    layer_extension_bundle() { layer_properties = {}; }
-    layer_extension_bundle(VkLayerProperties layer_props) : layer_properties(layer_props) {}
+    LayerExtensionBundle() { layerProperties = {}; }
+    LayerExtensionBundle(VkLayerProperties layer_props) : layerProperties(layer_props) {}
 };
 
-void write_instance_extensions(cc::vector<VkExtensionProperties>& out_extensions, const char* layername);
-void write_device_extensions(cc::vector<VkExtensionProperties>& out_extensions, VkPhysicalDevice device, const char* layername);
+void writeInstanceExtensions(cc::vector<VkExtensionProperties>& out_extensions, const char* layername);
+void writeDeviceExtensions(cc::vector<VkExtensionProperties>& out_extensions, VkPhysicalDevice device, const char* layername);
 
-struct layer_extension_set
+struct LayerExtensionSet
 {
     unique_name_set<vk_name_type::layer> layers;
     unique_name_set<vk_name_type::extension> extensions;
 };
 
-struct layer_extension_array
+struct LayerExtensionArray
 {
     // These are char const* intentionally for Vulkan interop
     // Only add literals!
@@ -36,10 +36,10 @@ struct layer_extension_array
     cc::vector<char const*> extensions;
 };
 
-[[nodiscard]] layer_extension_set get_available_instance_lay_ext();
-[[nodiscard]] layer_extension_set get_available_device_lay_ext(VkPhysicalDevice physical);
+LayerExtensionSet getAvailableInstanceExtensions();
+LayerExtensionSet getAvailableDeviceExtensions(VkPhysicalDevice physical);
 
-[[nodiscard]] layer_extension_array get_used_instance_lay_ext(layer_extension_set const& available, backend_config const& config);
-[[nodiscard]] layer_extension_array get_used_device_lay_ext(layer_extension_set const& available, backend_config const& config, bool& has_raytracing, bool& has_conservative_raster);
+LayerExtensionArray getUsedInstanceExtensions(LayerExtensionSet const& available, backend_config const& config);
+LayerExtensionArray getUsedDeviceExtensions(LayerExtensionSet const& available, backend_config const& config, bool& outHasRaytracing, bool& outHasConservativeRaster);
 
 }

--- a/src/phantasm-hardware-interface/vulkan/loader/detail/volk.h
+++ b/src/phantasm-hardware-interface/vulkan/loader/detail/volk.h
@@ -14,6 +14,8 @@
 #	error To use volk, you need to define VK_NO_PROTOTYPES before including vulkan.h
 #endif
 
+#include <phantasm-hardware-interface/vulkan/loader/detail/platform_defines.hh>
+
 /* VOLK_GENERATE_VERSION_DEFINE */
 #define VOLK_HEADER_VERSION 135
 /* VOLK_GENERATE_VERSION_DEFINE */

--- a/src/phantasm-hardware-interface/vulkan/loader/volk.hh
+++ b/src/phantasm-hardware-interface/vulkan/loader/volk.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "detail/platform_defines.hh"
 #include "detail/volk.h"
 
 #ifndef VK_VERSION_1_2

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -360,8 +360,7 @@ phi::handle::resource phi::vk::ResourcePool::injectBackbufferResource(
     CC_ASSERT(backbuffer_node.master_state_dependency != VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM && "backbuffer in invalid resource state");
 
     arg::resource_description& storedDesc = mParallelResourceDescriptions[swapchain_index];
-    storedDesc.type = arg::resource_description::e_resource_texture;
-    storedDesc.texture(format::bgra8un, tg::isize2(width, height));
+    storedDesc = arg::resource_description::texture(format::bgra8un, tg::isize2(width, height));
 
     return {res_handle};
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/resource_pool.cc
@@ -126,16 +126,15 @@ phi::handle::resource phi::vk::ResourcePool::createTexture(arg::texture_descript
     PHI_VK_VERIFY_SUCCESS(vmaCreateImage(mAllocator, &image_info, &alloc_info, &res_image, &res_alloc, nullptr));
     util::set_object_name(mDevice, res_image, "phi tex%s[%u] %s (%ux%u, %u mips)", vk_get_tex_dim_literal(description.dim),
                           description.depth_or_array_size, dbg_name ? dbg_name : "", description.width, description.height, image_info.mipLevels);
-    return acquireImage(res_alloc, res_image, description.fmt, image_info.mipLevels, image_info.arrayLayers, description.num_samples,
-                        description.width, description.height);
+    return acquireImage(res_alloc, res_image, description, image_info.mipLevels);
 }
 
-phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, unsigned stride_bytes, resource_heap heap, bool allow_uav, char const* dbg_name)
+phi::handle::resource phi::vk::ResourcePool::createBuffer(arg::buffer_description const& desc, char const* dbg_name)
 {
-    CC_CONTRACT(size_bytes > 0);
+    CC_CONTRACT(desc.size_bytes > 0);
     VkBufferCreateInfo buffer_info = {};
     buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    buffer_info.size = size_bytes;
+    buffer_info.size = desc.size_bytes;
 
     // right now we'll just take all usages this thing might have in API semantics
     // it might be required down the line to restrict this (as in, make it part of API)
@@ -146,18 +145,17 @@ phi::handle::resource phi::vk::ResourcePool::createBuffer(uint64_t size_bytes, u
     // NOTE: we currently do not make use of allow_uav or the heap type to restrict usage flags at all
     // allow_uav might have been a poor API decision, we might need something more finegrained instead, and have the default be allowing everything
     // problem is, in d3d12 ALLOW_UNORDERED_ACCESS is exclusive with ALLOW_DEPTH_STENCIL, so defaulting right away is not possible
-    (void)allow_uav;
     // if (allow_uav || heap == resource_heap::upload) { ... }
 
     VmaAllocationCreateInfo alloc_info = {};
-    alloc_info.usage = vk_heap_to_vma(heap);
+    alloc_info.usage = vk_heap_to_vma(desc.heap);
 
     VmaAllocation res_alloc;
     VkBuffer res_buffer;
     PHI_VK_VERIFY_SUCCESS(vmaCreateBuffer(mAllocator, &buffer_info, &alloc_info, &res_buffer, &res_alloc, nullptr));
-    util::set_object_name(mDevice, res_buffer, "pool buf %s (%uB, %uB stride, %s heap)", dbg_name ? dbg_name : "", unsigned(size_bytes), stride_bytes,
-                          vk_get_heap_type_literal(heap));
-    return acquireBuffer(res_alloc, res_buffer, buffer_info.usage, size_bytes, stride_bytes, heap);
+    util::set_object_name(mDevice, res_buffer, "pool buf %s (%uB, %uB stride, %s heap)", dbg_name ? dbg_name : "", unsigned(desc.size_bytes),
+                          desc.stride_bytes, vk_get_heap_type_literal(desc.heap));
+    return acquireBuffer(res_alloc, res_buffer, buffer_info.usage, desc);
 }
 
 std::byte* phi::vk::ResourcePool::mapBuffer(phi::handle::resource res, int begin, int end)
@@ -230,7 +228,14 @@ phi::handle::resource phi::vk::ResourcePool::createBufferInternal(uint64_t size_
     VkBuffer res_buffer;
     PHI_VK_VERIFY_SUCCESS(vmaCreateBuffer(mAllocator, &buffer_info, &alloc_info, &res_buffer, &res_alloc, nullptr));
     util::set_object_name(mDevice, res_buffer, "%s", debug_name);
-    return acquireBuffer(res_alloc, res_buffer, buffer_info.usage, size_bytes, stride_bytes, heap);
+
+
+    arg::buffer_description bufferDesc;
+    bufferDesc.heap = heap;
+    bufferDesc.allow_uav = false;
+    bufferDesc.size_bytes = uint32_t(size_bytes);
+    bufferDesc.stride_bytes = stride_bytes;
+    return acquireBuffer(res_alloc, res_buffer, buffer_info.usage, bufferDesc);
 }
 
 void phi::vk::ResourcePool::free(phi::handle::resource res)
@@ -279,6 +284,8 @@ void phi::vk::ResourcePool::initialize(VkPhysicalDevice physical, VkDevice devic
     mAllocatorDescriptors.initialize(device, max_num_resources, 0, 0, 0);
     mPool.initialize(max_num_resources + max_num_swapchains, static_alloc); // additional resources for swapchain backbuffers
 
+    mParallelResourceDescriptions.reset(static_alloc, mPool.max_size());
+
     mNumReservedBackbuffers = max_num_swapchains;
     mInjectedBackbufferViews = cc::alloc_array<VkImageView>::filled(mNumReservedBackbuffers, nullptr, static_alloc);
     for (auto i = 0u; i < mNumReservedBackbuffers; ++i)
@@ -290,11 +297,6 @@ void phi::vk::ResourcePool::initialize(VkPhysicalDevice physical, VkDevice devic
         backbuffer_node.heap = resource_heap::gpu;
         backbuffer_node.image.raw_image = nullptr;
         backbuffer_node.image.pixel_format = format::bgra8un;
-        backbuffer_node.image.num_samples = 1;
-        backbuffer_node.image.num_mips = 1;
-        backbuffer_node.image.num_array_layers = 1;
-        backbuffer_node.image.width = 0;
-        backbuffer_node.image.height = 0;
     }
 
     mSingleCBVLayout = mAllocatorDescriptors.createSingleCBVLayout(false);
@@ -322,6 +324,9 @@ void phi::vk::ResourcePool::destroy()
         PHI_LOG("leaked {} handle::resource object{}", num_leaks, num_leaks == 1 ? "" : "s");
     }
 
+    mPool.destroy();
+    mParallelResourceDescriptions = {};
+
     vmaDestroyAllocator(mAllocator);
     mAllocator = nullptr;
 
@@ -347,8 +352,6 @@ phi::handle::resource phi::vk::ResourcePool::injectBackbufferResource(
 
     resource_node& backbuffer_node = mPool.get(res_handle);
     backbuffer_node.image.raw_image = raw_image;
-    backbuffer_node.image.width = width;
-    backbuffer_node.image.height = height;
     out_prev_state = backbuffer_node.master_state;
     backbuffer_node.master_state = state;
     backbuffer_node.master_state_dependency = util::to_pipeline_stage_dependency(state, VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM);
@@ -356,12 +359,16 @@ phi::handle::resource phi::vk::ResourcePool::injectBackbufferResource(
     // This enum value would only be returned if the state is a SRV/UAV/CBV, which is not allowed for backbuffers (in our API, not Vulkan)
     CC_ASSERT(backbuffer_node.master_state_dependency != VK_PIPELINE_STAGE_FLAG_BITS_MAX_ENUM && "backbuffer in invalid resource state");
 
+    arg::resource_description& storedDesc = mParallelResourceDescriptions[swapchain_index];
+    storedDesc.type = arg::resource_description::e_resource_texture;
+    storedDesc.texture(format::bgra8un, tg::isize2(width, height));
+
     return {res_handle};
 }
 
-phi::handle::resource phi::vk::ResourcePool::acquireBuffer(VmaAllocation alloc, VkBuffer buffer, VkBufferUsageFlags usage, uint64_t buffer_width, unsigned buffer_stride, resource_heap heap)
+phi::handle::resource phi::vk::ResourcePool::acquireBuffer(VmaAllocation alloc, VkBuffer buffer, VkBufferUsageFlags usage, arg::buffer_description const& desc)
 {
-    bool const create_cbv_desc = (buffer_width < 65536) && (usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    bool const create_cbv_desc = (desc.size_bytes < 65536) && (usage & VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     VkDescriptorSet cbv_desc_set = nullptr;
     VkDescriptorSet cbv_desc_set_compute = nullptr;
@@ -385,7 +392,7 @@ phi::handle::resource phi::vk::ResourcePool::acquireBuffer(VmaAllocation alloc, 
         VkDescriptorBufferInfo cbv_info = {};
         cbv_info.buffer = buffer;
         cbv_info.offset = 0;
-        cbv_info.range = buffer_stride > 0 ? buffer_stride : buffer_width; // strided CBV if present (for dynamic offset steps)
+        cbv_info.range = desc.stride_bytes > 0 ? desc.stride_bytes : desc.size_bytes; // strided CBV if present (for dynamic offset steps)
 
         cc::capped_vector<VkWriteDescriptorSet, 2> writes;
         {
@@ -412,21 +419,25 @@ phi::handle::resource phi::vk::ResourcePool::acquireBuffer(VmaAllocation alloc, 
     resource_node& new_node = mPool.get(res);
     new_node.allocation = alloc;
     new_node.type = resource_node::resource_type::buffer;
-    new_node.heap = heap;
+    new_node.heap = desc.heap;
     new_node.buffer.raw_buffer = buffer;
     new_node.buffer.raw_uniform_dynamic_ds = cbv_desc_set;
     new_node.buffer.raw_uniform_dynamic_ds_compute = cbv_desc_set_compute;
-    new_node.buffer.width = buffer_width;
-    new_node.buffer.stride = buffer_stride;
+    new_node.buffer.width = desc.size_bytes;
+    new_node.buffer.stride = desc.stride_bytes;
     new_node.buffer.num_vma_maps = 0;
 
     new_node.master_state = resource_state::undefined;
     new_node.master_state_dependency = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    return {static_cast<handle::handle_t>(res)};
+    uint32_t descriptionIndex = mPool.get_handle_index(res);
+    arg::resource_description& storedDesc = mParallelResourceDescriptions[descriptionIndex];
+    storedDesc.type = arg::resource_description::e_resource_buffer;
+    storedDesc.info_buffer = desc;
+
+    return {res};
 }
-phi::handle::resource phi::vk::ResourcePool::acquireImage(
-    VmaAllocation alloc, VkImage image, format pixel_format, unsigned num_mips, unsigned num_array_layers, unsigned num_samples, int width, int height)
+phi::handle::resource phi::vk::ResourcePool::acquireImage(VmaAllocation alloc, VkImage image, arg::texture_description const& desc, uint32_t realNumMips)
 {
     unsigned const res = mPool.acquire();
 
@@ -435,17 +446,18 @@ phi::handle::resource phi::vk::ResourcePool::acquireImage(
     new_node.type = resource_node::resource_type::image;
     new_node.heap = resource_heap::gpu;
     new_node.image.raw_image = image;
-    new_node.image.pixel_format = pixel_format;
-    new_node.image.num_mips = num_mips;
-    new_node.image.num_array_layers = num_array_layers;
-    new_node.image.num_samples = num_samples;
-    new_node.image.width = width;
-    new_node.image.height = height;
+    new_node.image.pixel_format = desc.fmt;
 
     new_node.master_state = resource_state::undefined;
     new_node.master_state_dependency = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
-    return {static_cast<handle::handle_t>(res)};
+    uint32_t descriptionIndex = mPool.get_handle_index(res);
+    arg::resource_description& storedDesc = mParallelResourceDescriptions[descriptionIndex];
+    storedDesc.type = arg::resource_description::e_resource_texture;
+    storedDesc.info_texture = desc;
+    storedDesc.info_texture.num_mips = realNumMips;
+
+    return {res};
 }
 
 void phi::vk::ResourcePool::internalFree(resource_node& node)

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
@@ -25,7 +25,7 @@ phi::handle::shader_view phi::vk::ShaderViewPool::create(cc::span<resource_view 
     // UAV:
     //      Texture* -> VK_DESCRIPTOR_TYPE_STORAGE_IMAGE
     //      Buffer   -> VK_DESCRIPTOR_TYPE_STORAGE_BUFFER
-    auto const layout = mAllocator.createLayoutFromShaderViewArgs(srvs, uavs, static_cast<unsigned>(sampler_configs.size()), usage_compute);
+    auto const layout = mAllocator.createLayoutFromShaderViewArgs(srvs, uavs, uint32_t(sampler_configs.size()), usage_compute);
 
     // Do acquires requiring synchronization
     VkDescriptorSet res_raw;

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.cc
@@ -65,7 +65,7 @@ phi::handle::swapchain phi::vk::SwapchainPool::createSwapchain(const window_hand
     }
 
     // Create synchronization primitives and assign dummy command buffers
-    new_node.backbuffers.emplace(num_backbuffers);
+    new_node.backbuffers.resize(num_backbuffers);
     for (auto i = 0u; i < new_node.backbuffers.size(); ++i)
     {
         auto& backbuffer = new_node.backbuffers[i];
@@ -327,13 +327,13 @@ void phi::vk::SwapchainPool::setupSwapchain(phi::handle::swapchain handle, int w
     }
 
     // Query backbuffer VkImages
-    cc::capped_array<VkImage, 6> backbuffer_images(node.backbuffers.size());
+    VkImage backbuffer_images[6];
     {
         uint32_t num_backbuffers;
         // This is redundant, but the validation layer warns if we don't do this
         vkGetSwapchainImagesKHR(mDevice, node.swapchain, &num_backbuffers, nullptr);
         CC_ASSERT(num_backbuffers == node.backbuffers.size());
-        vkGetSwapchainImagesKHR(mDevice, node.swapchain, &num_backbuffers, backbuffer_images.data());
+        vkGetSwapchainImagesKHR(mDevice, node.swapchain, &num_backbuffers, backbuffer_images);
     }
 
     // Set images, create RTVs and framebuffers

--- a/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/swapchain_pool.hh
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <clean-core/atomic_linked_pool.hh>
-#include <clean-core/capped_array.hh>
+#include <clean-core/capped_vector.hh>
 
 #include <phantasm-hardware-interface/fwd.hh>
 #include <phantasm-hardware-interface/types.hh>
@@ -48,7 +48,7 @@ public:
         bool has_resized;
         unsigned active_fence_index;
         unsigned active_image_index;
-        cc::capped_array<backbuffer, 6> backbuffers; ///< all backbuffers
+        cc::capped_vector<backbuffer, 6> backbuffers; ///< all backbuffers
     };
 
 public:

--- a/src/phantasm-hardware-interface/vulkan/queue_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/queue_util.cc
@@ -1,6 +1,6 @@
 #include "queue_util.hh"
 
-#include <clean-core/capped_array.hh>
+#include <clean-core/capped_vector.hh>
 
 #include "common/verify.hh"
 #include "surface_util.hh"
@@ -47,8 +47,8 @@ phi::vk::suitable_queues phi::vk::get_suitable_queues(VkPhysicalDevice physical)
 
 phi::vk::chosen_queues phi::vk::get_chosen_queues(const phi::vk::suitable_queues& suitable)
 {
-    cc::capped_array<int, 16> queue_occupancy;
-    queue_occupancy.emplace(suitable.families.size(), 0);
+    cc::capped_vector<int, 16> queue_occupancy;
+    queue_occupancy.resize(suitable.families.size(), 0);
 
     auto const f_acquire_queue_index = [&](unsigned family_index) -> int {
         auto const& fam = suitable.families[family_index];

--- a/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
+++ b/src/phantasm-hardware-interface/vulkan/render_pass_pipeline.cc
@@ -27,7 +27,7 @@ VkRenderPass phi::vk::create_render_pass(VkDevice device, arg::framebuffer_confi
 
         for (auto const& rt : framebuffer.render_targets)
         {
-            auto& desc = attachments.emplace_back();
+            VkAttachmentDescription& desc = attachments.emplace_back();
             desc = {};
             desc.format = util::to_vk_format(rt.fmt);
             desc.samples = sample_bits;
@@ -45,7 +45,7 @@ VkRenderPass phi::vk::create_render_pass(VkDevice device, arg::framebuffer_confi
 
         if (framebuffer.depth_target != format::none)
         {
-            auto& desc = attachments.emplace_back();
+            VkAttachmentDescription& desc = attachments.emplace_back();
             desc = {};
             desc.format = util::to_vk_format(framebuffer.depth_target);
             desc.samples = sample_bits;


### PR DESCRIPTION
### General 
- New public API to receive resource descriptions from `handle::resource`

### Vulkan
- No longer load two extensions that are already core in Vulkan 1.1
- Improved error / diagnostic messages for missing extensions or instance layers
- platform_defines.h include placement fixed
- Best practices layer is now an optional native feature

### D3D12
- Added VRAM state query method