### PR TITLE
Speed up D3D12 init, fix corner cases, improved errors on shader_view limits

### DIFF
--- a/src/phantasm-hardware-interface/config.hh
+++ b/src/phantasm-hardware-interface/config.hh
@@ -52,11 +52,13 @@ enum class validation_level : uint8_t
 
 struct backend_config
 {
-    /// whether to enable API-level validations
+    // whether to enable API-level validations
     validation_level validation = validation_level::off;
 
-    /// the strategy for choosing a physical GPU
+    // the strategy for choosing a physical GPU
     adapter_preference adapter = adapter_preference::highest_vram;
+
+    // relevant if using adapter_preference::explicit_index, an index into the native adapter ordering
     uint32_t explicit_adapter_index = uint32_t(-1);
 
     enum native_feature_flags : uint8_t
@@ -82,37 +84,53 @@ struct backend_config
         native_feature_vk_best_practices_layer = 1 << 4
     };
 
-    /// native features to enable
+    // native features to enable
     uint8_t native_features = native_feature_none;
 
-    /// whether to enable DXR / VK raytracing features if available
+    // whether to enable DXR / VK raytracing features if available
     bool enable_raytracing = true;
 
-    /// whether to print basic information on init
+    // whether to print basic information on init
     bool print_startup_message = true;
 
-    /// amount of threads to accomodate
-    /// backend calls must only be made from <= [num_threads] unique OS threads
+    // amount of threads to accomodate
+    // backend calls must only be made from <= [num_threads] unique OS threads
     uint32_t num_threads = 1;
 
-    /// allocator for init-time allocations, only hit during init and shutdown
+    // allocator for init-time allocations, only hit during init and shutdown
     cc::allocator* static_allocator = cc::system_allocator;
-    /// allocator for runtime allocations, must be thread-safe
+    // allocator for runtime allocations, must be thread-safe
     cc::allocator* dynamic_allocator = cc::system_allocator;
 
+    //
     // resource limits
+    //
+
+    // maximum amount of handle::swapchain objects
     uint32_t max_num_swapchains = 32;
+    // maximum amount of handle::resource objects
     uint32_t max_num_resources = 2048;
+    // maximum amount of graphics and compute handle::pipeline_state objects
     uint32_t max_num_pipeline_states = 1024;
-    uint32_t max_num_cbvs = 2048;
+    // maximum amount of handle::shader_view objects
+    // this is also the maximum amount of CBV descriptors (only up to 1 per shader_view)
+    uint32_t max_num_shader_views = 2048;
+    // maximum amount of SRV descriptors in all shader views
     uint32_t max_num_srvs = 2048;
+    // maximum amount of UAV descriptors in all shader views
     uint32_t max_num_uavs = 2048;
+    // maximum amount of samplers in all shader views
     uint32_t max_num_samplers = 1024;
+    // maximum amount of handle::fence objects
     uint32_t max_num_fences = 4096;
+    // maximum amount of handle::accel_struct objects (raytracing acceleration structures)
     uint32_t max_num_accel_structs = 2048;
+    // maximum amount of raytracing handle::pipeline_state objects
     uint32_t max_num_raytrace_pipeline_states = 256;
 
-    // command list allocator sizes (total = #threads * #allocs/thread * #lists/alloc)
+    // command list allocators per thread, split into queue types
+    // maximum amount of handle::command_list objects is computed as:
+    // total = #threads * #allocs/thread * #lists/alloc
     uint32_t num_direct_cmdlist_allocators_per_thread = 5;
     uint32_t num_direct_cmdlists_per_allocator = 5;
     uint32_t num_compute_cmdlist_allocators_per_thread = 5;
@@ -128,4 +146,4 @@ struct backend_config
     uint32_t num_occlusion_queries = 1024;
     uint32_t num_pipeline_stat_queries = 256;
 };
-}
+} // namespace phi

--- a/src/phantasm-hardware-interface/d3d12/Adapter.hh
+++ b/src/phantasm-hardware-interface/d3d12/Adapter.hh
@@ -11,7 +11,10 @@ namespace phi::d3d12
 class Adapter
 {
 public:
-    void initialize(backend_config const& config);
+    // outCreatedDevice: The device created on the chosen physical GPU
+    // it has to be created in the GPU choice process and is expensive to re-create
+    void initialize(backend_config const& config, ID3D12Device*& outCreatedDevice);
+
     void destroy();
 
     bool isValid() const { return mAdapter != nullptr; }
@@ -28,4 +31,4 @@ private:
     IDXGIInfoQueue* mInfoQueue = nullptr;
 };
 
-}
+} // namespace phi::d3d12

