### PR TITLE
Vulkan Bindless Implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,3 +57,6 @@ CommentPragmas: '!Api.*'
 
 # Includes
 IncludeBlocks: Preserve
+
+# Closing namespace comments
+FixNamespaceComments: true

--- a/src/phantasm-hardware-interface/Backend.hh
+++ b/src/phantasm-hardware-interface/Backend.hh
@@ -104,11 +104,15 @@ public:
                                                                bool usage_compute = false)
         = 0;
 
-    // WARNING: This API is subject to change (will have to get more verbose for Vulkan)
-    [[nodiscard]] virtual handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute = false) = 0;
+    /// create an empty shader view without specific resources written to it
+    [[nodiscard]] virtual handle::shader_view createEmptyShaderView(arg::shader_view_description const& desc, bool usage_compute = false) = 0;
 
+    /// write resources as contiguous SRVs to a shader view at a specified offset
+    /// SRVs are indexed flat, meaning descriptor arrays are treated as sequential regular descriptors
     virtual void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) = 0;
 
+    /// write resources as contiguous UAVs to a shader view at a specified offset
+    /// UAVs are indexed flat, meaning descriptor arrays are treated as sequential regular descriptors
     virtual void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs) = 0;
 
     virtual void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers) = 0;
@@ -314,4 +318,4 @@ public:
 protected:
     Backend() = default;
 };
-}
+} // namespace phi

--- a/src/phantasm-hardware-interface/arguments.hh
+++ b/src/phantasm-hardware-interface/arguments.hh
@@ -101,6 +101,46 @@ struct compute_pipeline_state_description
     bool has_root_constants = false;
 };
 
+/// the category of a SRV or UAV descriptor slot in a shader
+enum class descriptor_category
+{
+    NONE = 0,
+
+    // HLSL: [RW]Texture1D/2D/3D/Cube[MS][Array]
+    texture,
+
+    // HLSL: [RW][Append][ByteAddress/Structured]Buffer
+    buffer,
+
+    // HLSL: RaytracingAccelerationStructure
+    raytracing_accel_struct,
+};
+
+/// properties of a single descriptor or descriptor array in a shader view
+struct descriptor_entry
+{
+    descriptor_category category = descriptor_category::NONE;
+    uint32_t array_size = 0;
+};
+
+/// describes the shape of a shader view
+/// used in createEmptyShaderView
+struct shader_view_description
+{
+    /// total amount of SRVs in the shader view
+    uint32_t num_srvs = 0;
+    /// properties of the SRV descriptors (in order) [optional in D3D12]
+    cc::span<descriptor_entry const> srv_entries = {};
+
+    /// total amount of UAVs in the shader view
+    uint32_t num_uavs = 0;
+    /// properties of the UAV descriptors (in order) [optional in D3D12]
+    cc::span<descriptor_entry const> uav_entries = {};
+
+    /// total amount of samplers in the shader view
+    uint32_t num_samplers = 0;
+};
+
 /// an element in a bottom-level acceleration strucutre
 struct blas_element
 {
@@ -305,7 +345,8 @@ struct resource_description
 
     e_resource_type type = e_resource_undefined;
 
-    union {
+    union
+    {
         texture_description info_texture;
         buffer_description info_buffer;
     };
@@ -349,4 +390,4 @@ public:
         return create(buffer_description::create(size_bytes, stride_bytes, heap, allow_uav));
     }
 };
-}
+} // namespace phi::arg

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -28,7 +28,7 @@ struct BackendD3D12::per_thread_component
     command_list_translator translator;
     CommandAllocatorsPerThread cmd_list_allocator;
 };
-}
+} // namespace phi::d3d12
 
 void phi::d3d12::BackendD3D12::initialize(const phi::backend_config& config)
 {
@@ -252,9 +252,9 @@ phi::handle::shader_view phi::d3d12::BackendD3D12::createShaderView(cc::span<con
     return mPoolShaderViews.create(srvs, uavs, samplers);
 }
 
-phi::handle::shader_view phi::d3d12::BackendD3D12::createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool /*usage_compute*/)
+phi::handle::shader_view phi::d3d12::BackendD3D12::createEmptyShaderView(arg::shader_view_description const& desc, bool /*usage_compute*/)
 {
-    return mPoolShaderViews.createEmpty(num_srvs_uavs, num_samplers);
+    return mPoolShaderViews.createEmpty(desc.num_srvs + desc.num_uavs, desc.num_samplers);
 }
 
 void phi::d3d12::BackendD3D12::writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs)

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.hh
@@ -87,7 +87,7 @@ public:
                                                        cc::span<sampler_config const> samplers,
                                                        bool usage_compute) override;
 
-    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute) override;
+    [[nodiscard]] handle::shader_view createEmptyShaderView(arg::shader_view_description const& desc, bool usage_compute) override;
 
     void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) override;
 

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -8,7 +8,7 @@
 #include "accel_struct_pool.hh"
 #include "resource_pool.hh"
 