--- a/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
+++ b/src/phantasm-hardware-interface/d3d12/BackendD3D12.cc
@@ -73,7 +73,7 @@ void phi::d3d12::BackendD3D12::initialize(const phi::backend_config& config)
 #endif
 
         mPoolResources.initialize(device, config.max_num_resources, config.max_num_swapchains, config.static_allocator, config.dynamic_allocator);
-        mPoolShaderViews.initialize(device, &mPoolResources, &mPoolAccelStructs, config.max_num_cbvs, config.max_num_srvs + config.max_num_uavs,
+        mPoolShaderViews.initialize(device, &mPoolResources, &mPoolAccelStructs, config.max_num_shader_views, config.max_num_srvs + config.max_num_uavs,
                                     config.max_num_samplers, config.static_allocator);
         mPoolPSOs.initialize(device, config.max_num_pipeline_states, config.max_num_raytrace_pipeline_states, config.static_allocator, config.dynamic_allocator);
         mPoolFences.initialize(device, config.max_num_fences, config.static_allocator);

--- a/src/phantasm-hardware-interface/d3d12/Device.hh
+++ b/src/phantasm-hardware-interface/d3d12/Device.hh
@@ -10,7 +10,7 @@ namespace phi::d3d12
 class Device
 {
 public:
-    void initialize(IDXGIAdapter& adapter, backend_config const& config);
+    void initialize(ID3D12Device* deviceToUse, IDXGIAdapter& adapter, backend_config const& config);
     void destroy();
 
     bool hasSM6WaveIntrinsics() const { return mFeatures.features.has(gpu_feature::hlsl_wave_ops); }

--- a/src/phantasm-hardware-interface/d3d12/adapter_choice_util.hh
+++ b/src/phantasm-hardware-interface/d3d12/adapter_choice_util.hh
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <clean-core/vector.hh>
+#include <cstdint>
+
+#include <clean-core/span.hh>
 
 #include <phantasm-hardware-interface/types.hh>
 
@@ -9,11 +11,14 @@
 
 namespace phi::d3d12
 {
-[[nodiscard]] gpu_feature_info get_gpu_features(ID3D12Device5* device);
+[[nodiscard]] gpu_feature_info getGPUFeaturesFromDevice(ID3D12Device5* device);
 
-/// Test the given adapter by creating a device with the min_feature level, returns the amount of device nodes, >= 0 on success
-[[nodiscard]] int test_adapter(IDXGIAdapter* adapter, D3D_FEATURE_LEVEL min_features, D3D_FEATURE_LEVEL& out_max_features);
+// Test the given adapter by creating a device with the min_feature level, returns true if the GPU is eligible
+bool testAdapterForFeatures(IDXGIAdapter* adapter, D3D_FEATURE_LEVEL& outMaxFeatures, ID3D12Device*& outDevice);
 
-/// Get all available adapter candidates
-[[nodiscard]] cc::vector<gpu_info> get_adapter_candidates();
-}
+// Get all available adapter candidates
+uint32_t getAdapterCandidates(IDXGIFactory4* factory,
+                              cc::span<phi::gpu_info> outCandidateInfos,
+                              cc::span<ID3D12Device*> outCandidateDevices,
+                              cc::span<IDXGIAdapter*> outCandidateAdapters);
+} // namespace phi::d3d12

--- a/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/cmd_list_pool.cc
@@ -2,6 +2,10 @@
 
 #include <clean-core/bit_cast.hh>
 
+#ifdef PHI_HAS_OPTICK
+#include <optick/optick.h>
+#endif
+
 #include <phantasm-hardware-interface/d3d12/BackendD3D12.hh>
 #include <phantasm-hardware-interface/d3d12/common/util.hh>
 #include <phantasm-hardware-interface/d3d12/common/verify.hh>
@@ -184,6 +188,10 @@ void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
                                              int max_num_unique_transitions_per_cmdlist,
                                              cc::span<CommandAllocatorsPerThread*> thread_allocators)
 {
+#ifdef PHI_HAS_OPTICK
+    OPTICK_EVENT();
+#endif
+
     auto const num_direct_lists_per_thread = size_t(num_direct_allocs * num_direct_lists_per_alloc);
     auto const num_compute_lists_per_thread = size_t(num_compute_allocs * num_compute_lists_per_alloc);
     auto const num_copy_lists_per_thread = size_t(num_copy_allocs * num_copy_lists_per_alloc);
@@ -208,6 +216,11 @@ void phi::d3d12::CommandListPool::initialize(phi::d3d12::BackendD3D12& backend,
     // initialize the three allocator bundles (direct, compute, copy)
     for (auto i = 0u; i < thread_allocators.size(); ++i)
     {
+#ifdef PHI_HAS_OPTICK
+        OPTICK_EVENT("Command List init for Thread");
+        OPTICK_TAG("Thread Index", i);
+#endif
+
         thread_allocators[i]->bundle_direct.initialize(*backend.nativeGetDevice(), static_alloc, D3D12_COMMAND_LIST_TYPE_DIRECT, num_direct_allocs,
                                                        num_direct_lists_per_alloc,
                                                        cc::span{mRawListsDirect}.subspan(i * num_direct_lists_per_thread, num_direct_lists_per_thread));
@@ -325,6 +338,10 @@ void phi::d3d12::CommandAllocatorBundle::internalInit(ID3D12Device5& device,
                                                       unsigned num_cmdlists,
                                                       cc::span<ID3D12GraphicsCommandList5*> out_cmdlists)
 {
+#ifdef PHI_HAS_OPTICK
+    OPTICK_EVENT("CreateCommandList calls");
+#endif
+
     node.initialize(device, list_type, num_cmdlists);
     ID3D12CommandAllocator* const raw_alloc = node.get_allocator();
 

--- a/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/d3d12/pools/shader_view_pool.cc
@@ -46,6 +46,12 @@ phi::handle::shader_view phi::d3d12::ShaderViewPool::createEmpty(uint32_t num_sr
         sampler_alloc = mSamplerAllocator.allocate(int(num_samplers));
     }
 
+    
+    CC_RUNTIME_ASSERTF(!mPool.is_full(),
+                       "Reached limit for shader_views, increase max_num_shader_views in the PHI backend config\n"
+                       "Current limit: {}",
+                       mPool.max_size());
+
     auto const pool_index = mPool.acquire();
 
     auto& new_node = mPool.get(pool_index);

--- a/src/phantasm-hardware-interface/features/gpu_info.cc
+++ b/src/phantasm-hardware-interface/features/gpu_info.cc
@@ -27,9 +27,9 @@ constexpr char const* get_preference_literal(phi::adapter_preference pref)
     }
     CC_UNREACHABLE_SWITCH_WORKAROUND(pref);
 }
-}
+} // namespace
 
-size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::adapter_preference preference)
+size_t phi::getPreferredGPU(cc::span<const phi::gpu_info> candidates, phi::adapter_preference preference)
 {
     auto const get_first_capable = [&]() -> size_t {
         for (auto i = 0u; i < candidates.size(); ++i)
@@ -97,7 +97,7 @@ size_t phi::get_preferred_gpu(cc::span<const phi::gpu_info> candidates, phi::ada
     return make_choice();
 }
 
-phi::gpu_vendor phi::get_gpu_info_from_pcie_id(unsigned vendor_id)
+phi::gpu_vendor phi::getGPUVendorFromPCIeID(unsigned vendor_id)
 {
     switch (vendor_id)
     {
@@ -118,7 +118,7 @@ phi::gpu_vendor phi::get_gpu_info_from_pcie_id(unsigned vendor_id)
     }
 }
 
-void phi::print_startup_message(cc::span<const phi::gpu_info> gpu_candidates, size_t chosen_index, const phi::backend_config& config, bool is_d3d12)
+void phi::printStartupMessage(cc::span<const phi::gpu_info> gpu_candidates, size_t chosen_index, const phi::backend_config& config, bool is_d3d12)
 {
     if (!config.print_startup_message)
         return;

--- a/src/phantasm-hardware-interface/features/gpu_info.hh
+++ b/src/phantasm-hardware-interface/features/gpu_info.hh
@@ -43,9 +43,9 @@ struct gpu_info
     bool has_raytracing;
 };
 
-gpu_vendor get_gpu_info_from_pcie_id(unsigned vendor_id);
+gpu_vendor getGPUVendorFromPCIeID(unsigned vendor_id);
 
-size_t get_preferred_gpu(cc::span<gpu_info const> candidates, adapter_preference preference);
+size_t getPreferredGPU(cc::span<gpu_info const> candidates, adapter_preference preference);
 
-void print_startup_message(cc::span<gpu_info const> gpu_candidates, size_t chosen_index, backend_config const& config, bool is_d3d12);
-}
+void printStartupMessage(cc::span<gpu_info const> gpu_candidates, size_t chosen_index, backend_config const& config, bool is_d3d12);
+} // namespace phi

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -129,7 +129,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
     {
         auto const vk_gpu_infos = get_all_vulkan_gpu_infos(mInstance);
         auto const gpu_infos = get_available_gpus(vk_gpu_infos);
-        auto const chosen_index = get_preferred_gpu(gpu_infos, config.adapter);
+        auto const chosen_index = getPreferredGPU(gpu_infos, config.adapter);
         CC_RUNTIME_ASSERT(chosen_index < gpu_infos.size() && "Found no GPU candidates");
 
         auto const& chosen_gpu = gpu_infos[chosen_index];
@@ -140,7 +140,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
         // Load device-based Vulkan entrypoints
         volkLoadDevice(mDevice.getDevice());
 
-        print_startup_message(gpu_infos, chosen_index, config, false);
+        printStartupMessage(gpu_infos, chosen_index, config, false);
 
         if (config.print_startup_message)
         {

--- a/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
+++ b/src/phantasm-hardware-interface/vulkan/BackendVulkan.cc
@@ -153,7 +153,7 @@ void phi::vk::BackendVulkan::initialize(const backend_config& config_arg)
     // Pool init
     mPoolPipelines.initialize(mDevice.getDevice(), config.max_num_pipeline_states, config.static_allocator);
     mPoolResources.initialize(mDevice.getPhysicalDevice(), mDevice.getDevice(), config.max_num_resources, config.max_num_swapchains, config.static_allocator);
-    mPoolShaderViews.initialize(mDevice.getDevice(), &mPoolResources, &mPoolAccelStructs, config.max_num_cbvs, config.max_num_srvs,
+    mPoolShaderViews.initialize(mDevice.getDevice(), &mPoolResources, &mPoolAccelStructs, config.max_num_shader_views, config.max_num_srvs,
                                 config.max_num_uavs, config.max_num_samplers, config.static_allocator);
     mPoolFences.initialize(mDevice.getDevice(), config.max_num_fences, config.static_allocator);
     mPoolQueries.initialize(mDevice.getDevice(), config.num_timestamp_queries, config.num_occlusion_queries, config.num_pipeline_stat_queries, config.static_allocator);

--- a/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
+++ b/src/phantasm-hardware-interface/vulkan/common/native_enum.hh
@@ -2,6 +2,7 @@
 
 #include <clean-core/assert.hh>
 
+#include <phantasm-hardware-interface/arguments.hh>
 #include <phantasm-hardware-interface/common/format_size.hh>
 #include <phantasm-hardware-interface/types.hh>
 
@@ -352,6 +353,7 @@ constexpr VkDescriptorType to_native_srv_desc_type(resource_view_dimension sv_di
         return VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
 
     case phi::resource_view_dimension::none:
+    case phi::resource_view_dimension::MAX_DIMENSION_RANGE:
         return VK_DESCRIPTOR_TYPE_MAX_ENUM;
     }
 
@@ -412,6 +414,7 @@ constexpr VkDescriptorType to_native_uav_desc_type(resource_view_dimension sv_di
 
     case phi::resource_view_dimension::raytracing_accel_struct:
     case phi::resource_view_dimension::none:
+    case phi::resource_view_dimension::MAX_DIMENSION_RANGE:
         return VK_DESCRIPTOR_TYPE_MAX_ENUM;
     }
 
@@ -445,6 +448,7 @@ constexpr VkImageViewType to_native_image_view_type(resource_view_dimension sv_d
     case phi::resource_view_dimension::raytracing_accel_struct:
         CC_ASSERT(false && "requested image view for buffer or raytracing structure");
     case phi::resource_view_dimension::none:
+    case phi::resource_view_dimension::MAX_DIMENSION_RANGE:
         return VK_IMAGE_VIEW_TYPE_MAX_ENUM;
     }
 

--- a/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
+++ b/src/phantasm-hardware-interface/vulkan/gpu_choice_util.cc
@@ -197,7 +197,7 @@ cc::vector<phi::gpu_info> phi::vk::get_available_gpus(cc::span<const vulkan_gpu_
 
         auto& new_gpu = res.emplace_back();
         new_gpu.index = i;
-        new_gpu.vendor = get_gpu_info_from_pcie_id(ll_info.physical_device_props.vendorID);
+        new_gpu.vendor = getGPUVendorFromPCIeID(ll_info.physical_device_props.vendorID);
         std::snprintf(new_gpu.name, sizeof(new_gpu.name), "%s", ll_info.physical_device_props.deviceName);
 
         // TODO: differentiate this somehow

--- a/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
+++ b/src/phantasm-hardware-interface/vulkan/pools/shader_view_pool.cc
@@ -367,6 +367,11 @@ phi::handle::shader_view phi::vk::ShaderViewPool::createShaderViewFromLayout(VkD
         res_raw = mAllocator.allocDescriptor(layout);
     }
 
+    CC_RUNTIME_ASSERTF(!mPool.is_full(),
+                       "Reached limit for shader_views, increase max_num_shader_views in the PHI backend config\n"
+                       "Current limit: {}",
+                       mPool.max_size());
+
     uint32_t const pool_index = mPool.acquire();
 
     // Populate new node


### PR DESCRIPTION
- Only create ID3D12Device once to save about 130ms on launch
- Fix some corner cases in D3D12 inits
- Improve error messages once shader_view limits are exceeded
- Add more comments to the backend config struct, rename `max_num_cbvs` to `max_num_shader_views`