-void phi::d3d12::DescriptorPageAllocator::initialize(ID3D12Device& device, D3D12_DESCRIPTOR_HEAP_TYPE type, unsigned num_descriptors, unsigned page_size, cc::allocator* static_alloc)
+void phi::d3d12::DescriptorPageAllocator::initialize(ID3D12Device& device, D3D12_DESCRIPTOR_HEAP_TYPE type, uint32_t num_descriptors, uint32_t page_size, cc::allocator* static_alloc)
 {
     mPageAllocator.initialize(num_descriptors, page_size, static_alloc);
     mDescriptorSize = device.GetDescriptorHandleIncrementSize(type);
@@ -49,6 +49,7 @@ phi::handle::shader_view phi::d3d12::ShaderViewPool::createEmpty(uint32_t num_sr
     auto const pool_index = mPool.acquire();
 
     auto& new_node = mPool.get(pool_index);
+    new_node = {};
     new_node.sampler_alloc_handle = sampler_alloc;
     new_node.srv_uav_alloc_handle = srv_uav_alloc;
 
@@ -56,18 +57,10 @@ phi::handle::shader_view phi::d3d12::ShaderViewPool::createEmpty(uint32_t num_sr
     {
         new_node.srv_uav_handle = mSRVUAVAllocator.getGPUStart(srv_uav_alloc);
     }
-    else
-    {
-        new_node.srv_uav_handle = {};
-    }
 
     if (sampler_alloc != -1)
     {
         new_node.sampler_handle = mSamplerAllocator.getGPUStart(sampler_alloc);
-    }
-    else
-    {
-        new_node.sampler_handle = {};
     }
 
     return {pool_index};
@@ -121,12 +114,15 @@ void phi::d3d12::ShaderViewPool::writeShaderViewSRVs(handle::shader_view sv, uin
     auto const& node = internalGet(sv);
     CC_ASSERT(node.srv_uav_alloc_handle != -1 && "writing resource view to shader_view without SRV/UAV slots");
 
-    auto const srv_uav_cpu_base = mSRVUAVAllocator.getCPUStart(node.srv_uav_alloc_handle);
+    auto const descriptorBase = mSRVUAVAllocator.getCPUStart(node.srv_uav_alloc_handle);
+
+    uint32_t maxNumDescriptors = mSRVUAVAllocator.getNumDescriptorsInAllocation(node.srv_uav_alloc_handle);
+    CC_ASSERT(srvs.size() + offset <= maxNumDescriptors && "writeShaderViewSRVs: write OOB");
 
     for (auto i = 0u; i < srvs.size(); ++i)
     {
-        auto const cpu_handle = mSRVUAVAllocator.incrementToIndex(srv_uav_cpu_base, offset + i);
-        writeSRV(cpu_handle, srvs[i]);
+        auto const cpuHandle = mSRVUAVAllocator.incrementToIndex(descriptorBase, offset + i);
+        writeSRV(cpuHandle, srvs[i]);
     }
 }
 
@@ -134,13 +130,16 @@ void phi::d3d12::ShaderViewPool::writeShaderViewUAVs(handle::shader_view sv, uin
 {
     auto const& node = internalGet(sv);
     CC_ASSERT(node.srv_uav_alloc_handle != -1 && "writing resource view to shader_view without SRV/UAV slots");
+    uint32_t maxNumDescriptors = mSRVUAVAllocator.getNumDescriptorsInAllocation(node.srv_uav_alloc_handle);
+    CC_ASSERT(uavs.size() + offset <= maxNumDescriptors && "writeShaderViewUAVs: write OOB");
 
-    auto const srv_uav_cpu_base = mSRVUAVAllocator.getCPUStart(node.srv_uav_alloc_handle);
+    auto const descriptorBase = mSRVUAVAllocator.getCPUStart(node.srv_uav_alloc_handle);
+
 
     for (auto i = 0u; i < uavs.size(); ++i)
     {
-        auto const cpu_handle = mSRVUAVAllocator.incrementToIndex(srv_uav_cpu_base, offset + i);
-        writeUAV(cpu_handle, uavs[i]);
+        auto const cpuHandle = mSRVUAVAllocator.incrementToIndex(descriptorBase, offset + i);
+        writeUAV(cpuHandle, uavs[i]);
     }
 }
 
@@ -148,6 +147,8 @@ void phi::d3d12::ShaderViewPool::writeShaderViewSamplers(handle::shader_view sv,
 {
     auto const& node = internalGet(sv);
     CC_ASSERT(node.sampler_alloc_handle != -1 && "writing resource view to shader_view without SRV/UAV slots");
+    uint32_t maxNumDescriptors = mSamplerAllocator.getNumDescriptorsInAllocation(node.srv_uav_alloc_handle);
+    CC_ASSERT(samplers.size() + offset <= maxNumDescriptors && "writeShaderViewSamplers: write OOB");
 
     auto const sampler_base = mSamplerAllocator.getCPUStart(node.sampler_alloc_handle);
 
@@ -160,13 +161,13 @@ void phi::d3d12::ShaderViewPool::writeShaderViewSamplers(handle::shader_view sv,
 
 void phi::d3d12::ShaderViewPool::free(phi::handle::shader_view sv)
 {
-    auto& data = mPool.get(unsigned(sv._value));
+    auto& data = mPool.get(uint32_t(sv._value));
     {
         auto lg = std::lock_guard(mMutex);
         mSRVUAVAllocator.free(data.srv_uav_alloc_handle);
         mSamplerAllocator.free(data.sampler_alloc_handle);
     }
-    mPool.release(unsigned(sv._value));
+    mPool.release(uint32_t(sv._value));
 }
 
 void phi::d3d12::ShaderViewPool::free(cc::span<const phi::handle::shader_view> svs)
@@ -177,19 +178,19 @@ void phi::d3d12::ShaderViewPool::free(cc::span<const phi::handle::shader_view> s
         if (!sv.is_valid())
             continue;
 
-        auto& data = mPool.get(unsigned(sv._value));
+        auto& data = mPool.get(uint32_t(sv._value));
         mSRVUAVAllocator.free(data.srv_uav_alloc_handle);
         mSamplerAllocator.free(data.sampler_alloc_handle);
-        mPool.release(unsigned(sv._value));
+        mPool.release(uint32_t(sv._value));
     }
 }
 
 void phi::d3d12::ShaderViewPool::initialize(ID3D12Device* device,
                                             phi::d3d12::ResourcePool* res_pool,
                                             phi::d3d12::AccelStructPool* as_pool,
-                                            unsigned num_shader_views,
-                                            unsigned num_srvs_uavs,
-                                            unsigned num_samplers,
+                                            uint32_t num_shader_views,
+                                            uint32_t num_srvs_uavs,
+                                            uint32_t num_samplers,
                                             cc::allocator* static_alloc)
 {
     CC_ASSERT(mDevice == nullptr && "double init");
@@ -212,7 +213,8 @@ void phi::d3d12::ShaderViewPool::writeSRV(D3D12_CPU_DESCRIPTOR_HANDLE handle, re
 {
     // the GPU VA if this is an accel struct
     D3D12_GPU_VIRTUAL_ADDRESS accelstruct_va = UINT64(-1);
-    if (srv.dimension == resource_view_dimension::raytracing_accel_struct)
+    bool const isAccelStruct = srv.dimension == resource_view_dimension::raytracing_accel_struct;
+    if (isAccelStruct)
     {
         accelstruct_va = mAccelStructPool->getNode(srv.accel_struct_info.accel_struct).buffer_as_va;
     }
@@ -220,8 +222,7 @@ void phi::d3d12::ShaderViewPool::writeSRV(D3D12_CPU_DESCRIPTOR_HANDLE handle, re
     auto const srv_desc = util::create_srv_desc(srv, accelstruct_va);
 
     // the raw resource, or none if this is an accel struct
-    ID3D12Resource* const raw_resource
-        = srv.dimension == resource_view_dimension::raytracing_accel_struct ? nullptr : mResourcePool->getRawResource(srv.resource);
+    ID3D12Resource* const raw_resource = isAccelStruct ? nullptr : mResourcePool->getRawResource(srv.resource);
 
     mDevice->CreateShaderResourceView(raw_resource, &srv_desc, handle);
 }

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -147,7 +147,7 @@ void phi::d3d12::ShaderViewPool::writeShaderViewSamplers(handle::shader_view sv,
 {
     auto const& node = internalGet(sv);
     CC_ASSERT(node.sampler_alloc_handle != -1 && "writing resource view to shader_view without SRV/UAV slots");
-    uint32_t maxNumDescriptors = mSamplerAllocator.getNumDescriptorsInAllocation(node.srv_uav_alloc_handle);
+    uint32_t maxNumDescriptors = mSamplerAllocator.getNumDescriptorsInAllocation(node.sampler_alloc_handle);
     CC_ASSERT(samplers.size() + offset <= maxNumDescriptors && "writeShaderViewSamplers: write OOB");
 
     auto const sampler_base = mSamplerAllocator.getCPUStart(node.sampler_alloc_handle);

--- a/src/phantasm-hardware-interface/fwd.hh
+++ b/src/phantasm-hardware-interface/fwd.hh
@@ -69,7 +69,7 @@ enum class accel_struct_build_flags : uint8_t;
 // helpers
 struct command_stream_parser;
 struct command_stream_writer;
-}
+} // namespace phi
 
 namespace phi::arg
 {
@@ -81,6 +81,7 @@ struct shader_binary;
 struct graphics_shader;
 struct graphics_pipeline_state_description;
 struct compute_pipeline_state_description;
+struct shader_view_description;
 
 using shader_arg_shapes = cc::span<shader_arg_shape const>;
 using graphics_shaders = cc::span<graphics_shader const>;
@@ -99,4 +100,4 @@ struct texture_description;
 struct buffer_description;
 struct resource_description;
 
-}
+} // namespace phi::arg

--- a/src/phantasm-hardware-interface/types.hh
+++ b/src/phantasm-hardware-interface/types.hh
@@ -264,9 +264,9 @@ enum class resource_view_dimension : uint8_t
 /// describes an element (either SRV or UAV) of a handle::shader_view
 struct resource_view
 {
-    handle::resource resource;
+    handle::resource resource = handle::null_resource;
 
-    resource_view_dimension dimension;
+    resource_view_dimension dimension = resource_view_dimension::none;
 
     struct texture_info_t
     {
@@ -851,4 +851,4 @@ struct vram_state_info
     uint64_t available_for_reservation_bytes = 0;
     uint64_t current_reservation_bytes = 0;
 };
-}
+} // namespace phi

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.hh
@@ -85,7 +85,7 @@ public:
                                                        cc::span<sampler_config const> samplers,
                                                        bool usage_compute) override;
 
-    [[nodiscard]] handle::shader_view createEmptyShaderView(uint32_t num_srvs_uavs, uint32_t num_samplers, bool usage_compute) override;
+    [[nodiscard]] handle::shader_view createEmptyShaderView(arg::shader_view_description const& desc, bool usage_compute) override;
 
     void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs) override;
 
@@ -223,6 +223,9 @@ private:
 
     struct per_thread_component;
     per_thread_component& getCurrentThreadComponent();
+
+    cc::allocator* getCurrentScratchAlloc();
+    void resetCurrentScratchAlloc();
 
 private:
     gpu_info mGPUInfo;

--- a/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
@@ -9,7 +9,7 @@
 
 namespace phi::vk::util
 {
-[[nodiscard]] constexpr VkAccessFlags to_access_flags(resource_state state)
+constexpr VkAccessFlags to_access_flags(resource_state state)
 {
     using rs = resource_state;
     switch (state)
@@ -63,7 +63,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] constexpr VkImageLayout to_image_layout(resource_state state)
+constexpr VkImageLayout to_image_layout(resource_state state)
 {
     using rs = resource_state;
     switch (state)
@@ -111,7 +111,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_flags(phi::shader_stage stage)
+constexpr VkPipelineStageFlags to_pipeline_stage_flags(phi::shader_stage stage)
 {
     switch (stage)
     {
@@ -146,7 +146,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(stage);
 }
 
-[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_flags_bitwise(phi::shader_stage_flags_t stage_flags)
+constexpr VkPipelineStageFlags to_pipeline_stage_flags_bitwise(phi::shader_stage_flags_t stage_flags)
 {
     VkPipelineStageFlags res = 0;
 
@@ -176,7 +176,7 @@ namespace phi::vk::util
     return res;
 }
 
-[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, VkPipelineStageFlags shader_flags)
+constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, VkPipelineStageFlags shader_flags)
 {
     using rs = resource_state;
     switch (state)
@@ -226,12 +226,12 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(state);
 }
 
-[[nodiscard]] constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, shader_stage stage = shader_stage::pixel)
+constexpr VkPipelineStageFlags to_pipeline_stage_dependency(resource_state state, shader_stage stage = shader_stage::pixel)
 {
     return to_pipeline_stage_dependency(state, to_pipeline_stage_flags(stage));
 }
 
-[[nodiscard]] constexpr VkPrimitiveTopology to_native(phi::primitive_topology topology)
+constexpr VkPrimitiveTopology to_native(phi::primitive_topology topology)
 {
     switch (topology)
     {
@@ -248,7 +248,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(topology);
 }
 
-[[nodiscard]] constexpr VkCompareOp to_native(phi::depth_function depth_func)
+constexpr VkCompareOp to_native(phi::depth_function depth_func)
 {
     switch (depth_func)
     {
@@ -275,7 +275,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(depth_func);
 }
 
-[[nodiscard]] constexpr VkCullModeFlags to_native(phi::cull_mode cull_mode)
+constexpr VkCullModeFlags to_native(phi::cull_mode cull_mode)
 {
     switch (cull_mode)
     {
@@ -291,7 +291,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] constexpr VkShaderStageFlagBits to_shader_stage_flags(phi::shader_stage stage)
+constexpr VkShaderStageFlagBits to_shader_stage_flags(phi::shader_stage stage)
 {
     switch (stage)
     {
@@ -332,7 +332,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] constexpr VkDescriptorType to_native_srv_desc_type(resource_view_dimension sv_dim)
+constexpr VkDescriptorType to_native_srv_desc_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -357,7 +357,43 @@ namespace phi::vk::util
 
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
-[[nodiscard]] constexpr VkDescriptorType to_native_uav_desc_type(resource_view_dimension sv_dim)
+
+constexpr VkDescriptorType to_native_srv_desc_type(arg::descriptor_category desc_cat)
+{
+    switch (desc_cat)
+    {
+    case arg::descriptor_category::buffer:
+        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    case arg::descriptor_category::raytracing_accel_struct:
+        return VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
+    case arg::descriptor_category::texture:
+        return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+
+    case arg::descriptor_category::NONE:
+        return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    }
+
+    CC_UNREACHABLE_SWITCH_WORKAROUND(desc_cat);
+}
+
+constexpr VkDescriptorType to_native_uav_desc_type(arg::descriptor_category desc_cat)
+{
+    switch (desc_cat)
+    {
+    case arg::descriptor_category::buffer:
+        return VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    case arg::descriptor_category::texture:
+        return VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+
+    case arg::descriptor_category::raytracing_accel_struct:
+    case arg::descriptor_category::NONE:
+        return VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    }
+
+    CC_UNREACHABLE_SWITCH_WORKAROUND(desc_cat);
+}
+
+constexpr VkDescriptorType to_native_uav_desc_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -382,12 +418,9 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
 
-[[nodiscard]] constexpr bool is_valid_as_uav_desc_type(resource_view_dimension sv_dim)
-{
-    return to_native_uav_desc_type(sv_dim) != VK_DESCRIPTOR_TYPE_MAX_ENUM;
-}
+constexpr bool is_valid_as_uav_desc_type(resource_view_dimension sv_dim) { return to_native_uav_desc_type(sv_dim) != VK_DESCRIPTOR_TYPE_MAX_ENUM; }
 
-[[nodiscard]] constexpr VkImageViewType to_native_image_view_type(resource_view_dimension sv_dim)
+constexpr VkImageViewType to_native_image_view_type(resource_view_dimension sv_dim)
 {
     switch (sv_dim)
     {
@@ -418,7 +451,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(sv_dim);
 }
 
-[[nodiscard]] constexpr VkImageAspectFlags to_native_image_aspect(format fmt)
+constexpr VkImageAspectFlags to_native_image_aspect(format fmt)
 {
     if (phi::util::is_view_format(fmt))
     {
@@ -447,7 +480,7 @@ namespace phi::vk::util
 }
 
 
-[[nodiscard]] constexpr VkFilter to_min_filter(sampler_filter filter)
+constexpr VkFilter to_min_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -467,7 +500,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] constexpr VkFilter to_mag_filter(sampler_filter filter)
+constexpr VkFilter to_mag_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -487,7 +520,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] constexpr VkSamplerMipmapMode to_mipmap_filter(sampler_filter filter)
+constexpr VkSamplerMipmapMode to_mipmap_filter(sampler_filter filter)
 {
     switch (filter)
     {
@@ -507,7 +540,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(filter);
 }
 
-[[nodiscard]] constexpr VkSamplerAddressMode to_native(sampler_address_mode mode)
+constexpr VkSamplerAddressMode to_native(sampler_address_mode mode)
 {
     switch (mode)
     {
@@ -524,7 +557,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(mode);
 }
 
-[[nodiscard]] constexpr VkCompareOp to_native(sampler_compare_func mode)
+constexpr VkCompareOp to_native(sampler_compare_func mode)
 {
     switch (mode)
     {
@@ -550,7 +583,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(mode);
 }
 
-[[nodiscard]] constexpr VkBorderColor to_native(sampler_border_color color)
+constexpr VkBorderColor to_native(sampler_border_color color)
 {
     switch (color)
     {
@@ -571,7 +604,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(color);
 }
 
-[[nodiscard]] constexpr VkSampleCountFlagBits to_native_sample_flags(unsigned num_samples)
+constexpr VkSampleCountFlagBits to_native_sample_flags(unsigned num_samples)
 {
     switch (num_samples)
     {
@@ -594,7 +627,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(num_samples);
 }
 
-[[nodiscard]] constexpr VkAttachmentLoadOp to_native(rt_clear_type clear_type)
+constexpr VkAttachmentLoadOp to_native(rt_clear_type clear_type)
 {
     switch (clear_type)
     {
@@ -609,7 +642,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(clear_type);
 }
 
-[[nodiscard]] constexpr VkImageType to_native(texture_dimension dim)
+constexpr VkImageType to_native(texture_dimension dim)
 {
     switch (dim)
     {
@@ -624,7 +657,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(dim);
 }
 
-[[nodiscard]] constexpr VkLogicOp to_native(blend_logic_op op)
+constexpr VkLogicOp to_native(blend_logic_op op)
 {
     switch (op)
     {
@@ -665,7 +698,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(op);
 }
 
-[[nodiscard]] constexpr VkBlendOp to_native(blend_op op)
+constexpr VkBlendOp to_native(blend_op op)
 {
     switch (op)
     {
@@ -684,7 +717,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(op);
 }
 
-[[nodiscard]] constexpr VkBlendFactor to_native(blend_factor bf)
+constexpr VkBlendFactor to_native(blend_factor bf)
 {
     switch (bf)
     {
@@ -713,7 +746,7 @@ namespace phi::vk::util
     CC_UNREACHABLE_SWITCH_WORKAROUND(bf);
 }
 
-[[nodiscard]] constexpr VkBuildAccelerationStructureFlagsNV to_native_accel_struct_build_flags(accel_struct_build_flags_t flags)
+constexpr VkBuildAccelerationStructureFlagsNV to_native_accel_struct_build_flags(accel_struct_build_flags_t flags)
 {
     VkBuildAccelerationStructureFlagsNV res = 0;
 
@@ -730,4 +763,4 @@ namespace phi::vk::util
 
     return res;
 }
-}
+} // namespace phi::vk::util

--- a/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/layer_extension_util.cc
@@ -273,10 +273,11 @@ phi::vk::LayerExtensionArray phi::vk::getUsedDeviceExtensions(const phi::vk::Lay
         PHI_LOG_ERROR(R"(Fatal: Missing vulkan swapchain extension "{}")", VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     }
 
-    if (!f_add_ext(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
-    {
-        PHI_LOG_ERROR(R"(Missing vulkan timeline semaphore extension "{}", try updating GPU drivers)", VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
-    }
+    // VK_KHR_timeline_semaphore  - core in Vk 1.2
+    // if (!f_add_ext(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+    //{
+    //    PHI_LOG_ERROR(R"(Missing vulkan timeline semaphore extension "{}", try updating GPU drivers)", VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+    //}
 
     // VK_KHR_relaxed_block_layout - core in Vk 1.1
     // https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VK_KHR_relaxed_block_layout.html

--- a/src/phantasm-hardware-interface/vulkan/loader/spirv_patch_util.hh
+++ b/src/phantasm-hardware-interface/vulkan/loader/spirv_patch_util.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 
 #include <clean-core/alloc_vector.hh>
 #include <clean-core/string.hh>
@@ -13,7 +14,7 @@
 
 namespace phi::vk::spv
 {
-enum spv_constants_e : unsigned
+enum spv_constants_e : uint32_t
 {
     // SPIR-V accepted by PHI Vulkan backends expects bindings by HLSL type as such:
 
@@ -52,9 +53,9 @@ namespace phi::vk::util
 /// info about a descriptor - where, what, and visibility
 struct spirv_desc_info
 {
-    unsigned set;
-    unsigned binding;
-    unsigned binding_array_size;
+    uint32_t set;
+    uint32_t binding;
+    uint32_t binding_array_size;
     VkDescriptorType type;                       ///< type of the descriptor
     VkShaderStageFlags visible_stage;            ///< shaders it is visible to
     VkPipelineStageFlags visible_pipeline_stage; ///< pipeline stages it is visible to (only depends upon visible_stage)
@@ -81,21 +82,20 @@ struct patched_spirv_stage
     cc::string entrypoint_name;
 };
 
-/// we have to shift all CBVs up by [max num shader args] sets to make our API work in vulkan
-/// unlike the register-to-binding shift with -fvk-[x]-shift, this cannot be done with DXC flags
-/// instead we provide these helpers which use the spirv-reflect library to do the same
+// we have to shift all CBVs up by [max num shader args] sets to make our API work in vulkan
+// unlike the register-to-binding shift with -fvk-[x]-shift, this cannot be done with DXC flags
+// instead we provide these helpers which use the spirv-reflect library to do the same
 [[nodiscard]] patched_spirv_stage create_patched_spirv(std::byte const* bytecode, size_t bytecode_size, spirv_refl_info& out_info, cc::allocator* scratch_alloc);
 
 void free_patched_spirv(patched_spirv_stage const& val);
 
-/// merge descriptor infos per entrypoint into a sorted, deduplicated list, with visiblity flags OR-d together per descriptor
+// merge descriptor infos per entrypoint into a sorted, deduplicated list, with visiblity flags OR-d together per descriptor
 cc::alloc_vector<spirv_desc_info> merge_spirv_descriptors(cc::span<spirv_desc_info> desc_infos, cc::allocator* alloc);
 
 void print_spirv_info(cc::span<spirv_desc_info const> info);
 
-/// returns true if the reflected descriptors are consistent with the passed arguments
-/// currently only checks if the amounts are equal
-[[nodiscard]] bool is_consistent_with_reflection(cc::span<spirv_desc_info const> reflected_descriptors, arg::shader_arg_shapes arg_shapes);
+// issues warnings if the reflection data is incosistent with argument shapes
+void warnIfReflectionIsIncosistent(cc::span<spirv_desc_info const> reflected_descriptors, arg::shader_arg_shapes arg_shapes);
 
 //
 // serialization of fully processed SPIR-V

--- a/src/phantasm-hardware-interface/vulkan/pipeline_layout.cc
+++ b/src/phantasm-hardware-interface/vulkan/pipeline_layout.cc
@@ -7,7 +7,7 @@
 #include <phantasm-hardware-interface/vulkan/resources/descriptor_allocator.hh>
 #include <phantasm-hardware-interface/vulkan/resources/transition_barrier.hh>
 
-void phi::vk::detail::pipeline_layout_params::descriptor_set_params::add_descriptor(VkDescriptorType type, unsigned binding, unsigned array_size, VkShaderStageFlags visibility)
+void phi::vk::detail::pipeline_layout_params::descriptor_set_params::add_descriptor(VkDescriptorType type, uint32_t binding, uint32_t array_size, VkShaderStageFlags visibility)
 {
     VkDescriptorSetLayoutBinding& new_binding = bindings.emplace_back();
     new_binding = {};

--- a/src/phantasm-hardware-interface/vulkan/pipeline_layout.hh
+++ b/src/phantasm-hardware-interface/vulkan/pipeline_layout.hh
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <clean-core/array.hh>
+#include <cstdint>
+
 #include <clean-core/capped_vector.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
@@ -41,10 +42,12 @@ struct pipeline_layout_params
     {
         cc::capped_vector<VkDescriptorSetLayoutBinding, 64> bindings;
 
-        void add_descriptor(VkDescriptorType type, unsigned binding, unsigned array_size, VkShaderStageFlags visibility);
+        void add_descriptor(VkDescriptorType type, uint32_t binding, uint32_t array_size, VkShaderStageFlags visibility);
 
         // this function is no longer in use
-        [[deprecated("dropped support for immutable samplers")]] void fill_in_immutable_samplers(cc::span<VkSampler const> samplers);
+        [[deprecated("dropped support for immutable samplers")]] //
+        void
+        fill_in_immutable_samplers(cc::span<VkSampler const> samplers);
 
         VkDescriptorSetLayout create_layout(VkDevice device) const;
     };
@@ -57,7 +60,7 @@ struct pipeline_layout_params
 
     void initialize_from_reflection_info(cc::span<util::spirv_desc_info const> reflection_info);
 };
-}
+} // namespace detail
 
 struct pipeline_layout
 {
@@ -81,4 +84,4 @@ struct pipeline_layout
     void print() const;
 };
 
-}
+} // namespace phi::vk

--- a/src/phantasm-hardware-interface/vulkan/pools/fence_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/fence_pool.cc
@@ -82,7 +82,7 @@ void phi::vk::FencePool::signalCPU(phi::handle::fence fence, uint64_t val) const
     info.semaphore = get(fence);
     info.value = val;
 
-    PHI_VK_VERIFY_SUCCESS(vkSignalSemaphoreKHR(mDevice, &info));
+    PHI_VK_VERIFY_SUCCESS(vkSignalSemaphore(mDevice, &info));
 }
 
 void phi::vk::FencePool::waitCPU(phi::handle::fence fence, uint64_t val) const
@@ -95,14 +95,12 @@ void phi::vk::FencePool::waitCPU(phi::handle::fence fence, uint64_t val) const
     info.pSemaphores = &sem;
     info.pValues = &val;
 
-    // NOTE: KHR! We're not on Vulkan 1.2, these are the extension timeline semaphores and not the 1.2 core ones
-    PHI_VK_VERIFY_SUCCESS(vkWaitSemaphoresKHR(mDevice, &info, UINT64_MAX));
+    PHI_VK_VERIFY_SUCCESS(vkWaitSemaphores(mDevice, &info, UINT64_MAX));
 }
 
 uint64_t phi::vk::FencePool::getValue(phi::handle::fence fence) const
 {
     uint64_t res;
-    // NOTE: KHR! We're not on Vulkan 1.2, these are the extension timeline semaphores and not the 1.2 core ones
-    PHI_VK_VERIFY_SUCCESS(vkGetSemaphoreCounterValueKHR(mDevice, get(fence), &res));
+    PHI_VK_VERIFY_SUCCESS(vkGetSemaphoreCounterValue(mDevice, get(fence), &res));
     return res;
 }

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.hh
@@ -2,10 +2,9 @@
 
 #include <mutex>
 
+#include <clean-core/alloc_array.hh>
 #include <clean-core/atomic_linked_pool.hh>
-#include <clean-core/capped_vector.hh>
 #include <clean-core/span.hh>
-#include <clean-core/vector.hh>
 
 #include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/limits.hh>
@@ -24,7 +23,19 @@ class ShaderViewPool
 public:
     // frontend-facing API
 
-    [[nodiscard]] handle::shader_view create(cc::span<resource_view const> srvs, cc::span<resource_view const> uavs, cc::span<sampler_config const> samplers, bool usage_compute);
+    [[nodiscard]] handle::shader_view create(cc::span<resource_view const> srvs,
+                                             cc::span<resource_view const> uavs,
+                                             cc::span<sampler_config const> samplers,
+                                             bool usage_compute,
+                                             cc::allocator* scratch);
+
+    handle::shader_view createEmpty(arg::shader_view_description const& desc, bool usageCompute);
+
+    void writeShaderViewSRVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> srvs, cc::allocator* scratch);
+
+    void writeShaderViewUAVs(handle::shader_view sv, uint32_t offset, cc::span<resource_view const> uavs, cc::allocator* scratch);
+
+    void writeShaderViewSamplers(handle::shader_view sv, uint32_t offset, cc::span<sampler_config const> samplers, cc::allocator* scratch);
 
     void free(handle::shader_view sv);
     void free(cc::span<handle::shader_view const> svs);
@@ -34,32 +45,61 @@ public:
     void initialize(VkDevice device, ResourcePool* res_pool, AccelStructPool* as_pool, unsigned num_cbvs, unsigned num_srvs, unsigned num_uavs, unsigned num_samplers, cc::allocator* static_alloc);
     void destroy();
 
-    [[nodiscard]] VkDescriptorSet get(handle::shader_view sv) const { return mPool.get(sv._value).raw_desc_set; }
+    [[nodiscard]] VkDescriptorSet get(handle::shader_view sv) const { return mPool.get(sv._value).descriptorSet; }
 
     [[nodiscard]] VkImageView makeImageView(resource_view const& sve, bool is_uav, bool restrict_usage_for_shader) const;
 
 
 private:
-    struct shader_view_node
+    struct ShaderViewNode
     {
-        VkDescriptorSet raw_desc_set;
+        VkDescriptorSet descriptorSet;
 
         // the descriptor set layout used to create the descriptor set proper
         // This MUST stay alive, if it isn't alive, no warnings are emitted but
         // vkCmdBindDescriptorSets spuriously crashes the driver with compute binding points
-        VkDescriptorSetLayout raw_desc_set_layout;
+        VkDescriptorSetLayout descriptorSetLayout;
 
+        uint32_t numSRVs = 0;
+
+        // low memory: these are only accessed during shader_view updates, creation and destruction
+        // we do not semantically require these, they just have to stay alive
         // image views in use by this shader view
-        cc::vector<VkImageView> image_views;
+        cc::alloc_array<VkImageView> imageViews;
         // samplers in use by this shader view
-        cc::vector<VkSampler> samplers;
+        cc::alloc_array<VkSampler> samplers;
+
+        // optionally contains the descriptor entries for shader views that were created empty
+        // this is required for a mapping from flat SRV/UAV descriptor indices to binding and array index
+        cc::alloc_array<phi::arg::descriptor_entry> optionalDescriptorEntries;
+        uint32_t numDescriptorEntriesSRV = 0;
     };
 
 private:
+    handle::shader_view createShaderViewFromLayout(VkDescriptorSetLayout layout,
+                                                   uint32_t numSRVs,
+                                                   uint32_t numUAVs,
+                                                   uint32_t numSamplers,
+                                                   cc::allocator* dynamicAlloc,
+                                                   phi::arg::shader_view_description const* optDescription);
+
     [[nodiscard]] VkSampler makeSampler(sampler_config const& config) const;
 
-    void internalFree(shader_view_node& node) const;
+    ShaderViewNode& internalGet(handle::shader_view res)
+    {
+        CC_ASSERT(res.is_valid() && "invalid shader_view handle");
+        return mPool.get(res._value);
+    }
 
+    void internalFree(ShaderViewNode& node) const;
+
+    // translates a flat index into a shader view's SRVs into the corresponding binding and array index
+    // returns true on success
+    bool flatSRVIndexToBindingAndArrayIndex(ShaderViewNode const& node, uint32_t flatIdx, uint32_t& outBinding, uint32_t& outArrayIndex) const;
+
+    // translates a flat index into a shader view's UAVs into the corresponding binding and array index
+    // returns true on success
+    bool flatUAVIndexToBindingAndArrayIndex(ShaderViewNode const& node, uint32_t flatIdx, uint32_t& outBinding, uint32_t& outArrayIndex) const;
 
 private:
     // non-owning
@@ -68,11 +108,11 @@ private:
     AccelStructPool* mAccelStructPool = nullptr;
 
     /// The main pool data
-    cc::atomic_linked_pool<shader_view_node> mPool;
+    cc::atomic_linked_pool<ShaderViewNode> mPool;
 
     /// "Backing" allocator
     DescriptorAllocator mAllocator;
     std::mutex mMutex;
 };
 
-}
+} // namespace phi::vk

--- a/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.cc
+++ b/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.cc
@@ -156,7 +156,9 @@ VkDescriptorSetLayout DescriptorAllocator::createLayoutFromDescription(arg::shad
         ++srvHead;
     }
 
-    CC_ASSERT(numSRVsInEntries == desc.num_srvs && "Amount of SRVs specified does not match the sum of given SRV ranges when creating an empty shader view");
+    CC_ASSERT_MSG(numSRVsInEntries == desc.num_srvs,
+                  "Amount of SRVs specified does not match the sum of given SRV entries when creating an empty shader view\n"
+                  "For the Vulkan backend, arg::shader_view_description::srv_entries is not optional");
 
     uint32_t uavHead = 0u;
     uint32_t numUAVsInEntries = 0u;
@@ -169,7 +171,9 @@ VkDescriptorSetLayout DescriptorAllocator::createLayoutFromDescription(arg::shad
         ++uavHead;
     }
 
-    CC_ASSERT(numUAVsInEntries == desc.num_uavs && "Amount of UAVs specified does not match the sum of given UAV ranges when creating an empty shader view");
+    CC_ASSERT_MSG(numUAVsInEntries == desc.num_uavs,
+                  "Amount of UAVs specified does not match the sum of given UAV entries when creating an empty shader view\n"
+                  "For the Vulkan backend, arg::shader_view_description::uav_entries is not optional");
 
     for (auto i = 0u; i < desc.num_samplers; ++i)
     {

--- a/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.cc
+++ b/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.cc
@@ -138,4 +138,52 @@ VkDescriptorSetLayout DescriptorAllocator::createLayoutFromShaderViewArgs(cc::sp
 
     return layout;
 }
+VkDescriptorSetLayout DescriptorAllocator::createLayoutFromDescription(arg::shader_view_description const& desc, bool usageCompute)
+{
+    // NOTE: Eventually arguments could be constrained to stages in a more fine-grained manner
+    auto const argument_visibility = usageCompute ? VK_SHADER_STAGE_COMPUTE_BIT : VK_SHADER_STAGE_ALL_GRAPHICS;
+
+    detail::pipeline_layout_params::descriptor_set_params params;
+
+    uint32_t srvHead = 0u;
+    uint32_t numSRVsInEntries = 0u;
+    for (auto const& entry : desc.srv_entries)
+    {
+        auto const native_type = util::to_native_srv_desc_type(entry.category);
+
+        params.add_descriptor(native_type, spv::srv_binding_start + srvHead, entry.array_size, argument_visibility);
+        numSRVsInEntries += entry.array_size;
+        ++srvHead;
+    }
+
+    CC_ASSERT(numSRVsInEntries == desc.num_srvs && "Amount of SRVs specified does not match the sum of given SRV ranges when creating an empty shader view");
+
+    uint32_t uavHead = 0u;
+    uint32_t numUAVsInEntries = 0u;
+    for (auto const& entry : desc.uav_entries)
+    {
+        auto const native_type = util::to_native_uav_desc_type(entry.category);
+
+        params.add_descriptor(native_type, spv::uav_binding_start + uavHead, entry.array_size, argument_visibility);
+        numUAVsInEntries += entry.array_size;
+        ++uavHead;
+    }
+
+    CC_ASSERT(numUAVsInEntries == desc.num_uavs && "Amount of UAVs specified does not match the sum of given UAV ranges when creating an empty shader view");
+
+    for (auto i = 0u; i < desc.num_samplers; ++i)
+    {
+        params.add_descriptor(VK_DESCRIPTOR_TYPE_SAMPLER, spv::sampler_binding_start + i, 1, argument_visibility);
+    }
+
+    VkDescriptorSetLayoutCreateInfo layout_info = {};
+    layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    layout_info.bindingCount = uint32_t(params.bindings.size());
+    layout_info.pBindings = params.bindings.data();
+
+    VkDescriptorSetLayout layout;
+    PHI_VK_VERIFY_SUCCESS(vkCreateDescriptorSetLayout(mDevice, &layout_info, nullptr, &layout));
+
+    return layout;
 }
+} // namespace phi::vk

--- a/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.hh
+++ b/src/phantasm-hardware-interface/vulkan/resources/descriptor_allocator.hh
@@ -22,19 +22,18 @@ public:
     void free(VkDescriptorSet descriptor_set);
 
     // free-threaded
-    [[nodiscard]] VkDescriptorSetLayout createSingleCBVLayout(bool usage_compute) const;
+    VkDescriptorSetLayout createSingleCBVLayout(bool usage_compute) const;
 
-    [[nodiscard]] VkDescriptorSetLayout createLayoutFromShaderViewArgs(cc::span<resource_view const> srvs,
-                                                                       cc::span<resource_view const> uavs,
-                                                                       unsigned num_samplers,
-                                                                       bool usage_compute) const;
+    VkDescriptorSetLayout createLayoutFromShaderViewArgs(cc::span<resource_view const> srvs, cc::span<resource_view const> uavs, unsigned num_samplers, bool usage_compute) const;
+
+    VkDescriptorSetLayout createLayoutFromDescription(arg::shader_view_description const& desc, bool usageCompute);
 
 
-    [[nodiscard]] VkDevice getDevice() const { return mDevice; }
+    VkDevice getDevice() const { return mDevice; }
 
 private:
     VkDevice mDevice = nullptr;
     VkDescriptorPool mPool;
 };
 
-}
+} // namespace phi::vk


### PR DESCRIPTION
- Expand the `createEmptyShaderView` API to allow Vulkan implementation
    - Add `arg::shader_view_description`, `arg::descriptor_entry` and `arg::descriptor_category`
    - Add Vulkan implementation
    - Minor fixes in D3D12 implementation

- Bump Vulkan API version to 1.2
- Minor changes, fix warnings
- Add internal TLS scratch allocator mechanism in vulkan backend